### PR TITLE
Join ACARA to VCE Results using a manually created join key

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This merges all years into one, drops a bunch of columns that aren't of interest
 
 Of course, OF COURSE, the Victorian and federal governments (ACARA) don't name schools the same thing. As such a lookup table has been manually created to map the Victorian school name to the ACARA name. This is required to join the VCE results to information such as the school location, school's ICSEA, etc.
 
-This is by no means perfect so if you find errors either raise an issue or better yet raise a PR with the proposed fix.
+This is by no means perfect so if you find errors please raise an issue or better yet raise a PR with the proposed fix.
 
 ## Running the Web App
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,7 @@ Explores VCE study scores by school. It produces a plotly dash web app that allo
 
 - Comparing how schools perform over time, eg via their median study score
 - A ranking of the "top-N" schools
-- A map to see how VCE results change across Melbourne/the state
-
-## To-Do
-
-- [ ] Go through the fuzzy match of school names & correct the mistakes
-  - There are quite a few unfortunately :(
+- A map to see how VCE results change across Melbourne/the state``
 
 ## Data
 
@@ -38,7 +33,25 @@ poetry run python data_loader.py
 
 This merges all years into one, drops a bunch of columns that aren't of interest and merges the VCE results with the school profiles information. It will produce a file called `vce_school_results_analysis_dataset.csv`.
 
-## Run the Web App
+### Notes on the Data
+
+Of course, OF COURSE, the Victorian and federal governments (ACARA) don't name schools the same thing. As such a lookup table has been manually created to map the Victorian school name to the ACARA name. This is required to join the VCE results to information such as the school location, school's ICSEA, etc.
+
+This is by no means perfect so if you find errors either raise an issue or better yet raise a PR with the proposed fix.
+
+## Running the Web App
+
+A [mapbox token](https://docs.mapbox.com/help/getting-started/access-tokens/) is required for the `Schools Map` page to work. Create a token and set the environment variable:
+
+```bash
+export MAPBOX_TOKEN={your token}
+```
+
+Build the environment:
+
+```bash
+poetry install
+```
 
 Start up the app:
 

--- a/data_loader.py
+++ b/data_loader.py
@@ -191,59 +191,6 @@ def get_close_match(school_name: str, school_name_options: Iterable) -> str:
     return None
 
 
-def create_joining_key(
-    school_name_results: Iterable, school_name_profile: Iterable
-) -> pd.DataFrame:
-    keys = [
-        {
-            "school_name": x,
-            "join_key": get_close_match(x, school_name_profile),
-        }
-        for x in school_name_results
-    ]
-
-    # A bunch of TAFEs don't have school info. For the purposes of this analysis, exclude them
-    keys = [x for x in keys if x["join_key"] is not None]
-
-    # This unfortunately knocks out a few legit schools that difflib couldn't pick up
-    # Manually add them back in
-    fixers = [
-        {
-            "school_name": "Ballarat SC - Mount Rowan",
-            "join_key": "Mount Rowan Secondary College",
-        },
-        {
-            "school_name": "Ballarat SC - Woodmans Hill",
-            "join_key": "Woodmans Hill Secondary College",
-        },
-        {
-            "school_name": "Keysborough SC - Acacia",
-            "join_key": "Keysborough Secondary College",
-        },
-        {
-            "school_name": "Keysborough SC - Banksia",
-            "join_key": "Keysborough Secondary College",
-        },
-        {
-            "school_name": "Footscray High School",
-            "join_key": "Footscray Learning Precinct Secondary College (interim name)",
-        },
-    ]
-
-    fixer_schools = [x["school_name"] for x in fixers]
-    keys = [x for x in keys if x["school_name"] not in fixer_schools]
-    keys = keys + fixers
-
-    # Difflib also flips out on a bunch. Manually fix those...
-    # Ashwood Secondary College
-    # Ballarat Secondary College
-    # Brauer College
-    # St Catherine's School when joined is both a Catholic primary school AND Indepdendent combined school. Debug this!
-
-    # %%
-    return pd.DataFrame(keys)
-
-
 def create_analysis_dataset(save: bool = True):
     print("Collating VCE Results Files")
     results_df = get_results()
@@ -261,16 +208,18 @@ def create_analysis_dataset(save: bool = True):
 
     # Append school information to results data
     print("Joining school profile data to VCE results")
-    keys_df = create_joining_key(
-        results_df["School"].unique(), school_profile_df["School Name"].unique()
+    joining_table = pd.read_csv(
+        "raw_data/School Name Joining Keys - vce_school_names.csv"
     )
 
-    results_df = pd.merge(results_df, keys_df, left_on="School", right_on="school_name")
+    results_df = pd.merge(
+        results_df, joining_table, left_on="School", right_on="vce_school_name"
+    )
     results_df = pd.merge(
         results_df,
         school_profile_df,
-        left_on=["join_key", "year"],
-        right_on=["School Name", "Calendar Year"],
+        left_on=["ACARA SML ID", "year"],
+        right_on=["ACARA SML ID", "Calendar Year"],
         how="left",
     )
 

--- a/data_loader.py
+++ b/data_loader.py
@@ -208,9 +208,7 @@ def create_analysis_dataset(save: bool = True):
 
     # Append school information to results data
     print("Joining school profile data to VCE results")
-    joining_table = pd.read_csv(
-        "raw_data/School Name Joining Keys - vce_school_names.csv"
-    )
+    joining_table = pd.read_csv("raw_data/school_name_joining_keys.csv.csv")
 
     results_df = pd.merge(
         results_df, joining_table, left_on="School", right_on="vce_school_name"

--- a/data_loader.py
+++ b/data_loader.py
@@ -208,7 +208,7 @@ def create_analysis_dataset(save: bool = True):
 
     # Append school information to results data
     print("Joining school profile data to VCE results")
-    joining_table = pd.read_csv("raw_data/school_name_joining_keys.csv.csv")
+    joining_table = pd.read_csv("raw_data/school_name_joining_keys.csv")
 
     results_df = pd.merge(
         results_df, joining_table, left_on="School", right_on="vce_school_name"

--- a/raw_data/school_name_joining_keys.csv
+++ b/raw_data/school_name_joining_keys.csv
@@ -1,0 +1,681 @@
+vce_school_name,acara_school_name,ACARA SML ID
+Academy of Mary Immaculate,Academy of Mary Immaculate,45704
+Adass Israel School,Adass Israel School,46213
+Advance College of Education,Advance College of Education Incorporated,52378
+Advance Community College,Advance College of Education Incorporated,52378
+Advance TAFE,,
+School is closed,,
+Aitken College,Aitken College,46353
+Al Iman College,Al Iman College,52380
+Al Siraat College,Al Siraat College,46390
+Al-Taqwa College,Al-Taqwa College,46309
+Albert Park College,Albert Park College,50267
+Albury Wodonga Comm College,Indie School Wodonga,43720
+Alexandra Secondary College,Alexandra Secondary College,45349
+Alia College,Alia College,46354
+Alice Miller School,Alice Miller School,52381
+Alkira Secondary College,Alkira Secondary College,45604
+Alphington Grammar School,Alphington Grammar School,46316
+Altona College,Altona College,45587
+Antonine College,Antonine College,46112
+Apollo Bay P-12 College,Apollo Bay P-12 College,45292
+Aquinas College,Aquinas College,45947
+Ararat Secondary College,Ararat Secondary College,45523
+Armstrong Creek School,Armstrong Creek School,52589
+Ashwood High School,Ashwood High School,45518
+Ashwood Secondary College,Ashwood High School,45518
+Assumption College,Assumption College,45647
+Auburn High School,Auburn High School,50684
+Australian Internatl Academy,Australian International Academy of Education,46297
+Ave Maria College,Ave Maria College,45958
+Avila College,Avila College,45976
+Bacchus Marsh College,Bacchus Marsh College,45525
+Bacchus Marsh Grammar,Bacchus Marsh Grammar,46314
+Baimbridge College,Baimbridge College,45552
+Bairnsdale Secondary College,Bairnsdale Secondary College,45489
+Balcombe Grammar School,Balcombe Grammar School,46383
+Ballarat Christian College,Ballarat Christian College,46384
+Ballarat Clarendon College,Ballarat Clarendon College,46146
+Ballarat Grammar,Ballarat Grammar,46166
+Ballarat High School,Ballarat High School,45350
+Ballarat SC - Mount Rowan,Mount Rowan Secondary College,45565
+Ballarat SC - Woodmans Hill,Woodmans Hill Secondary College,52702
+Ballarat Secondary College,,
+Ballarat Secondary College - Mount Rowan Campus,Mount Rowan Secondary College,45565
+Ballarat Secondary College - Woodmans Hill Campus,Woodmans Hill Secondary College,52702
+Balmoral K-12 Comm College,Balmoral K-12 Community College,45602
+Balwyn High School,Balwyn High School,45351
+Bannockburn P-12 College,Bannockburn P-12 College,44168
+Bass Coast College,Bass Coast College,40597
+Bayside Christian College,Bayside Christian College,46271
+Bayside P-12 College,Bayside P-12 College,45538
+Bayswater Secondary College,Bayswater Secondary College,45352
+Bayview College,Bayview College,46161
+Beaconhills College,Beaconhills College,46282
+Beaufort Secondary College,Beaufort Secondary College,45353
+Beaumaris Secondary College,Beaumaris Secondary College,52592
+Beechworth Secondary College,Beechworth Secondary College,45354
+Belgrave Heights Christian Schl,Belgrave Heights Christian School,46286
+Bellarine Secondary College,Bellarine Secondary College,45456
+Belmont High School,Belmont High School,45355
+Benalla P-12 College,Benalla P-12 College,50569
+Bendigo Senior Sec College,Bendigo Senior Secondary College,40576
+Bendigo South East 7-10 SC,Bendigo South East 7-10 Secondary College,45387
+Bendigo TAFE,,
+Bentleigh Secondary College,Bentleigh Secondary College,45338
+Berry Street Victoria,Berry Street School,46375
+Berwick Grammar School,St Margaret's Berwick Grammar,46203
+Berwick Secondary College,Berwick Secondary College,45356
+Beth Rivkah Ladies College,Beth Rivkah Ladies College,46216
+Bialik College,Bialik College,46221
+Billanook College,Billanook College,46264
+Birchip P-12 School,Birchip P-12 School,45568
+Blackburn High School,Blackburn High School,45357
+Boort District P-12 School,Boort District P-12 School,50271
+Boronia K-12 College,Boronia K-12 College,44703
+Box Hill High School,Box Hill High School,45359
+Box Hill Institute,,
+Box Hill Institute - CAE campus,,
+Box Hill Senior Sec College,Box Hill Senior Secondary College,45326
+Braemar College,Braemar College,46238
+Brauer College,Brauer Secondary College,45345
+Braybrook College,Braybrook College,45360
+Brentwood Secondary College,Brentwood Secondary College,45361
+Bright P-12 College,Bright P-12 College,44140
+Brighton Grammar School,Brighton Grammar School,46200
+Brighton Secondary College,Brighton Secondary College,45362
+Broadford Secondary College,Broadford Secondary College,45363
+Brunswick Secondary College,Brunswick Secondary College,45545
+Buckley Park College,Buckley Park College,45364
+Bundoora Secondary College,Bundoora Secondary College,45395
+Camberwell Anglican Girls GS,Camberwell Girls Grammar School,46204
+Camberwell Grammar School,Camberwell Grammar School,46199
+Camberwell High School,Camberwell High School,45365
+Camperdown College,Camperdown College,45319
+Cann River P-12 College,Cann River P-12 College,44670
+Canterbury Girls Sec College,Canterbury Girls Secondary College,45366
+Carey Baptist Grammar School,Carey Baptist Grammar School,46186
+Caroline Chisholm Catholic Coll,Caroline Chisholm Catholic College,40900
+Caroline Chisholm Catholic College,Caroline Chisholm Catholic College,40900
+Carrum Downs Sec College,Carrum Downs Secondary College,45482
+Carwatha College P-12,Carwatha College P-12,45225
+Casey Grammar School,Casey Grammar School,46326
+Casterton Secondary College,Casterton Secondary College,45367
+Castlemaine Secondary College,Castlemaine Secondary College,45561
+Cathedral College,Cathedral College Wangaratta,46373
+Catherine McAuley College,Catherine McAuley College,40412
+Catholic College Bendigo,Catherine McAuley College,40412
+Catholic College Sale,Catholic College Sale,45737
+Catholic College Wodonga,Catholic College Wodonga,46043
+Catholic Ladies College,Catholic Ladies' College Ltd,45726
+Catholic Regional College,Catholic Regional College Caroline Springs,46121
+Caulfield Grammar School,Caulfield Grammar School,46139
+Caulfield Park Comm School,Oakwood School,45468
+Central Gippsland Inst of TAFE,,
+Centre for Adult Education,,
+Chaffey Secondary College,Chaffey Secondary College,45337
+Chairo Christian School,Chairo Christian School,46295
+Charles La Trobe P-12 College,Charles La Trobe P-12 College,45616
+Charlton College,Charlton College,45566
+Cheltenham Secondary College,Cheltenham Secondary College,45368
+Chisholm Institute,,
+Chisholm Institute of TAFE,,
+Christ the King Anglican Coll,Cobram Anglican Grammar School,46356
+Christian Brothers' College,St Mary's College,45660
+Christian College Institute,Christian College Highton,46262
+Cire Community School,Cire Community School,51484
+Clonard College,Clonard College,45909
+Cobden Technical School,Cobden Technical School,45327
+Cobram Anglican Grammar School,Cobram Anglican Grammar School,46356
+Cobram Secondary College,Cobram Secondary College,45369
+Coburg High School,Coburg High School,40780
+Coburg Senior High School,Coburg High School,40780
+Cohuna Secondary College,Cohuna Secondary College,45370
+Colac Secondary College,Colac Secondary College,45593
+Collingwood College,Collingwood College,45296
+Community College Gippsland,,
+Copperfield College,Copperfield College,40689
+Cornish College,Cornish College,50513
+Corryong College,Corryong College,45576
+Covenant College,Covenant College,46257
+Craigieburn Secondary College,Craigieburn Secondary College,45496
+Cranbourne East Sec College,Cranbourne East Secondary College,50278
+Cranbourne Secondary College,Cranbourne Secondary College,45372
+Croydon Community School,Croydon Community School,45374
+Crusoe 7-10 Secondary College,Crusoe 7-10 Secondary College,45333
+Damascus College,Damascus College,45679
+Dandenong High School,Dandenong High School,45588
+Darul Ulum College of Victoria,Darul Ulum College of Victoria,46345
+Daylesford Neighb'hood Centre,,
+Daylesford Secondary College,Daylesford Secondary College,45329
+De La Salle College,De La Salle College,45771
+Derrinallum P12 College,Derrinallum P-12 College,45183
+Diamond Valley College,Diamond Valley College,45521
+Diamond Valley Learn Centre,,
+Dimboola Memorial Sec College,Dimboola Memorial Secondary College,45376
+Distance Education Victoria,,
+Diversitat,,
+Divrei Emineh,Divrei Emineh,50505
+Djerriwarrh Community College,Djerriwarrh Community & Education Services - Djerriwarrh Community College,53016
+Djerriwarrh Emp. & Edu. Servic.,Djerriwarrh Community & Education Services - Djerriwarrh Community College,53016
+Donald High School,Donald High School,45378
+Doncaster Secondary College,Doncaster Secondary College,45379
+Donvale Christian College,Donvale Christian College,46235
+Dromana Secondary College,Dromana Secondary College,45330
+Drouin Secondary College,Drouin Secondary College,45380
+Eaglehawk Secondary College,Eaglehawk Secondary College,45381
+East Doncaster Sec College,East Doncaster Secondary College,45377
+East Loddon P-12 College,East Loddon P-12 College,45299
+East Preston Islamic College,East Preston Islamic College,46349
+Echuca College,Echuca College,40434
+Edenhope College,Edenhope College,45222
+Edgars Creek Secondary College,Edgars Creek Secondary College,52591
+Edinburgh College,Edinburgh College,46222
+Education Centre Gippsland,ECG College,40835
+Elisabeth Murdoch College,Elisabeth Murdoch College,45506
+Eltham College,Eltham College,46232
+Eltham High School,Eltham High School,45382
+Elwood College,Elwood College,45383
+Emerald Secondary College,Emerald Secondary College,45497
+Emmanuel College,Emmanuel College,45979
+Emmaus College,Emmaus College,45936
+Epping Secondary College,Epping Secondary College,45384
+Essendon Keilor College,Essendon Keilor College,45543
+Euroa Secondary College,Euroa Secondary College,45385
+F.C.J. College,FCJ College,45693
+Fairhills High School,Fairhills High School,45386
+Federation Training,,
+Federation University Australia,,
+Fintona Girls School,Fintona Girls' School,46149
+Firbank Grammar School,Firbank Grammar School,46164
+Fitzroy High School,Fitzroy High School,45517
+Flinders Christian Comm College,Flinders Christian Community College,46299
+Footscray City College,Footscray Learning Precinct Secondary College (interim name),52813
+Footscray High School,Footscray Learning Precinct Secondary College (interim name),52813
+Forest Hill College,Forest Hill College,45508
+Foster Secondary College,Foster Secondary College,45389
+Foundation Learning Centre,,
+Fountain Gate Sec College,Fountain Gate Secondary College,45600
+Frankston High School,Frankston High School,45390
+Galen College,Galen Catholic College,46023
+Geelong Baptist College,Geelong Baptist College,46370
+Geelong Grammar School,Geelong Grammar School,50402
+Geelong High School,Geelong High School,45391
+Geelong Lutheran College,Geelong Lutheran College,46388
+Genazzano F.C.J. College,Genazzano FCJ College,45752
+Gilmore College For Girls,Footscray Learning Precinct Secondary College (interim name),52813
+Gilson College,Gilson College,46239
+Gippsland Grammar,Gippsland Grammar,46196
+Girton Grammar School,Girton Grammar School,46325
+Gisborne Secondary College,Gisborne Secondary College,45393
+Gladstone Park Sec College,Gladstone Park Secondary College,45394
+Glen Eira College,Glen Eira College,45495
+Glen Waverley Sec College,Glen Waverley Secondary College,45546
+Gleneagles Secondary College,Gleneagles Secondary College,45599
+Glenroy Neighbourhood Centre,Glenroy Specialist School,44907
+Glenroy Private,Glenroy Private,50503
+Glenroy Secondary College,Glenroy Secondary College,45625
+Glenvale School,OneSchool Global Vic,46360
+Goldfields Employment & Learn,,
+Good News Lutheran College,Good News Lutheran College,46334
+Good Shepherd College,Good Shepherd College - Senior Campus,46267
+Gordon Institute,,
+Gordon Institute of TAFE,,
+Goroke P-12 College,Goroke P-12 College,45301
+Goulburn Ovens Inst of TAFE,,
+Goulburn Valley Grammar Schl,Goulburn Valley Grammar School,46273
+Goulburn Valley Grammar School,Goulburn Valley Grammar School,46273
+Grace Christian College Wodonga,Grace Christian College Wodonga,46302
+Greater Shepparton SC - McGuire,Greater Shepparton Secondary College,53105
+Greater Shepparton SC - Wanganui,Greater Shepparton Secondary College,53105
+Greater Shepparton SC McGuire,Greater Shepparton Secondary College,53105
+Greater Shepparton SC Wanganui,Greater Shepparton Secondary College,53105
+Greater Shepparton Sec College,Greater Shepparton Secondary College,53105
+Greensborough Sec College,Greensborough Secondary College,45522
+Grovedale College,Grovedale College,45331
+Haileybury College,Haileybury College,46189
+Haileybury Girls College,Haileybury College,46189
+Haileybury Rendall School,Haileybury College,46189
+Hallam Senior Sec College,Hallam Secondary College,40623
+Hampton Park Sec College,Hampton Park Secondary College,45499
+Hawkesdale College,Hawkesdale P12 College,45224
+Hazel Glen College,Hazel Glen College,50683
+Healesville High School,Healesville High School,45397
+Heathdale Christian College,Heathdale Christian College,46275
+Heatherton Christian College,Heatherton Christian College,46350
+Heathmont College,Heathmont College,45555
+Heritage College,Heritage College,46212
+Hester Hornbrook Academy,Hester Hornbrook Academy,52517
+Heywood & District Sec College,Heywood District Secondary College,45398
+Highvale Secondary College,Highvale Secondary College,45399
+Highview Christian Comm College,Highview College,46142
+Hillcrest Christian College,Hillcrest Christian College,46276
+Holmes Grammar School,Holmes Grammar School,40736
+Holmes Secondary College,Holmes Grammar School,40736
+Holmesglen Institute,,
+Holmesglen Institute of TAFE,,
+Holy Trinity Lutheran College,Holy Trinity Lutheran College,46242
+Homestead Senior Sec College,Homestead Senior Secondary College,52780
+Hopetoun P-12 College,Hopetoun P-12 College,45400
+Hoppers Crossing Sec College,Hoppers Crossing Secondary College,45500
+Horsham College,Horsham College,45556
+Hume Anglican Grammar,Hume Anglican Grammar,46385
+Hume Central Sec College,Hume Central Secondary College,50190
+Huntingtower School,Huntingtower School,46201
+Ilim College,Ilim College,46328
+Ilim College Boys Campus,Ilim College,46328
+Ilim College Kiewa Campus,Ilim College,46328
+Ilim College of Australia,Ilim College,46328
+Indie School Wodonga,Indie School Wodonga,43720
+Iona College Geelong,Iona College Geelong,52858
+Irymple Secondary College,Irymple Secondary College,45332
+Islamic College of Melbourne,Islamic College Of Melbourne,50312
+Ivanhoe Girls' Grammar School,Ivanhoe Girls' Grammar School,46185
+Ivanhoe Grammar School,Ivanhoe Grammar School,46170
+John Fawkner College,John Fawkner Secondary College,45626
+John Monash Science School,John Monash Science School,40828
+John Paul College,John Paul College,45994
+Kambrya College,Kambrya College,45480
+Kangan Institute,,
+Kangan Institute of TAFE,,
+Kaniva P-12 College,Kaniva College,45575
+Kardinia Internatl College,Kardinia International College,46332
+Karingal,McClelland Secondary College,45571
+Keilor Downs College,Keilor Downs Secondary College,45501
+Kensington Comm High School,Kensington Community High School,45404
+Kerang Christian College,Kerang Christian College,46289
+Kerang Technical High School,Kerang Technical High School,45403
+Kew High School,Kew High School,45405
+Keysborough SC - Acacia,Keysborough Secondary College,45595
+Keysborough SC - Banksia,Keysborough Secondary College,45595
+Kilbreda College,Kilbreda College,45712
+Killester College,Killester College,45906
+Kilvington Grammar School,Kilvington Grammar School,46188
+Kings College,King's College,46306
+Kingswood College,Kingswood College,46202
+Kolbe Catholic College,Kolbe Catholic College,46123
+Koo Wee Rup Sec College,Koo Wee Rup Secondary College,45407
+Koonung Secondary College,Koonung Secondary College,45406
+Korowa Anglican Girls' School,Korowa Anglican Girls' School,46136
+Korumburra Sec College,Korumburra Secondary College,45408
+Kurnai College,Kurnai College,45503
+Kurunjang Secondary College,Kurunjang Secondary College,45504
+Kyabram P-12 College,Kyabram P-12 College,45409
+Kyneton Secondary College,Kyneton High School,45412
+Lake Bolac College,Lake Bolac College,44149
+Lakes Entrance Sec College,Lakes Entrance Secondary College,45505
+Lakeside Lutheran College,Lakeside College,46380
+Lakeview Senior College,Lakeview Senior College,50199
+Lalor North Sec College,Lalor North Secondary College,45414
+Lalor Secondary College,Lalor Secondary College,45413
+Lara Secondary College,Lara Secondary College,45574
+Lauriston Girls School,Lauriston Girls' School,46150
+Lavalla Catholic College,Lavalla Catholic College,40708
+Lavers Hill K-12 College,Lavers Hill K-12 College,45304
+Lavers Hill P12 College,Lavers Hill K-12 College,45304
+Laverton P-12 College,Laverton P-12 College,45590
+Leibler Yavneh College,Leibler Yavneh College,46218
+Leongatha Secondary College,Leongatha Secondary College,45520
+Lighthouse Christian College,Lighthouse Christian College,46315
+Lilydale Heights College,Lilydale Heights College,45335
+Lilydale High School,Lilydale High School,45415
+Little Yarra Steiner School,Little Yarra Steiner School,46313
+Loreto College,Loreto College,45638
+Loreto Mandeville Hall,Loreto Mandeville Hall,45810
+Lorne P-12 College,Lorne P-12 College,52491
+Lorne-Aireys Inlet P-12 Coll,Lorne P-12 College,52491
+Lowanna College,Lowanna College,45559
+Lowther Hall Anglican GS,Lowther Hall Anglican Grammar School,46179
+Loyola College,Loyola College,46053
+Luther College,Luther College,46223
+Lynall Hall Community School,Lynall Hall Community School,45417
+Lyndale Secondary College,Lyndale Secondary College,45416
+Lyndhurst Secondary College,Lyndhurst Secondary College,45328
+Mac.Robertson Girls' High Schl,MacRobertson Girls High School,45437
+MacKillop Catholic Reg College,MacKillop Catholic Regional College,46002
+Macleod College,Macleod College,45311
+Maffra Secondary College,Maffra Secondary College,45418
+Mallacoota P-12 College,Mallacoota P-12 College,44613
+Manangatang P-12 College,Manangatang P-12 College,45306
+Manor Lakes P-12 College,Manor Lakes P-12 College,45580
+Mansfield Secondary College,Mansfield Secondary College,45419
+Maranatha Christian School,Maranatha Christian School,46226
+Marcellin College,Marcellin College,45874
+Marian College Ararat,Marian College,45700
+Marian College Myrtleford,Marian College,46008
+Marian College Sunshine,Marian College,45963
+Maribyrnong Sec College,Maribyrnong Secondary College,45420
+Marist - Sion College,Marist-Sion College,45875
+Marist College Bendigo,Marist College Bendigo,50698
+Marist Sion College,Marist-Sion College,45875
+Mary MacKillop Catholic College,Mary MacKillop Catholic Regional College,46081
+Maryborough Education Centre,Maryborough Education Centre,50200
+Marymede Catholic College,Marymede Catholic College,46117
+Mater Christi College,Mater Christi College,45970
+Matthew Flinders Girls' SC,Matthew Flinders Girls Secondary College,45422
+Mazenod College,Mazenod College,45996
+McClelland Secondary College,McClelland Secondary College,45571
+McGuire College,Greater Shepparton Secondary College,53105
+McKinnon Secondary College,Mckinnon Secondary College,45436
+Melba College,Melba Secondary College,45421
+Melbourne City Mission,,
+Melbourne Girls Grammar,Melbourne Girls Grammar,46157
+Melbourne Girls' College,Melbourne Girls College,45557
+Melbourne Grammar School,Melbourne Grammar School,46137
+Melbourne High School,Melbourne High School,45423
+Melbourne Montessori School,Melbourne Montessori School,46244
+Melbourne Polytechnic,,
+Melbourne Rudolf Steiner Schl,Melbourne Rudolf Steiner School,46230
+Melbourne Senior Sec College,,
+Melton Christian College,Melton Christian College,46303
+Melton Secondary College,Melton Secondary College,45424
+Mentone Girls' Grammar School,Mentone Girls' Grammar School,46195
+Mentone Girls' Sec College,Mentone Girls Secondary College,45425
+Mentone Grammar School,Mentone Grammar School,46184
+Merbein P-10 College,Merbein P-10 College,45612
+Mercy College,Mercy College,45985
+Mercy Regional College,Mercy Regional College,45745
+Merinda Park Learning Centre,,
+Mernda Central P-12 College,Mernda Central P-12 College,52478
+Methodist Ladies College,Methodist Ladies' College,46144
+Mildura Senior College,Mildura Senior College,40562
+Mill Park Secondary College,Mill Park Secondary College,45524
+Minaret College,Minaret College,46321
+Mirboo North Sec College,Mirboo North Secondary College,45426
+Monbulk College,Monbulk College,45427
+Monivae College,Monivae College,45893
+Monterey Secondary College,Monterey Secondary College,45547
+Montmorency Sec College,Montmorency Secondary College,45428
+Mooroolbark College,Mooroolbark College,45429
+Mooroopna Secondary College,Greater Shepparton Secondary College,53105
+Mordialloc College,Mordialloc College,45431
+Mornington Secondary College,Mornington Secondary College,45542
+Mortlake College,Mortlake P-12 College,45184
+Mount Alexander 7-12 Coll,Mount Alexander 7-12 College,45375
+Mount Beauty Sec College,Mount Beauty Secondary College,45432
+Mount Clear College,Mount Clear College,45339
+Mount Eliza Sec College,Mount Eliza Secondary College,45433
+Mount Erin College,Mount Erin Secondary College,45324
+Mount Evelyn Christian School,Mount Evelyn Christian School,46229
+Mount Lilydale Mercy College,Mount Lilydale Mercy College,45706
+Mount Ridley P-12 College,Mount Ridley P-12 College,45585
+Mount Rowan Secondary College,Mount Rowan Secondary College,45565
+Mount Scopus Memorial College,Mount Scopus Memorial College,46208
+Mount St Joseph Girls' College,Mount St Joseph Girls' College,45964
+Mount Waverley Sec College,Mount Waverley Secondary College,45434
+Mountain District Christian SC,Mountain District Christian School,46258
+Mountain District Christian Schl,Mountain District Christian School,46258
+Mountain District Comm College,Mountain District Community College,53091
+Mountain District Learn Centre,,
+Mountain District Women's Co-Op,,
+Mt Hira College,Mt Hira College,46359
+Mullauna College,Mullauna Secondary College,45519
+Murrayville Community College,Murrayville Community College,45223
+Murtoa P-12 College,Murtoa College,44306
+Myrtleford P-12 College,Myrtleford P-12 College,40584
+Nagle College,Nagle College,45933
+Narre Community Learn Centre,,
+Narre Warren Sth P-12 College,Narre Warren South P-12 College,45573
+Nathalia Secondary College,Nathalia Secondary College,45438
+Nazareth College,Nazareth College,46079
+Neerim District Sec College,Neerim District Secondary College,45439
+Newcomb Secondary College,Newcomb Secondary College,45440
+Newhaven College,Newhaven College,46260
+Nhill College,Nhill College,45569
+Noble Park Secondary College,Noble Park Secondary College,45551
+North Geelong Sec College,North Geelong Secondary College,45392
+North Melbourne Grammar Coll,,
+North Ringwood Comm House,,
+Northcote High School,Northcote High School,45442
+Northern Bay P-12 College,Northern Bay P-12 College,50291
+Northern College of Arts & Tech,Northern College of the Arts and Technology,45341
+Northern Melbourne Inst of TAFE,,
+Northside Christian College,Northside Christian College,46251
+Norwood Secondary College,Norwood Secondary College,45443
+Nossal High School,Nossal High School,45594
+Notre Dame College,Notre Dame College,45715
+Numurkah Secondary College,Numurkah Secondary College,45444
+Nunawading Christian College,Nunawading Christian College - Secondary,46231
+Oakleigh Grammar,Oakleigh Grammar,46287
+Oakwood School,Oakwood School,45468
+Oberon High School,Oberon High School,45445
+Officer Secondary College,Officer Secondary College,51485
+OneSchool Global Vic,OneSchool Global Vic,46360
+Orbost Secondary College,Orbost Secondary College,45446
+Our Lady of Mercy College,Our Lady of Mercy College,45760
+Our Lady of Sacred Heart Coll,Our Lady of the Sacred Heart College,45868
+Our Lady of Sion College,Our Lady of Sion College,45823
+Ouyen P-12 College,Ouyen P-12 College,45447
+Overnewton Anglican Comm Coll,Overnewton Anglican Community College,46310
+Oxley Christian College,Oxley Christian College,46255
+Ozford College,Ozford College,40714
+Padua College,Padua College,45713
+Pakenham Secondary College,Pakenham Secondary College,45449
+Parade College,Parade College,45629
+Parkdale Secondary College,Parkdale Secondary College,45450
+Parkville College,Parkville College,50576
+Pascoe Vale Girls Sec College,Pascoe Vale Girls Secondary College,45452
+Patterson River Sec College,Patterson River Secondary College,45509
+Peninsula Grammar,Peninsula Grammar,46219
+Peninsula Train & Employment,,
+Penleigh & Essendon Grammar,Penleigh & Essendon Grammar School,46180
+Penola Catholic College,Penola Catholic College,46096
+Peter Lalor Secondary College,Peter Lalor Secondary College,45334
+Peter Lalor Vocational Coll,,
+Phoenix P-12 Comm Coll,Phoenix P-12 Community College,50268
+Pines Learning,,
+Plenty River College,Plenty River College,53092
+Plenty Valley Christian College,Plenty Valley Christian College,46269
+Point Cook Senior Sec College,Point Cook Senior Secondary College,40786
+Portland Secondary College,Portland Secondary College,45534
+Prahran Community Centre,,
+Prahran Community Learn Centre,,
+Prahran High School,Prahran High School,52698
+Presbyterian Ladies' College,Presbyterian Ladies' College,46162
+Presentation College,,
+Preshil The Margaret Lyttle MS,"Preshil, The Margaret Lyttle Memorial School",46206
+Preshil The Margaret Lyttle SC,"Preshil, The Margaret Lyttle Memorial School",46206
+Preshil The Margaret Lyttle Schl,"Preshil, The Margaret Lyttle Memorial School",46206
+Preston High School,Preston High School,52699
+Preston Reservoir ACE,Preston Reservoir Adult Community Education Inc | Prace College,52482
+Princes Hill Sec College,Princes Hill Secondary College,45454
+Pyramid Hill College,Pyramid Hill College,44346
+Rainbow P-12 College,Rainbow P-12 College,51482
+Rainbow Secondary College,Rainbow P-12 College,51482
+Red Cliffs Secondary College,Red Cliffs Secondary College,45458
+Red Rock Christian College,Red Rock Christian College,46342
+Reservoir High School,Reservoir High School,45498
+Richmond High School,Richmond High School,52703
+Ringwood Secondary College,Ringwood Secondary College,45459
+River Nile School,River Nile School,52480
+RMIT TAFE,,
+Robinvale College,Robinvale College,52377
+Robinvale P-12 College,Robinvale College,52377
+Rochester Secondary College,Rochester Secondary College,45460
+Rosebud Secondary College,Rosebud Secondary College,45461
+Rosehill Secondary College,Rosehill Secondary College,45340
+Rowville Secondary College,Rowville Secondary College,45512
+Roxburgh College,Roxburgh College,45476
+Rushworth P-12 College,Rushworth P-12 College,45310
+Rutherglen High School,Rutherglen High School,45462
+Ruyton Girls' School,Ruyton Girls' School,46138
+Sacre Coeur,Sacre Coeur,45654
+Sacred Heart College,Sacred Heart College,45672
+Sacred Heart College Geelong,Sacred Heart College,45672
+Sacred Heart College Kyneton,Sacred Heart College,45682
+Sacred Heart Girls' College,Sacred Heart Girls' College,45922
+Saint Ignatius College,Saint Ignatius College Geelong,45721
+Sale College,Sale College,40726
+Salesian College,Salesian College Chadstone,45870
+Salesian College Sunbury,Salesian College Sunbury,45827
+Sandringham College,Sandringham College,40620
+Santa Maria College,Santa Maria College,45841
+Scoresby Secondary College,Scoresby Secondary College,45463
+Scotch College,Scotch College,46172
+SEDA College,SEDA College (Victoria),52527
+SEDA Group,,
+Seymour College,Seymour College,40851
+Shelford Girls' Grammar,Shelford Girls' Grammar,46183
+Shepparton ACE College,Shepparton ACE Secondary College,40848
+Shepparton ACE Sec College,Shepparton ACE Secondary College,40848
+Shepparton Christian College,Shepparton Christian College,46344
+Shepparton High School,Sherbrooke Community School,45316
+Sherbrooke Community School,Siena College Ltd,45857
+Siena College,Simonds Catholic College,45631
+Simonds Catholic College,Simonds Catholic College,45631
+Sirius College - Eastmeadows,Sirius College,46335
+Sirius College - Ibrahim Dellal,Sirius College,46335
+Sirius College - Keysborough,Sirius College,46335
+Sirius College - Meadow Fair,Sirius College,46335
+Skillsplus,,
+SkillsPlus,,
+Somerville Secondary College,Somerville Secondary College,45605
+South Gippsland Sec College,Foster Secondary College,45389
+South Oakleigh Sec College,South Oakleigh Secondary College,45539
+South West Institute of TAFE,,
+Southern Cross Grammar,Southern Cross Grammar,50394
+Southern Grampians Adult Edu,,
+Springside West Sec College,Springside West Secondary College,52594
+St Albans Secondary College,St Albans Secondary College,45466
+St Aloysius College,St Aloysius College,45735
+St Andrews Christian College,St Andrews Christian College,46293
+St Anne's College,St Anne's College,52735
+St Arnaud Secondary College,St Arnaud Secondary College,45467
+St Augustine's College,St Augustine's College,45739
+St Bede's College,St Bede's College,45855
+St Bernard's College,St Bernard's College,45864
+St Brigid's College,St Brigid's College,45793
+St Catherine's School,St Catherine's School,46178
+St Columba's College,St Columba's College,45748
+St Francis Xavier College,St Francis Xavier College,40621
+St Helena Secondary College,St Helena Secondary College,45510
+St John's Greek Orth College,St John's College Preston,46252
+St John's Regional College,St John's Regional College,45932
+St Joseph's College,St Joseph's College,45732
+St Kevin's College,St Kevin's College,45848
+St Leonard's College,St Leonard's College,46173
+St Margaret's School,St Margaret's Berwick Grammar,46203
+St Mary MacKillop College,St Mary MacKillop College,46085
+St Mary of the Angels School,St Mary of the Angels College,45945
+St Mary's College,St Mary's College,45660
+St Mary's College Melbourne,St Mary's College Melbourne,45632
+St Mary's Coptic Orth College,St Mary's Coptic Orthodox College,46320
+St Michael's Grammar School,St Michael's Grammar School,46163
+St Monica's College,St Monica's College,40615
+St Patrick's College,St Patrick's College,45634
+St Paul's Anglican Grammar Schl,St Paul's Anglican Grammar School,46277
+St Peter's College,St Peter's College,46087
+St Thomas Aquinas College,St Thomas Aquinas College,46346
+Star of the Sea College,Star of the Sea College,45675
+Staughton College,Staughton College,45336
+Stawell Secondary College,Stawell Secondary College,45511
+Stott's College,Stott's Colleges,50313
+Strathcona Baptist Girls GS,Strathcona Baptist Girls' Grammar,46192
+Strathmore Secondary College,Strathmore Secondary College,45469
+Sunbury College,Sunbury College,45470
+Sunbury Downs Sec College,Sunbury Downs Secondary College,45507
+Sunraysia Institute of TAFE,,
+Sunshine College,Sunshine College,45529
+Surf Coast Sec College,Surf Coast Secondary College,50460
+Suzanne Cory High School,Suzanne Cory High School,50301
+Swan Hill College,Swan Hill College,45540
+Swifts Creek P-12 School,Swifts Creek P-12 School,45623
+Swifts Creek School,Swifts Creek P-12 School,45623
+Swinburne Senior Sec College,Swinburne Senior Secondary College,40430
+Swinburne Uni of Tech - TAFE,,
+Sydney Road Community School,Sydney Road Community School,45471
+TAFE Gippsland,,
+Tallangatta Secondary College,Tallangatta Secondary College,45472
+Tarneit Senior College,Tarneit Senior College,50459
+Taylors College,,
+Taylors Lakes Sec College,Taylors Lakes Secondary College,45527
+Templestowe College,Templestowe College,45560
+Terang College Sec Campus,Terang College,45307
+The Bendigo Kangan Institute,,
+The Centre,,
+The David Scott School,David Scott School,52481
+The Geelong College,The Geelong College,46159
+The Grange P-12 College,The Grange P-12 College,45526
+The Hamilton & Alexandra Coll,The Hamilton and Alexandra College,46167
+The King David School,The King David School,46247
+The Knox School,The Knox School,46274
+The Lakes South Morang College,The Lakes South Morang College,45578
+The Peninsula School,Peninsula Grammar,46219
+Thomas Carr College,Thomas Carr College,46102
+Thomastown Secondary College,Thomastown Secondary College,45473
+Thornbury High School,Thornbury High School,45533
+Timboon P-12 School,Timboon P-12 School,45321
+Tintern Grammar,Tintern Grammar,46175
+Tintern Schools,Tintern Grammar,46175
+Toorak College,Toorak College,46177
+Trafalgar High School,Trafalgar High School,45474
+Training & Edu. Programs Aust.,,
+Traralgon College,Traralgon College,40588
+Trinity College Colac,Trinity College Colac Inc,45710
+Trinity Grammar School,Trinity Grammar School Kew,46156
+Trinity Lutheran College,Trinity Lutheran College,46272
+Tyrrell College,Tyrrell College,45203
+University High School,University High School,45475
+Upper Yarra Community House,,
+Upper Yarra Secondary College,Upper Yarra Secondary College,45477
+Upwey High School,Upwey High School,45478
+Vermont Secondary College,Vermont Secondary College,45479
+Victoria Uni of Tech - TAFE,,
+Victoria University - TAFE,,
+Victoria University Polytechnic,,
+Victoria University SC,,
+Victorian College for the Deaf,Victorian College For The Deaf,44652
+Victorian College of the Arts,Victorian College Of The Arts Secondary School,45344
+Victory Christian College,Victory Christian College,46327
+Victory Lutheran College,Victory Lutheran College,46323
+Viewbank College,Viewbank College,45550
+Village High School,Village High School,52861
+Virtual School Victoria,Virtual School Victoria,45322
+Wallan Secondary College,Wallan Secondary College,45532
+Wanganui Park Sec College,Greater Shepparton Secondary College,53105
+Wangaratta High School,Wangaratta High School,45483
+Wantirna College,Wantirna College,45484
+Warracknabeal Sec College,Warracknabeal Secondary College,45485
+Warragul Regional College,Warragul Regional College,45563
+Warrandyte High School,Warrandyte High School,45486
+Warrnambool College,Warrnambool College,45549
+Waverley Christian College,Waverley Christian College,46246
+Wedderburn College,Wedderburn College,45323
+Weeroona College Bendigo,Weeroona College Bendigo,45347
+Wellington Secondary College,Wellington Secondary College,45487
+Werribee Secondary College,Werribee Secondary College,45488
+Werrimull P-12 College,Werrimull P-12 School,45318
+Wesley College,Wesley College,46132
+Westall Secondary College,Westall Secondary College,45490
+Westbourne Grammar School,Westbourne Grammar School,46249
+Western Heights Sec College,Western Heights Secondary College,45558
+Western Port Sec College,Western Port Secondary College,45396
+Western Senior Sec Coll,,
+Wheelers Hill Sec College,Wheelers Hill Secondary College,45491
+Whitefriars College,Whitefriars College Inc,45865
+Whittlesea Secondary College,Whittlesea Secondary College,45348
+William Angliss Inst of TAFE,,
+William Ruthven Sec College,William Ruthven Secondary College,45627
+Williamstown High School,Williamstown High School,40427
+Wodonga Institute of TAFE,,
+Wodonga Senior Sec College,Wodonga Senior Secondary College,40429
+Wonthaggi Secondary College,Bass Coast College,40597
+Woodleigh School,Woodleigh School,46391
+Woodmans Hill Secondary College,Woodmans Hill Secondary College,52702
+Wycheproof P-12 College,Wycheproof P-12 College,45567
+Wyndham Central Sec Coll,Wyndham Central Secondary College,45346
+Wyndham Comm & Educ Centre,,
+Wyndham Community Centre,,
+Xavier College,Xavier College,45696
+Yarra Hills Sec Coll Mooroolbark,Yarra Hills Secondary College,50185
+Yarra Hills Sec Coll Mt Evelyn,Yarra Hills Secondary College,50185
+Yarra Hills Secondary College,Yarra Hills Secondary College,50185
+Yarra Valley Community School,Cire Community School,51484
+Yarra Valley Grammar School,Yarra Valley Grammar,46224
+Yarram Secondary College,Yarram Secondary College,45493
+Yarrawonga College P-12,Yarrawonga College P-12,45608
+Yea High School,Yea High School,45494
+Yeshivah College,Yeshivah College,46215
+Yesodei HaTorah College,Yesodei HaTorah College,46376
+Youth2Industry College,Youth2Industry College,52992
+Yuille Park Community College,Yuille Park P-8 Community College,45268

--- a/vce_school_results_analysis_dataset.csv
+++ b/vce_school_results_analysis_dataset.csv
@@ -8,7 +8,7 @@ Academy of Mary Immaculate,45704.0,2019,FITZROY,31.0,7.0,94.8,100.0,1084.0,Catho
 Academy of Mary Immaculate,45704.0,2020,FITZROY,30.0,5.2,95.7,100.0,1083.0,Catholic,Secondary,670.0,-37.803711,144.974409
 Academy of Mary Immaculate,45704.0,2021,FITZROY,30.0,6.5,94.0,100.0,1081.0,Catholic,Secondary,697.0,-37.803711,144.974409
 Academy of Mary Immaculate,45704.0,2022,FITZROY,32.0,7.0,94.9,100.0,1079.0,Catholic,Secondary,679.0,-37.803711,144.974409
-Academy of Mary Immaculate,,2023,FITZROY,31.0,10.3,93.8,99.0,,,,,,
+Academy of Mary Immaculate,45704.0,2023,FITZROY,31.0,10.3,93.8,99.0,,,,,,
 Adass Israel School,46213.0,2014,ELSTERNWICK,,,,,947.0,Independent,Combined,503.0,-37.883899,145.008205
 Adass Israel School,46213.0,2015,ELSTERNWICK,,,,,939.0,Independent,Combined,514.0,-37.883899,145.008205
 Adass Israel School,46213.0,2016,ELSTERNWICK,,,,,944.0,Independent,Combined,512.0,-37.883899,145.008205
@@ -21,16 +21,17 @@ Adass Israel School,46213.0,2021,ELSTERNWICK,,,,,943.0,Independent,Combined,437.
 Adass Israel School,46213.0,2021,EAST ST KILDA,,,,,943.0,Independent,Combined,437.0,-37.883899,145.008205
 Adass Israel School,46213.0,2022,ELSTERNWICK,,,,,928.0,Independent,Combined,418.0,-37.883899,145.008205
 Adass Israel School,46213.0,2022,EAST ST KILDA,,,,,928.0,Independent,Combined,418.0,-37.883899,145.008205
-Adass Israel School,,2023,ELSTERNWICK,,,,100.0,,,,,,
-Adass Israel School,,2023,EAST ST KILDA,,,,,,,,,,
+Adass Israel School,46213.0,2023,ELSTERNWICK,,,,100.0,,,,,,
+Adass Israel School,46213.0,2023,EAST ST KILDA,,,,,,,,,,
 Advance College of Education,52378.0,2017,ROSEBUD WEST,,,,,,Independent,Special,66.0,-38.382705,144.885067
 Advance College of Education,52378.0,2018,ROSEBUD WEST,,,,,,Independent,Special,48.0,-38.382705,144.885067
 Advance College of Education,52378.0,2019,ROSEBUD WEST,,,,,,Independent,Special,47.0,-38.382705,144.885067
 Advance College of Education,52378.0,2020,ROSEBUD WEST,,,,,,Independent,Special,54.0,-38.382705,144.885067
 Advance College of Education,52378.0,2021,ROSEBUD WEST,,,,,978.0,Independent,Special,52.0,-38.382705,144.885067
 Advance College of Education,52378.0,2022,ROSEBUD WEST,,,,,934.0,Independent,Special,63.0,-38.382705,144.885067
-Advance College of Education,,2023,ROSEBUD WEST,,,,75.0,,,,,,
-Advance Community College,45223.0,2016,ROSEBUD WEST,,,,,1000.0,Government,Combined,120.0,-35.26557452,141.17733647
+Advance College of Education,52378.0,2023,ROSEBUD WEST,,,,75.0,,,,,,
+Advance Community College,52378.0,2016,ROSEBUD WEST,,,,,,Independent,Special,51.0,-38.382705,144.885067
+Advance TAFE,,2014,BAIRNSDALE,19.0,0.0,0.0,100.0,,,,,,
 Aitken College,46353.0,2014,GREENVALE,30.0,5.2,97.0,98.0,1064.0,Independent,Combined,1271.0,-37.627398,144.888422
 Aitken College,46353.0,2015,GREENVALE,30.0,6.3,92.0,99.0,1067.0,Independent,Combined,1273.0,-37.627398,144.888422
 Aitken College,46353.0,2016,GREENVALE,31.0,7.7,94.0,99.0,1068.0,Independent,Combined,1266.0,-37.627398,144.888422
@@ -40,10 +41,10 @@ Aitken College,46353.0,2019,GREENVALE,29.0,4.9,91.1,99.0,1079.0,Independent,Comb
 Aitken College,46353.0,2020,GREENVALE,29.0,5.1,87.5,100.0,1079.0,Independent,Combined,1274.0,-37.627398,144.888422
 Aitken College,46353.0,2021,GREENVALE,28.0,2.7,94.2,98.0,1085.0,Independent,Combined,1292.0,-37.627398,144.888422
 Aitken College,46353.0,2022,GREENVALE,28.0,2.2,91.4,100.0,1091.0,Independent,Combined,1428.0,-37.627398,144.888422
-Aitken College,,2023,GREENVALE,28.0,5.6,89.1,99.0,,,,,,
+Aitken College,46353.0,2023,GREENVALE,28.0,5.6,89.1,99.0,,,,,,
 Al Iman College,52380.0,2021,MELTON SOUTH,26.0,3.9,35.7,100.0,1031.0,Independent,Combined,723.0,-37.706956,144.564872
 Al Iman College,52380.0,2022,MELTON SOUTH,25.0,0.0,53.8,92.0,1038.0,Independent,Combined,846.0,-37.706956,144.564872
-Al Iman College,,2023,MELTON SOUTH,29.0,5.9,82.6,100.0,,,,,,
+Al Iman College,52380.0,2023,MELTON SOUTH,29.0,5.9,82.6,100.0,,,,,,
 Al Siraat College,46390.0,2014,EPPING,32.0,0.0,,,982.0,Independent,Combined,409.0,-37.62426056,145.03753369
 Al Siraat College,46390.0,2015,EPPING,31.0,13.6,100.0,100.0,992.0,Independent,Combined,510.0,-37.62426056,145.03753369
 Al Siraat College,46390.0,2016,EPPING,28.0,0.0,80.0,100.0,1017.0,Independent,Combined,643.0,-37.62426056,145.03753369
@@ -53,7 +54,7 @@ Al Siraat College,46390.0,2019,EPPING,27.0,1.3,92.9,100.0,1024.0,Independent,Com
 Al Siraat College,46390.0,2020,EPPING,28.0,1.7,100.0,100.0,1024.0,Independent,Combined,994.0,-37.62426056,145.03753369
 Al Siraat College,46390.0,2021,EPPING,30.0,4.6,95.0,100.0,1042.0,Independent,Combined,1059.0,-37.62426056,145.03753369
 Al Siraat College,46390.0,2022,EPPING,32.0,16.2,100.0,100.0,1048.0,Independent,Combined,1138.0,-37.62426056,145.03753369
-Al Siraat College,,2023,EPPING,32.0,8.9,97.4,100.0,,,,,,
+Al Siraat College,46390.0,2023,EPPING,32.0,8.9,97.4,100.0,,,,,,
 Al-Taqwa College,46309.0,2014,TRUGANINA,26.0,2.2,91.0,100.0,1003.0,Independent,Combined,1701.0,-37.85265,144.722023
 Al-Taqwa College,46309.0,2015,TRUGANINA,28.0,2.2,97.0,100.0,1009.0,Independent,Combined,1825.0,-37.85265,144.722023
 Al-Taqwa College,46309.0,2016,TRUGANINA,28.0,2.3,96.0,100.0,1009.0,Independent,Combined,1970.0,-37.85265,144.722023
@@ -63,7 +64,7 @@ Al-Taqwa College,46309.0,2019,TRUGANINA,27.0,2.9,94.7,97.0,1035.0,Independent,Co
 Al-Taqwa College,46309.0,2020,TRUGANINA,27.0,3.1,90.5,100.0,1035.0,Independent,Combined,2095.0,-37.85265,144.722023
 Al-Taqwa College,46309.0,2021,TRUGANINA,26.0,0.7,96.6,100.0,1047.0,Independent,Combined,2149.0,-37.85265,144.722023
 Al-Taqwa College,46309.0,2022,TRUGANINA,30.0,5.3,97.1,99.0,1054.0,Independent,Combined,2182.0,-37.85265,144.722023
-Al-Taqwa College,,2023,TRUGANINA,31.0,4.0,93.7,100.0,,,,,,
+Al-Taqwa College,46309.0,2023,TRUGANINA,31.0,4.0,93.7,100.0,,,,,,
 Albert Park College,50267.0,2014,ALBERT PARK,34.0,25.0,,,1112.0,Government,Secondary,703.0,-37.84436706,144.94741572
 Albert Park College,50267.0,2015,ALBERT PARK,32.0,9.1,,,1115.0,Government,Secondary,884.0,-37.84436706,144.94741572
 Albert Park College,50267.0,2016,ALBERT PARK,31.0,9.2,78.0,99.0,1113.0,Government,Secondary,1036.0,-37.84436706,144.94741572
@@ -73,15 +74,15 @@ Albert Park College,50267.0,2019,ALBERT PARK,31.0,8.6,87.7,98.0,1114.0,Governmen
 Albert Park College,50267.0,2020,ALBERT PARK,31.0,10.1,88.3,99.0,1116.0,Government,Secondary,1444.0,-37.84436706,144.94741572
 Albert Park College,50267.0,2021,ALBERT PARK,30.0,9.0,85.8,99.0,1119.0,Government,Secondary,1551.0,-37.84436706,144.94741572
 Albert Park College,50267.0,2022,ALBERT PARK,32.0,8.8,85.6,98.0,1124.0,Government,Secondary,1559.0,-37.84436706,144.94741572
-Albert Park College,,2023,ALBERT PARK,31.0,6.3,83.3,99.0,,,,,,
-Albury Wodonga Comm College,45587.0,2014,WODONGA,,,,,989.0,Government,Combined,205.0,-37.86152274,144.8172644
-Albury Wodonga Comm College,45587.0,2015,WODONGA,,,,,987.0,Government,Combined,218.0,-37.86152274,144.8172644
-Albury Wodonga Comm College,45587.0,2016,WODONGA,,,,,992.0,Government,Combined,242.0,-37.86152274,144.8172644
-Albury Wodonga Comm College,45587.0,2017,WODONGA,,,,,1001.0,Government,Combined,273.0,-37.86152274,144.8172644
-Albury Wodonga Comm College,45587.0,2018,WODONGA,,,,,1002.0,Government,Combined,313.0,-37.86152274,144.8172644
-Albury Wodonga Comm College,45587.0,2019,WODONGA,,,,,1001.0,Government,Combined,385.0,-37.86152274,144.8172644
-Albury Wodonga Comm College,45587.0,2020,WODONGA,,,,,1008.0,Government,Combined,483.0,-37.86152274,144.8172644
-Albury Wodonga Comm College,45587.0,2021,WODONGA,,,,,1012.0,Government,Combined,556.0,-37.86152274,144.8172644
+Albert Park College,50267.0,2023,ALBERT PARK,31.0,6.3,83.3,99.0,,,,,,
+Albury Wodonga Comm College,43720.0,2014,WODONGA,,,,,,Independent,Special,63.0,-36.118028,146.889403
+Albury Wodonga Comm College,43720.0,2015,WODONGA,,,,,,Independent,Special,45.0,-36.118028,146.889403
+Albury Wodonga Comm College,43720.0,2016,WODONGA,,,,,,Independent,Special,39.0,-36.118028,146.889403
+Albury Wodonga Comm College,43720.0,2017,WODONGA,,,,,,Independent,Special,160.0,-36.118028,146.889403
+Albury Wodonga Comm College,43720.0,2018,WODONGA,,,,,,Independent,Special,222.0,-36.118028,146.889403
+Albury Wodonga Comm College,43720.0,2019,WODONGA,,,,,,Independent,Special,282.0,-36.118028,146.889403
+Albury Wodonga Comm College,43720.0,2020,WODONGA,,,,,,Independent,Special,438.0,-36.118028,146.889403
+Albury Wodonga Comm College,43720.0,2021,WODONGA,,,,,956.0,Independent,Special,580.0,-36.118028,146.889403
 Alexandra Secondary College,45349.0,2014,ALEXANDRA,28.0,2.2,97.0,100.0,973.0,Government,Secondary,291.0,-37.19449,145.701477
 Alexandra Secondary College,45349.0,2015,ALEXANDRA,27.0,4.3,68.0,87.0,960.0,Government,Secondary,301.0,-37.19449,145.701477
 Alexandra Secondary College,45349.0,2016,ALEXANDRA,26.0,2.7,72.0,88.0,960.0,Government,Secondary,297.0,-37.19449,145.701477
@@ -91,7 +92,7 @@ Alexandra Secondary College,45349.0,2019,ALEXANDRA,28.0,3.0,57.7,96.0,975.0,Gove
 Alexandra Secondary College,45349.0,2020,ALEXANDRA,27.0,5.2,76.0,96.0,976.0,Government,Secondary,308.0,-37.19449,145.701477
 Alexandra Secondary College,45349.0,2021,ALEXANDRA,26.0,0.8,69.6,100.0,981.0,Government,Secondary,319.0,-37.19449,145.701477
 Alexandra Secondary College,45349.0,2022,ALEXANDRA,26.0,0.0,69.2,95.0,972.0,Government,Secondary,329.0,-37.19449,145.701477
-Alexandra Secondary College,,2023,ALEXANDRA,23.0,0.6,32.5,98.0,,,,,,
+Alexandra Secondary College,45349.0,2023,ALEXANDRA,23.0,0.6,32.5,98.0,,,,,,
 Alia College,46354.0,2014,HAWTHORN EAST,27.0,3.7,73.0,91.0,1129.0,Independent,Secondary,71.0,-37.843225,145.045173
 Alia College,46354.0,2015,HAWTHORN EAST,27.0,1.2,72.0,100.0,1091.0,Independent,Secondary,88.0,-37.843225,145.045173
 Alia College,46354.0,2016,HAWTHORN EAST,27.0,4.5,78.0,89.0,1115.0,Independent,Secondary,86.0,-37.843225,145.045173
@@ -101,14 +102,14 @@ Alia College,46354.0,2019,HAWTHORN EAST,20.0,0.0,70.0,90.0,996.0,Independent,Sec
 Alia College,46354.0,2020,HAWTHORN EAST,23.0,2.6,27.8,89.0,1043.0,Independent,Secondary,68.0,-37.843225,145.045173
 Alia College,46354.0,2021,HAWTHORN EAST,24.0,0.0,25.0,83.0,1054.0,Independent,Secondary,68.0,-37.843225,145.045173
 Alia College,46354.0,2022,HAWTHORN EAST,25.0,0.0,44.4,67.0,1115.0,Independent,Secondary,91.0,-37.843225,145.045173
-Alia College,,2023,HAWTHORN EAST,24.0,,69.2,100.0,,,,,,
+Alia College,46354.0,2023,HAWTHORN EAST,24.0,,69.2,100.0,,,,,,
 Alice Miller School,52381.0,2017,MACEDON,29.0,4.3,71.0,100.0,1123.0,Independent,Secondary,289.0,-37.44664,144.531585
 Alice Miller School,52381.0,2018,MACEDON,31.0,9.6,60.0,100.0,1118.0,Independent,Secondary,336.0,-37.44664,144.531585
 Alice Miller School,52381.0,2019,MACEDON,31.0,7.2,52.6,100.0,1110.0,Independent,Secondary,357.0,-37.44664,144.531585
 Alice Miller School,52381.0,2020,MACEDON,32.0,9.3,72.7,100.0,1110.0,Independent,Secondary,369.0,-37.44664,144.531585
 Alice Miller School,52381.0,2021,MACEDON,35.0,14.2,75.0,100.0,1116.0,Independent,Combined,372.0,-37.44664,144.531585
 Alice Miller School,52381.0,2022,MACEDON,31.0,10.0,65.2,100.0,1133.0,Independent,Combined,389.0,-37.44664,144.531585
-Alice Miller School,,2023,MACEDON,34.0,10.9,71.8,97.0,,,,,,
+Alice Miller School,52381.0,2023,MACEDON,34.0,10.9,71.8,97.0,,,,,,
 Alkira Secondary College,45604.0,2014,CRANBOURNE NORTH,29.0,3.0,70.0,99.0,1002.0,Government,Secondary,973.0,-38.073313,145.310519
 Alkira Secondary College,45604.0,2015,CRANBOURNE NORTH,28.0,2.4,74.0,97.0,1009.0,Government,Secondary,1073.0,-38.073313,145.310519
 Alkira Secondary College,45604.0,2016,CRANBOURNE NORTH,27.0,1.3,70.0,96.0,1003.0,Government,Secondary,1137.0,-38.073313,145.310519
@@ -118,7 +119,7 @@ Alkira Secondary College,45604.0,2019,CRANBOURNE NORTH,28.0,3.4,74.5,100.0,1006.
 Alkira Secondary College,45604.0,2020,CRANBOURNE NORTH,30.0,3.2,85.0,98.0,1000.0,Government,Secondary,1483.0,-38.073313,145.310519
 Alkira Secondary College,45604.0,2021,CRANBOURNE NORTH,29.0,3.5,81.5,97.0,997.0,Government,Secondary,1621.0,-38.073313,145.310519
 Alkira Secondary College,45604.0,2022,CRANBOURNE NORTH,29.0,5.2,75.0,99.0,988.0,Government,Secondary,1738.0,-38.073313,145.310519
-Alkira Secondary College,,2023,CRANBOURNE NORTH,29.0,4.7,57.3,98.0,,,,,,
+Alkira Secondary College,45604.0,2023,CRANBOURNE NORTH,29.0,4.7,57.3,98.0,,,,,,
 Alphington Grammar School,46316.0,2014,ALPHINGTON,31.0,9.3,87.0,100.0,1111.0,Independent,Combined,493.0,-37.780429,145.036174
 Alphington Grammar School,46316.0,2015,ALPHINGTON,28.0,8.4,96.0,98.0,1102.0,Independent,Combined,501.0,-37.780429,145.036174
 Alphington Grammar School,46316.0,2016,ALPHINGTON,31.0,9.8,92.0,100.0,,Independent,Combined,509.0,-37.780429,145.036174
@@ -128,11 +129,11 @@ Alphington Grammar School,46316.0,2019,ALPHINGTON,32.0,14.0,98.5,100.0,1102.0,In
 Alphington Grammar School,46316.0,2020,ALPHINGTON,31.0,4.8,100.0,100.0,1102.0,Independent,Combined,514.0,-37.780429,145.036174
 Alphington Grammar School,46316.0,2021,ALPHINGTON,31.0,5.0,97.9,100.0,1127.0,Independent,Combined,497.0,-37.780429,145.036174
 Alphington Grammar School,46316.0,2022,ALPHINGTON,32.0,13.8,93.2,100.0,1140.0,Independent,Combined,519.0,-37.780429,145.036174
-Alphington Grammar School,,2023,ALPHINGTON,33.0,16.6,92.3,100.0,,,,,,
+Alphington Grammar School,46316.0,2023,ALPHINGTON,33.0,16.6,92.3,100.0,,,,,,
 Altona College,45587.0,2020,ALTONA,29.0,0.0,,,1008.0,Government,Combined,483.0,-37.86152274,144.8172644
 Altona College,45587.0,2021,ALTONA,31.0,7.7,86.7,100.0,1012.0,Government,Combined,556.0,-37.86152274,144.8172644
 Altona College,45587.0,2022,ALTONA,24.0,0.0,71.4,96.0,1017.0,Government,Combined,600.0,-37.86152274,144.8172644
-Altona College,,2023,ALTONA,28.0,1.1,60.7,100.0,,,,,,
+Altona College,45587.0,2023,ALTONA,28.0,1.1,60.7,100.0,,,,,,
 Antonine College,46112.0,2014,PASCOE VALE SOUTH,29.0,5.2,91.0,100.0,904.0,Catholic,Combined,816.0,-37.74119138,144.9427365
 Antonine College,46112.0,2015,PASCOE VALE SOUTH,27.0,3.1,100.0,100.0,944.0,Catholic,Combined,791.0,-37.74119138,144.9427365
 Antonine College,46112.0,2016,PASCOE VALE SOUTH,27.0,4.4,97.0,100.0,949.0,Catholic,Combined,805.0,-37.74119138,144.9427365
@@ -142,7 +143,7 @@ Antonine College,46112.0,2019,PASCOE VALE SOUTH,27.0,1.9,80.0,98.0,969.0,Catholi
 Antonine College,46112.0,2020,PASCOE VALE SOUTH,27.0,0.6,93.8,100.0,974.0,Catholic,Combined,805.0,-37.74119138,144.9427365
 Antonine College,46112.0,2021,PASCOE VALE SOUTH,28.0,5.2,93.5,100.0,976.0,Catholic,Combined,821.0,-37.741099,144.942754
 Antonine College,46112.0,2022,PASCOE VALE SOUTH,25.0,4.6,83.6,100.0,976.0,Catholic,Combined,821.0,-37.741099,144.942754
-Antonine College,,2023,PASCOE VALE SOUTH,26.0,2.9,87.3,98.0,,,,,,
+Antonine College,46112.0,2023,PASCOE VALE SOUTH,26.0,2.9,87.3,98.0,,,,,,
 Apollo Bay P-12 College,45292.0,2014,APOLLO BAY,31.0,6.5,89.0,89.0,1035.0,Government,Combined,241.0,-38.753524,143.660507
 Apollo Bay P-12 College,45292.0,2015,APOLLO BAY,29.0,6.4,100.0,100.0,1024.0,Government,Combined,242.0,-38.753524,143.660507
 Apollo Bay P-12 College,45292.0,2016,APOLLO BAY,32.0,6.3,71.0,93.0,1026.0,Government,Combined,262.0,-38.753524,143.660507
@@ -152,7 +153,7 @@ Apollo Bay P-12 College,45292.0,2019,APOLLO BAY,28.0,1.6,100.0,100.0,1038.0,Gove
 Apollo Bay P-12 College,45292.0,2020,APOLLO BAY,29.0,1.5,75.0,100.0,1041.0,Government,Combined,290.0,-38.753524,143.660507
 Apollo Bay P-12 College,45292.0,2021,APOLLO BAY,33.0,5.4,69.2,100.0,1044.0,Government,Combined,298.0,-38.753524,143.660507
 Apollo Bay P-12 College,45292.0,2022,APOLLO BAY,30.0,2.5,57.1,95.0,1043.0,Government,Combined,305.0,-38.753524,143.660507
-Apollo Bay P-12 College,,2023,APOLLO BAY,31.0,11.8,58.8,100.0,,,,,,
+Apollo Bay P-12 College,45292.0,2023,APOLLO BAY,31.0,11.8,58.8,100.0,,,,,,
 Aquinas College,45947.0,2014,RINGWOOD,31.0,6.7,89.0,100.0,1057.0,Catholic,Secondary,1637.0,-37.82303115,145.23518332
 Aquinas College,45947.0,2015,RINGWOOD,31.0,9.5,92.0,100.0,1059.0,Catholic,Secondary,1636.0,-37.82303115,145.23518332
 Aquinas College,45947.0,2016,RINGWOOD,31.0,6.0,85.0,100.0,1055.0,Catholic,Secondary,1653.0,-37.82303115,145.23518332
@@ -162,7 +163,7 @@ Aquinas College,45947.0,2019,RINGWOOD,30.0,5.6,88.4,100.0,1065.0,Catholic,Second
 Aquinas College,45947.0,2020,RINGWOOD,30.0,6.3,91.0,100.0,1070.0,Catholic,Secondary,1679.0,-37.82303115,145.23518332
 Aquinas College,45947.0,2021,RINGWOOD,31.0,7.5,85.2,99.0,1073.0,Catholic,Secondary,1684.0,-37.82303115,145.23518332
 Aquinas College,45947.0,2022,RINGWOOD,30.0,7.9,85.8,99.0,1077.0,Catholic,Secondary,1662.0,-37.82303115,145.23518332
-Aquinas College,,2023,RINGWOOD,31.0,6.4,80.5,99.0,,,,,,
+Aquinas College,45947.0,2023,RINGWOOD,31.0,6.4,80.5,99.0,,,,,,
 Ararat Secondary College,45523.0,2014,ARARAT,25.0,0.0,56.0,97.0,937.0,Government,Secondary,325.0,-37.28599961,142.92196149
 Ararat Secondary College,45523.0,2015,ARARAT,26.0,0.0,77.0,100.0,928.0,Government,Secondary,285.0,-37.28599961,142.92196149
 Ararat Secondary College,45523.0,2016,ARARAT,25.0,0.0,81.0,95.0,929.0,Government,Secondary,270.0,-37.28599961,142.92196149
@@ -172,10 +173,10 @@ Ararat Secondary College,45523.0,2019,ARARAT,24.0,0.0,54.5,100.0,944.0,Governmen
 Ararat Secondary College,45523.0,2020,ARARAT,23.0,0.0,14.3,93.0,945.0,Government,Secondary,295.0,-37.28599961,142.92196149
 Ararat Secondary College,45523.0,2021,ARARAT,25.0,2.7,52.6,89.0,947.0,Government,Secondary,287.0,-37.28599961,142.92196149
 Ararat Secondary College,45523.0,2022,ARARAT,25.0,3.0,62.5,100.0,941.0,Government,Secondary,292.0,-37.28599961,142.92196149
-Ararat Secondary College,,2023,ARARAT,27.0,,38.9,94.0,,,,,,
-Armstrong Creek School,45058.0,2021,ARMSTRONG CREEK,,,,,994.0,Government,Special,589.0,-37.884042,144.687587
-Armstrong Creek School,45058.0,2022,ARMSTRONG CREEK,,,,,987.0,Government,Special,643.0,-37.884042,144.687587
-Armstrong Creek School,,2023,ARMSTRONG CREEK,,,,,,,,,,
+Ararat Secondary College,45523.0,2023,ARARAT,27.0,,38.9,94.0,,,,,,
+Armstrong Creek School,52589.0,2021,ARMSTRONG CREEK,,,,,,,,,,
+Armstrong Creek School,52589.0,2022,ARMSTRONG CREEK,,,,,,,,,,
+Armstrong Creek School,52589.0,2023,ARMSTRONG CREEK,,,,,,,,,,
 Ashwood High School,45518.0,2016,ASHWOOD,28.0,4.7,88.0,100.0,1036.0,Government,Secondary,355.0,-37.86409815,145.10340983
 Ashwood High School,45518.0,2017,ASHWOOD,29.0,5.0,95.0,98.0,1034.0,Government,Secondary,378.0,-37.86409815,145.10340983
 Ashwood High School,45518.0,2018,ASHWOOD,29.0,3.9,94.3,100.0,1054.0,Government,Secondary,414.0,-37.86409815,145.10340983
@@ -183,9 +184,9 @@ Ashwood High School,45518.0,2019,ASHWOOD,30.0,4.3,91.9,97.0,1065.0,Government,Se
 Ashwood High School,45518.0,2020,ASHWOOD,28.0,2.1,92.9,100.0,1073.0,Government,Secondary,568.0,-37.86409815,145.10340983
 Ashwood High School,45518.0,2021,ASHWOOD,33.0,10.8,95.5,100.0,1074.0,Government,Secondary,635.0,-37.86409815,145.10340983
 Ashwood High School,45518.0,2022,ASHWOOD,30.0,2.6,86.7,100.0,1087.0,Government,Secondary,715.0,-37.86409815,145.10340983
-Ashwood High School,,2023,ASHWOOD,32.0,10.1,78.5,98.0,,,,,,
-Ashwood Secondary College,45443.0,2014,ASHWOOD,29.0,4.6,93.0,100.0,1024.0,Government,Secondary,1083.0,-37.800473,145.238246
-Ashwood Secondary College,45443.0,2015,ASHWOOD,29.0,5.2,93.0,95.0,1025.0,Government,Secondary,1088.0,-37.800473,145.238246
+Ashwood High School,45518.0,2023,ASHWOOD,32.0,10.1,78.5,98.0,,,,,,
+Ashwood Secondary College,45518.0,2014,ASHWOOD,29.0,4.6,93.0,100.0,1027.0,Government,Secondary,358.0,-37.86409815,145.10340983
+Ashwood Secondary College,45518.0,2015,ASHWOOD,29.0,5.2,93.0,95.0,1033.0,Government,Secondary,341.0,-37.86409815,145.10340983
 Assumption College,45647.0,2014,KILMORE,30.0,4.3,88.0,100.0,1054.0,Catholic,Secondary,1195.0,-37.301013,144.947629
 Assumption College,45647.0,2015,KILMORE,30.0,4.6,83.0,100.0,1051.0,Catholic,Secondary,1207.0,-37.301013,144.947629
 Assumption College,45647.0,2016,KILMORE,29.0,3.4,82.0,100.0,1042.0,Catholic,Secondary,1211.0,-37.301013,144.947629
@@ -195,7 +196,7 @@ Assumption College,45647.0,2019,KILMORE,28.0,3.5,72.0,100.0,1039.0,Catholic,Seco
 Assumption College,45647.0,2020,KILMORE,28.0,4.0,69.3,99.0,1040.0,Catholic,Secondary,1236.0,-37.301013,144.947629
 Assumption College,45647.0,2021,KILMORE,28.0,4.0,75.2,100.0,1040.0,Catholic,Secondary,1263.0,-37.301013,144.947629
 Assumption College,45647.0,2022,KILMORE,27.0,1.9,76.2,100.0,1046.0,Catholic,Secondary,1384.0,-37.301013,144.947629
-Assumption College,,2023,KILMORE,27.0,2.1,57.9,99.0,,,,,,
+Assumption College,45647.0,2023,KILMORE,27.0,2.1,57.9,99.0,,,,,,
 Auburn High School,50684.0,2014,HAWTHORN EAST,24.0,2.0,82.0,87.0,1007.0,Government,Secondary,296.0,-37.839849,145.044628
 Auburn High School,50684.0,2015,HAWTHORN EAST,27.0,3.1,83.0,97.0,1059.0,Government,Secondary,308.0,-37.839849,145.044628
 Auburn High School,50684.0,2016,HAWTHORN EAST,27.0,3.0,79.0,89.0,1071.0,Government,Secondary,369.0,-37.839849,145.044628
@@ -205,9 +206,9 @@ Auburn High School,50684.0,2019,HAWTHORN EAST,30.0,8.8,88.9,92.0,1124.0,Governme
 Auburn High School,50684.0,2020,HAWTHORN EAST,31.0,8.7,79.6,98.0,1151.0,Government,Secondary,562.0,-37.839849,145.044628
 Auburn High School,50684.0,2021,HAWTHORN EAST,31.0,10.6,94.3,100.0,1153.0,Government,Secondary,616.0,-37.83968,145.04544
 Auburn High School,50684.0,2022,HAWTHORN EAST,31.0,11.0,95.5,97.0,1151.0,Government,Secondary,675.0,-37.83968,145.04544
-Auburn High School,,2023,HAWTHORN EAST,31.0,7.5,92.8,98.0,,,,,,
-Australian Internatl Academy,,2014,COBURG,27.0,0.0,94.0,97.0,,,,,,
-Australian Internatl Academy,,2015,COBURG,28.0,2.4,100.0,100.0,,,,,,
+Auburn High School,50684.0,2023,HAWTHORN EAST,31.0,7.5,92.8,98.0,,,,,,
+Australian Internatl Academy,46297.0,2014,COBURG,27.0,0.0,94.0,97.0,,,,,,
+Australian Internatl Academy,46297.0,2015,COBURG,28.0,2.4,100.0,100.0,,,,,,
 Australian Internatl Academy,46297.0,2016,COBURG,27.0,0.6,100.0,100.0,1055.0,Independent,Combined,1265.0,-37.736331,144.966123
 Australian Internatl Academy,46297.0,2017,COBURG,30.0,5.3,98.0,100.0,1053.0,Independent,Combined,1285.0,-37.736331,144.966123
 Australian Internatl Academy,46297.0,2018,COBURG,24.0,0.0,97.1,97.0,1050.0,Independent,Combined,1353.0,-37.736331,144.966123
@@ -218,8 +219,8 @@ Australian Internatl Academy,46297.0,2021,COBURG,24.0,0.6,95.2,97.0,1061.0,Indep
 Australian Internatl Academy,46297.0,2021,CAROLINE SPRINGS,26.0,2.6,100.0,100.0,1061.0,Independent,Combined,1584.0,-37.736331,144.966123
 Australian Internatl Academy,46297.0,2022,COBURG,23.0,0.0,86.6,100.0,1063.0,Independent,Combined,1779.0,-37.736331,144.966123
 Australian Internatl Academy,46297.0,2022,CAROLINE SPRINGS,24.0,1.5,100.0,100.0,1063.0,Independent,Combined,1779.0,-37.736331,144.966123
-Australian Internatl Academy,,2023,COBURG,24.0,0.9,90.9,100.0,,,,,,
-Australian Internatl Academy,,2023,CAROLINE SPRINGS,27.0,1.6,100.0,100.0,,,,,,
+Australian Internatl Academy,46297.0,2023,COBURG,24.0,0.9,90.9,100.0,,,,,,
+Australian Internatl Academy,46297.0,2023,CAROLINE SPRINGS,27.0,1.6,100.0,100.0,,,,,,
 Ave Maria College,45958.0,2014,ABERFELDIE,32.0,9.3,97.0,100.0,1042.0,Catholic,Secondary,786.0,-37.756618,144.897964
 Ave Maria College,45958.0,2015,ABERFELDIE,32.0,6.8,95.0,99.0,1067.0,Catholic,Secondary,795.0,-37.756618,144.897964
 Ave Maria College,45958.0,2016,ABERFELDIE,31.0,5.4,96.0,100.0,1060.0,Catholic,Secondary,799.0,-37.756618,144.897964
@@ -229,7 +230,7 @@ Ave Maria College,45958.0,2019,ABERFELDIE,33.0,9.5,86.6,100.0,1066.0,Catholic,Se
 Ave Maria College,45958.0,2020,ABERFELDIE,32.0,9.1,96.0,100.0,1068.0,Catholic,Secondary,828.0,-37.756618,144.897964
 Ave Maria College,45958.0,2021,ABERFELDIE,31.0,5.8,95.9,100.0,1066.0,Catholic,Secondary,829.0,-37.756618,144.897964
 Ave Maria College,45958.0,2022,ABERFELDIE,30.0,6.2,92.4,100.0,1069.0,Catholic,Secondary,815.0,-37.756618,144.897964
-Ave Maria College,,2023,ABERFELDIE,31.0,7.2,95.8,100.0,,,,,,
+Ave Maria College,45958.0,2023,ABERFELDIE,31.0,7.2,95.8,100.0,,,,,,
 Avila College,45976.0,2014,MOUNT WAVERLEY,32.0,10.2,97.0,100.0,1081.0,Catholic,Secondary,1121.0,-37.874671,145.133255
 Avila College,45976.0,2015,MOUNT WAVERLEY,33.0,12.1,97.0,100.0,1089.0,Catholic,Secondary,1104.0,-37.874671,145.133255
 Avila College,45976.0,2016,MOUNT WAVERLEY,32.0,10.0,97.0,100.0,1085.0,Catholic,Secondary,1098.0,-37.874671,145.133255
@@ -239,7 +240,7 @@ Avila College,45976.0,2019,MOUNT WAVERLEY,32.0,8.7,99.3,100.0,1095.0,Catholic,Se
 Avila College,45976.0,2020,MOUNT WAVERLEY,31.0,7.1,98.2,100.0,1100.0,Catholic,Secondary,1094.0,-37.874671,145.133255
 Avila College,45976.0,2021,MOUNT WAVERLEY,32.0,7.2,98.0,100.0,1103.0,Catholic,Secondary,1106.0,-37.874671,145.133255
 Avila College,45976.0,2022,MOUNT WAVERLEY,31.0,8.4,98.0,100.0,1108.0,Catholic,Secondary,1071.0,-37.874671,145.133255
-Avila College,,2023,MOUNT WAVERLEY,31.0,6.8,92.6,99.0,,,,,,
+Avila College,45976.0,2023,MOUNT WAVERLEY,31.0,6.8,92.6,99.0,,,,,,
 Bacchus Marsh College,45525.0,2014,BACCHUS MARSH,26.0,0.6,74.0,96.0,950.0,Government,Secondary,798.0,-37.68562875,144.43305835
 Bacchus Marsh College,45525.0,2015,BACCHUS MARSH,25.0,1.0,69.0,96.0,960.0,Government,Secondary,763.0,-37.68562875,144.43305835
 Bacchus Marsh College,45525.0,2016,BACCHUS MARSH,26.0,0.8,60.0,96.0,954.0,Government,Secondary,776.0,-37.68562875,144.43305835
@@ -249,7 +250,7 @@ Bacchus Marsh College,45525.0,2019,BACCHUS MARSH,26.0,2.0,73.5,93.0,974.0,Govern
 Bacchus Marsh College,45525.0,2020,BACCHUS MARSH,24.0,0.8,66.7,88.0,971.0,Government,Secondary,942.0,-37.68562875,144.43305835
 Bacchus Marsh College,45525.0,2021,BACCHUS MARSH,25.0,2.4,53.6,100.0,975.0,Government,Secondary,977.0,-37.68562875,144.43305835
 Bacchus Marsh College,45525.0,2022,BACCHUS MARSH,24.0,1.7,56.4,84.0,966.0,Government,Secondary,984.0,-37.68562875,144.43305835
-Bacchus Marsh College,,2023,BACCHUS MARSH,25.0,0.4,53.4,93.0,,,,,,
+Bacchus Marsh College,45525.0,2023,BACCHUS MARSH,25.0,0.4,53.4,93.0,,,,,,
 Bacchus Marsh Grammar,46314.0,2014,BACCHUS MARSH,32.0,8.8,98.0,100.0,1058.0,Independent,Combined,1776.0,-37.6907285,144.43130808
 Bacchus Marsh Grammar,46314.0,2015,BACCHUS MARSH,31.0,9.3,97.0,99.0,1066.0,Independent,Combined,1856.0,-37.6907285,144.43130808
 Bacchus Marsh Grammar,46314.0,2016,BACCHUS MARSH,31.0,8.9,95.0,100.0,1065.0,Independent,Combined,1875.0,-37.6907285,144.43130808
@@ -259,7 +260,7 @@ Bacchus Marsh Grammar,46314.0,2019,BACCHUS MARSH,31.0,9.2,95.8,100.0,1096.0,Inde
 Bacchus Marsh Grammar,46314.0,2020,BACCHUS MARSH,31.0,10.1,95.3,99.0,1096.0,Independent,Combined,2690.0,-37.690308,144.431829
 Bacchus Marsh Grammar,46314.0,2021,BACCHUS MARSH,31.0,9.1,87.5,100.0,1105.0,Independent,Combined,3097.0,-37.690308,144.431829
 Bacchus Marsh Grammar,46314.0,2022,BACCHUS MARSH,31.0,9.8,92.5,99.0,1107.0,Independent,Combined,3262.0,-37.690308,144.431829
-Bacchus Marsh Grammar,,2023,BACCHUS MARSH,32.0,11.4,92.5,100.0,,,,,,
+Bacchus Marsh Grammar,46314.0,2023,BACCHUS MARSH,32.0,11.4,92.5,100.0,,,,,,
 Baimbridge College,45552.0,2014,HAMILTON,26.0,1.8,59.0,92.0,954.0,Government,Combined,487.0,-37.733311,142.014634
 Baimbridge College,45552.0,2015,HAMILTON,24.0,2.4,53.0,93.0,949.0,Government,Combined,494.0,-37.733311,142.014634
 Baimbridge College,45552.0,2016,HAMILTON,25.0,2.0,75.0,92.0,961.0,Government,Combined,430.0,-37.733311,142.014634
@@ -269,7 +270,7 @@ Baimbridge College,45552.0,2019,HAMILTON,22.0,0.5,56.8,100.0,962.0,Government,Se
 Baimbridge College,45552.0,2020,HAMILTON,24.0,0.7,39.5,84.0,956.0,Government,Secondary,418.0,-37.733311,142.014634
 Baimbridge College,45552.0,2021,HAMILTON,24.0,2.1,51.5,97.0,958.0,Government,Secondary,392.0,-37.733311,142.014634
 Baimbridge College,45552.0,2022,HAMILTON,25.0,5.0,66.7,94.0,945.0,Government,Secondary,354.0,-37.733311,142.014634
-Baimbridge College,,2023,HAMILTON,24.0,,51.9,96.0,,,,,,
+Baimbridge College,45552.0,2023,HAMILTON,24.0,,51.9,96.0,,,,,,
 Bairnsdale Secondary College,45489.0,2014,BAIRNSDALE,26.0,0.6,68.0,84.0,930.0,Government,Secondary,975.0,-37.83202616,147.62203757
 Bairnsdale Secondary College,45489.0,2015,BAIRNSDALE,24.0,0.9,52.0,91.0,939.0,Government,Secondary,1007.0,-37.83202616,147.62203757
 Bairnsdale Secondary College,45489.0,2016,BAIRNSDALE,26.0,2.1,73.0,95.0,947.0,Government,Secondary,1069.0,-37.83202616,147.62203757
@@ -279,7 +280,7 @@ Bairnsdale Secondary College,45489.0,2019,BAIRNSDALE,23.0,0.5,57.6,91.0,941.0,Go
 Bairnsdale Secondary College,45489.0,2020,BAIRNSDALE,25.0,1.0,73.5,99.0,945.0,Government,Secondary,1116.0,-37.83202616,147.62203757
 Bairnsdale Secondary College,45489.0,2021,BAIRNSDALE,26.0,2.8,61.2,98.0,950.0,Government,Secondary,1140.0,-37.83202616,147.62203757
 Bairnsdale Secondary College,45489.0,2022,BAIRNSDALE,26.0,2.1,65.9,95.0,943.0,Government,Secondary,1125.0,-37.83202616,147.62203757
-Bairnsdale Secondary College,,2023,BAIRNSDALE,26.0,0.8,38.1,99.0,,,,,,
+Bairnsdale Secondary College,45489.0,2023,BAIRNSDALE,26.0,0.8,38.1,99.0,,,,,,
 Balcombe Grammar School,46383.0,2014,MOUNT MARTHA,29.0,5.1,98.0,100.0,1087.0,Independent,Combined,767.0,-38.2738,145.033
 Balcombe Grammar School,46383.0,2015,MOUNT MARTHA,30.0,5.3,85.0,100.0,1083.0,Independent,Combined,779.0,-38.2738,145.033
 Balcombe Grammar School,46383.0,2016,MOUNT MARTHA,31.0,10.2,88.0,100.0,1094.0,Independent,Combined,800.0,-38.2738,145.033
@@ -289,7 +290,7 @@ Balcombe Grammar School,46383.0,2019,MOUNT MARTHA,31.0,7.9,95.7,100.0,1094.0,Ind
 Balcombe Grammar School,46383.0,2020,MOUNT MARTHA,30.0,3.1,90.7,100.0,1094.0,Independent,Combined,904.0,-38.2738,145.033
 Balcombe Grammar School,46383.0,2021,MOUNT MARTHA,32.0,8.4,84.6,100.0,1098.0,Independent,Combined,918.0,-38.2738,145.033
 Balcombe Grammar School,46383.0,2022,MOUNT MARTHA,32.0,11.3,69.6,100.0,1098.0,Independent,Combined,934.0,-38.2738,145.033
-Balcombe Grammar School,,2023,MOUNT MARTHA,30.0,5.3,78.2,100.0,,,,,,
+Balcombe Grammar School,46383.0,2023,MOUNT MARTHA,30.0,5.3,78.2,100.0,,,,,,
 Ballarat Christian College,46384.0,2014,SEBASTOPOL,28.0,0.0,63.0,100.0,1034.0,Independent,Combined,305.0,-37.59333224,143.84324898
 Ballarat Christian College,46384.0,2015,SEBASTOPOL,30.0,6.1,74.0,100.0,1043.0,Independent,Combined,314.0,-37.59333224,143.84324898
 Ballarat Christian College,46384.0,2016,SEBASTOPOL,28.0,0.0,40.0,100.0,1043.0,Independent,Combined,325.0,-37.59333224,143.84324898
@@ -299,7 +300,7 @@ Ballarat Christian College,46384.0,2019,SEBASTOPOL,29.0,23.1,58.3,100.0,1039.0,I
 Ballarat Christian College,46384.0,2020,SEBASTOPOL,29.0,2.4,69.2,100.0,1039.0,Independent,Combined,294.0,-37.59333224,143.84324898
 Ballarat Christian College,46384.0,2021,SEBASTOPOL,22.0,0.0,60.0,100.0,1044.0,Independent,Combined,304.0,-37.59333224,143.84324898
 Ballarat Christian College,46384.0,2022,SEBASTOPOL,25.0,0.0,43.8,94.0,1042.0,Independent,Combined,300.0,-37.59333224,143.84324898
-Ballarat Christian College,,2023,SEBASTOPOL,29.0,,58.3,100.0,,,,,,
+Ballarat Christian College,46384.0,2023,SEBASTOPOL,29.0,,58.3,100.0,,,,,,
 Ballarat Clarendon College,46146.0,2014,BALLARAT,37.0,34.7,99.0,100.0,1155.0,Independent,Combined,1238.0,-37.55964761,143.8336504
 Ballarat Clarendon College,46146.0,2015,BALLARAT,37.0,33.0,98.0,100.0,1159.0,Independent,Combined,1270.0,-37.55964761,143.8336504
 Ballarat Clarendon College,46146.0,2016,BALLARAT,37.0,30.0,97.0,100.0,1163.0,Independent,Combined,1322.0,-37.55964761,143.8336504
@@ -309,7 +310,7 @@ Ballarat Clarendon College,46146.0,2019,BALLARAT,39.0,45.0,95.7,99.0,1160.0,Inde
 Ballarat Clarendon College,46146.0,2020,BALLARAT,38.0,38.4,94.6,100.0,1159.0,Independent,Combined,1515.0,-37.55964761,143.8336504
 Ballarat Clarendon College,46146.0,2021,BALLARAT,37.0,32.5,93.2,100.0,1161.0,Independent,Combined,1618.0,-37.55964761,143.8336504
 Ballarat Clarendon College,46146.0,2022,BALLARAT,38.0,35.5,91.3,100.0,1165.0,Independent,Combined,1701.0,-37.55964761,143.8336504
-Ballarat Clarendon College,,2023,BALLARAT,39.0,45.8,94.2,100.0,,,,,,
+Ballarat Clarendon College,46146.0,2023,BALLARAT,39.0,45.8,94.2,100.0,,,,,,
 Ballarat Grammar,46166.0,2014,WENDOUREE,34.0,15.9,92.0,100.0,1125.0,Independent,Combined,1322.0,-37.539237,143.83083
 Ballarat Grammar,46166.0,2015,WENDOUREE,33.0,12.7,93.0,100.0,1135.0,Independent,Combined,1343.0,-37.539237,143.83083
 Ballarat Grammar,46166.0,2016,WENDOUREE,32.0,9.4,86.0,100.0,1130.0,Independent,Combined,1386.0,-37.539237,143.83083
@@ -319,7 +320,7 @@ Ballarat Grammar,46166.0,2019,WENDOUREE,32.0,13.9,90.0,100.0,1129.0,Independent,
 Ballarat Grammar,46166.0,2020,WENDOUREE,32.0,10.6,86.0,100.0,1129.0,Independent,Combined,1603.0,-37.539237,143.83083
 Ballarat Grammar,46166.0,2021,WENDOUREE,32.0,13.3,91.0,100.0,1121.0,Independent,Combined,1653.0,-37.539237,143.83083
 Ballarat Grammar,46166.0,2022,WENDOUREE,31.0,9.2,82.9,100.0,1120.0,Independent,Combined,1735.0,-37.539237,143.83083
-Ballarat Grammar,,2023,WENDOUREE,32.0,9.4,81.2,100.0,,,,,,
+Ballarat Grammar,46166.0,2023,WENDOUREE,32.0,9.4,81.2,100.0,,,,,,
 Ballarat High School,45350.0,2014,BALLARAT,27.0,3.0,70.0,92.0,1000.0,Government,Secondary,1408.0,-37.554234,143.817713
 Ballarat High School,45350.0,2015,BALLARAT,27.0,2.5,69.0,98.0,1001.0,Government,Secondary,1400.0,-37.554234,143.817713
 Ballarat High School,45350.0,2016,BALLARAT,28.0,3.6,64.0,97.0,1000.0,Government,Secondary,1394.0,-37.547025,143.801504
@@ -329,14 +330,14 @@ Ballarat High School,45350.0,2019,BALLARAT,29.0,3.8,58.0,92.0,1004.0,Government,
 Ballarat High School,45350.0,2020,BALLARAT,28.0,3.9,66.7,98.0,1007.0,Government,Secondary,1417.0,-37.554234,143.817713
 Ballarat High School,45350.0,2021,BALLARAT,28.0,1.8,60.7,94.0,1009.0,Government,Secondary,1464.0,-37.554234,143.817713
 Ballarat High School,45350.0,2022,BALLARAT,29.0,5.8,62.0,98.0,1012.0,Government,Secondary,1450.0,-37.554234,143.817713
-Ballarat High School,,2023,BALLARAT,29.0,5.3,53.4,95.0,,,,,,
+Ballarat High School,45350.0,2023,BALLARAT,29.0,5.3,53.4,95.0,,,,,,
 Ballarat SC - Mount Rowan,45565.0,2018,WENDOUREE,26.0,0.0,55.6,89.0,931.0,Government,Secondary,635.0,-37.51987872,143.83419003
-Ballarat SC - Woodmans Hill,,2018,BALLARAT EAST,24.0,1.3,52.4,95.0,,,,,,
-Ballarat Secondary College,45532.0,2014,BALLARAT,22.0,0.0,52.0,92.0,960.0,Government,Secondary,541.0,-37.41944661,144.98036163
-Ballarat Secondary College,45532.0,2015,BALLARAT,24.0,0.7,59.0,94.0,964.0,Government,Secondary,581.0,-37.41944661,144.98036163
-Ballarat Secondary College,45532.0,2016,BALLARAT,27.0,2.2,65.0,88.0,968.0,Government,Secondary,604.0,-37.41944661,144.98036163
-Ballarat Secondary College - Mount Rowan Campus,45472.0,2017,WENDOUREE,23.0,0.0,81.0,97.0,983.0,Government,Secondary,406.0,-36.220441,147.172667
-Ballarat Secondary College - Woodmans Hill Campus,45472.0,2017,BALLARAT EAST,28.0,0.0,55.0,94.0,983.0,Government,Secondary,406.0,-36.220441,147.172667
+Ballarat SC - Woodmans Hill,52702.0,2018,BALLARAT EAST,24.0,1.3,52.4,95.0,,,,,,
+Ballarat Secondary College,,2014,BALLARAT,22.0,0.0,52.0,92.0,,,,,,
+Ballarat Secondary College,,2015,BALLARAT,24.0,0.7,59.0,94.0,,,,,,
+Ballarat Secondary College,,2016,BALLARAT,27.0,2.2,65.0,88.0,,,,,,
+Ballarat Secondary College - Mount Rowan Campus,45565.0,2017,WENDOUREE,23.0,0.0,81.0,97.0,916.0,Government,Secondary,630.0,-37.51987872,143.83419003
+Ballarat Secondary College - Woodmans Hill Campus,52702.0,2017,BALLARAT EAST,28.0,0.0,55.0,94.0,,,,,,
 Balmoral K-12 Comm College,45602.0,2014,BALMORAL,31.0,3.4,67.0,100.0,1033.0,Government,Combined,158.0,-37.240557,141.82737163
 Balmoral K-12 Comm College,45602.0,2015,BALMORAL,28.0,0.0,57.0,100.0,1012.0,Government,Combined,162.0,-37.240557,141.82737163
 Balmoral K-12 Comm College,45602.0,2016,BALMORAL,30.0,0.0,100.0,100.0,1017.0,Government,Combined,144.0,-37.240557,141.82737163
@@ -345,7 +346,7 @@ Balmoral K-12 Comm College,45602.0,2019,BALMORAL,,,0.0,100.0,1012.0,Government,C
 Balmoral K-12 Comm College,45602.0,2020,BALMORAL,,,0.0,100.0,1009.0,Government,Combined,104.0,-37.240557,141.82737163
 Balmoral K-12 Comm College,45602.0,2021,BALMORAL,,,0.0,100.0,1012.0,Government,Combined,97.0,-37.240557,141.82737163
 Balmoral K-12 Comm College,45602.0,2022,BALMORAL,,,,,1006.0,Government,Combined,82.0,-37.240557,141.82737163
-Balmoral K-12 Comm College,,2023,BALMORAL,,,100.0,100.0,,,,,,
+Balmoral K-12 Comm College,45602.0,2023,BALMORAL,,,100.0,100.0,,,,,,
 Balwyn High School,45351.0,2014,BALWYN NORTH,34.0,20.1,93.0,100.0,1138.0,Government,Secondary,2059.0,-37.79785922,145.07677235
 Balwyn High School,45351.0,2015,BALWYN NORTH,34.0,21.6,95.0,100.0,1138.0,Government,Secondary,2085.0,-37.79785922,145.07677235
 Balwyn High School,45351.0,2016,BALWYN NORTH,34.0,22.0,93.0,100.0,1138.0,Government,Secondary,2085.0,-37.79785922,145.07677235
@@ -355,12 +356,12 @@ Balwyn High School,45351.0,2019,BALWYN NORTH,34.0,18.6,92.7,100.0,1130.0,Governm
 Balwyn High School,45351.0,2020,BALWYN NORTH,33.0,17.5,92.6,98.0,1131.0,Government,Secondary,2207.0,-37.79785922,145.07677235
 Balwyn High School,45351.0,2021,BALWYN NORTH,32.0,16.9,91.4,99.0,1130.0,Government,Secondary,2182.0,-37.79785922,145.07677235
 Balwyn High School,45351.0,2022,BALWYN NORTH,32.0,16.2,91.7,97.0,1142.0,Government,Secondary,2183.0,-37.79785922,145.07677235
-Balwyn High School,,2023,BALWYN NORTH,32.0,16.5,92.2,99.0,,,,,,
+Balwyn High School,45351.0,2023,BALWYN NORTH,32.0,16.5,92.2,99.0,,,,,,
 Bannockburn P-12 College,44168.0,2021,BANNOCKBURN,30.0,0.0,,,991.0,Government,Combined,926.0,-38.047092,144.16951
 Bannockburn P-12 College,44168.0,2022,BANNOCKBURN,25.0,0.0,76.2,100.0,987.0,Government,Combined,929.0,-38.047092,144.16951
-Bannockburn P-12 College,,2023,BANNOCKBURN,24.0,0.9,42.3,92.0,,,,,,
+Bannockburn P-12 College,44168.0,2023,BANNOCKBURN,24.0,0.9,42.3,92.0,,,,,,
 Bass Coast College,40597.0,2022,WONTHAGGI,27.0,3.1,66.4,99.0,990.0,Government,Secondary,1511.0,-38.609807,145.597177
-Bass Coast College,,2023,WONTHAGGI,28.0,3.0,57.2,98.0,,,,,,
+Bass Coast College,40597.0,2023,WONTHAGGI,28.0,3.0,57.2,98.0,,,,,,
 Bayside Christian College,46271.0,2014,LANGWARRIN SOUTH,29.0,3.9,87.0,100.0,1051.0,Independent,Combined,532.0,-38.178632,145.16302
 Bayside Christian College,46271.0,2015,LANGWARRIN SOUTH,30.0,4.2,76.0,100.0,1048.0,Independent,Combined,527.0,-38.178632,145.16302
 Bayside Christian College,46271.0,2016,LANGWARRIN SOUTH,30.0,7.3,94.0,100.0,1045.0,Independent,Combined,518.0,-38.178632,145.16302
@@ -370,7 +371,7 @@ Bayside Christian College,46271.0,2019,LANGWARRIN SOUTH,29.0,3.8,96.8,97.0,1075.
 Bayside Christian College,46271.0,2020,LANGWARRIN SOUTH,30.0,5.0,96.3,96.0,1075.0,Independent,Combined,579.0,-38.178632,145.16302
 Bayside Christian College,46271.0,2021,LANGWARRIN SOUTH,30.0,6.0,79.2,100.0,1078.0,Independent,Combined,564.0,-38.178632,145.16302
 Bayside Christian College,46271.0,2022,LANGWARRIN SOUTH,30.0,9.9,95.7,100.0,1076.0,Independent,Combined,530.0,-38.178632,145.16302
-Bayside Christian College,,2023,LANGWARRIN SOUTH,28.0,7.2,61.3,100.0,,,,,,
+Bayside Christian College,46271.0,2023,LANGWARRIN SOUTH,28.0,7.2,61.3,100.0,,,,,,
 Bayside P-12 College,45538.0,2014,NEWPORT,28.0,3.1,62.0,93.0,956.0,Government,Combined,995.0,-37.85770007,144.88521383
 Bayside P-12 College,45538.0,2015,NEWPORT,27.0,2.8,74.0,99.0,970.0,Government,Combined,953.0,-37.85770007,144.88521383
 Bayside P-12 College,45538.0,2016,NEWPORT,30.0,3.9,68.0,96.0,974.0,Government,Combined,917.0,-37.85770007,144.88521383
@@ -380,7 +381,7 @@ Bayside P-12 College,45538.0,2019,NEWPORT,28.0,2.7,78.3,100.0,1007.0,Government,
 Bayside P-12 College,45538.0,2020,NEWPORT,29.0,4.0,81.6,98.0,1009.0,Government,Combined,1055.0,-37.85770007,144.88521383
 Bayside P-12 College,45538.0,2021,NEWPORT,30.0,5.0,75.0,90.0,1010.0,Government,Combined,1009.0,-37.85770007,144.88521383
 Bayside P-12 College,45538.0,2022,NEWPORT,29.0,3.1,67.6,99.0,1002.0,Government,Combined,1026.0,-37.85770007,144.88521383
-Bayside P-12 College,,2023,NEWPORT,28.0,2.0,54.3,96.0,,,,,,
+Bayside P-12 College,45538.0,2023,NEWPORT,28.0,2.0,54.3,96.0,,,,,,
 Bayswater Secondary College,45352.0,2014,BAYSWATER,22.0,0.0,43.0,93.0,956.0,Government,Secondary,210.0,-37.83903,145.261998
 Bayswater Secondary College,45352.0,2015,BAYSWATER,25.0,0.0,56.0,94.0,947.0,Government,Secondary,212.0,-37.83903,145.261998
 Bayswater Secondary College,45352.0,2016,BAYSWATER,21.0,1.2,56.0,94.0,941.0,Government,Secondary,178.0,-37.83903,145.261998
@@ -390,7 +391,7 @@ Bayswater Secondary College,45352.0,2019,BAYSWATER,23.0,1.8,35.3,94.0,977.0,Gove
 Bayswater Secondary College,45352.0,2020,BAYSWATER,25.0,0.0,50.0,100.0,969.0,Government,Secondary,214.0,-37.83903,145.261998
 Bayswater Secondary College,45352.0,2021,BAYSWATER,26.0,0.0,50.0,94.0,962.0,Government,Secondary,192.0,-37.83903,145.261998
 Bayswater Secondary College,45352.0,2022,BAYSWATER,25.0,0.0,58.3,100.0,952.0,Government,Secondary,174.0,-37.83903,145.261998
-Bayswater Secondary College,,2023,BAYSWATER,28.0,,27.8,89.0,,,,,,
+Bayswater Secondary College,45352.0,2023,BAYSWATER,28.0,,27.8,89.0,,,,,,
 Bayview College,46161.0,2014,PORTLAND,29.0,3.2,72.0,100.0,1038.0,Independent,Secondary,239.0,-38.3452,141.606
 Bayview College,46161.0,2015,PORTLAND,29.0,3.4,87.0,97.0,1024.0,Independent,Secondary,241.0,-38.3452,141.606
 Bayview College,46161.0,2016,PORTLAND,28.0,1.7,78.0,97.0,1032.0,Independent,Secondary,209.0,-38.3452,141.606
@@ -400,7 +401,7 @@ Bayview College,46161.0,2019,PORTLAND,28.0,0.9,72.7,100.0,1015.0,Independent,Sec
 Bayview College,46161.0,2020,PORTLAND,30.0,4.2,71.4,100.0,1015.0,Independent,Secondary,232.0,-38.3452,141.606
 Bayview College,46161.0,2021,PORTLAND,28.0,0.0,86.4,95.0,1024.0,Independent,Secondary,245.0,-38.3452,141.606
 Bayview College,46161.0,2022,PORTLAND,26.0,2.2,80.0,93.0,1026.0,Independent,Secondary,259.0,-38.3452,141.606
-Bayview College,,2023,PORTLAND,28.0,4.8,67.7,100.0,,,,,,
+Bayview College,46161.0,2023,PORTLAND,28.0,4.8,67.7,100.0,,,,,,
 Beaconhills College,46282.0,2014,BERWICK,31.0,4.8,89.0,100.0,1003.0,Independent,Combined,2819.0,-38.061898,145.467319
 Beaconhills College,46282.0,2014,PAKENHAM,31.0,5.4,90.0,99.0,1003.0,Independent,Combined,2819.0,-38.061898,145.467319
 Beaconhills College,46282.0,2015,BERWICK,31.0,6.2,90.0,100.0,1000.0,Independent,Combined,2874.0,-38.061898,145.467319
@@ -419,8 +420,8 @@ Beaconhills College,46282.0,2021,BERWICK,29.0,5.8,93.2,99.0,1087.0,Independent,C
 Beaconhills College,46282.0,2021,PAKENHAM,30.0,5.7,67.8,98.0,1087.0,Independent,Combined,2867.0,-38.061898,145.467319
 Beaconhills College,46282.0,2022,BERWICK,31.0,5.8,91.5,98.0,1088.0,Independent,Combined,2861.0,-38.061898,145.467319
 Beaconhills College,46282.0,2022,PAKENHAM,30.0,3.9,72.9,92.0,1088.0,Independent,Combined,2861.0,-38.061898,145.467319
-Beaconhills College,,2023,BERWICK,29.0,5.9,89.1,100.0,,,,,,
-Beaconhills College,,2023,PAKENHAM,29.0,1.7,79.2,100.0,,,,,,
+Beaconhills College,46282.0,2023,BERWICK,29.0,5.9,89.1,100.0,,,,,,
+Beaconhills College,46282.0,2023,PAKENHAM,29.0,1.7,79.2,100.0,,,,,,
 Beaufort Secondary College,45353.0,2014,BEAUFORT,25.0,2.2,83.0,94.0,963.0,Government,Secondary,172.0,-37.43831986,143.38254684
 Beaufort Secondary College,45353.0,2015,BEAUFORT,24.0,1.3,69.0,100.0,951.0,Government,Secondary,182.0,-37.43831986,143.38254684
 Beaufort Secondary College,45353.0,2016,BEAUFORT,26.0,1.6,43.0,86.0,943.0,Government,Secondary,200.0,-37.43831986,143.38254684
@@ -430,9 +431,9 @@ Beaufort Secondary College,45353.0,2019,BEAUFORT,26.0,0.0,58.3,100.0,961.0,Gover
 Beaufort Secondary College,45353.0,2020,BEAUFORT,28.0,0.0,70.0,100.0,963.0,Government,Secondary,201.0,-37.43831986,143.38254684
 Beaufort Secondary College,45353.0,2021,BEAUFORT,28.0,2.0,64.3,93.0,966.0,Government,Secondary,204.0,-37.43831986,143.38254684
 Beaufort Secondary College,45353.0,2022,BEAUFORT,27.0,0.0,60.0,90.0,968.0,Government,Secondary,202.0,-37.43831986,143.38254684
-Beaufort Secondary College,,2023,BEAUFORT,26.0,,50.0,100.0,,,,,,
+Beaufort Secondary College,45353.0,2023,BEAUFORT,26.0,,50.0,100.0,,,,,,
 Beaumaris Secondary College,52592.0,2022,BEAUMARIS,31.0,8.3,,,1110.0,Government,Secondary,836.0,-37.98163,145.033698
-Beaumaris Secondary College,,2023,BEAUMARIS,29.0,5.0,79.4,98.0,,,,,,
+Beaumaris Secondary College,52592.0,2023,BEAUMARIS,29.0,5.0,79.4,98.0,,,,,,
 Beechworth Secondary College,45354.0,2014,BEECHWORTH,26.0,2.3,76.0,100.0,1036.0,Government,Secondary,238.0,-36.3471944894634,146.69064223671
 Beechworth Secondary College,45354.0,2015,BEECHWORTH,29.0,0.8,75.0,88.0,1039.0,Government,Secondary,249.0,-36.3471944894634,146.69064223671
 Beechworth Secondary College,45354.0,2016,BEECHWORTH,25.0,2.0,52.0,100.0,1031.0,Government,Secondary,245.0,-36.3471944894634,146.69064223671
@@ -442,7 +443,7 @@ Beechworth Secondary College,45354.0,2019,BEECHWORTH,25.0,5.1,50.0,100.0,1026.0,
 Beechworth Secondary College,45354.0,2020,BEECHWORTH,29.0,13.7,84.2,100.0,1036.0,Government,Secondary,236.0,-36.3471944894634,146.69064223671
 Beechworth Secondary College,45354.0,2021,BEECHWORTH,29.0,9.1,53.3,100.0,1032.0,Government,Secondary,232.0,-36.3471944894634,146.69064223671
 Beechworth Secondary College,45354.0,2022,BEECHWORTH,25.0,0.0,63.0,100.0,1024.0,Government,Secondary,251.0,-36.3471944894634,146.69064223671
-Beechworth Secondary College,,2023,BEECHWORTH,26.0,,66.7,100.0,,,,,,
+Beechworth Secondary College,45354.0,2023,BEECHWORTH,26.0,,66.7,100.0,,,,,,
 Belgrave Heights Christian Schl,46286.0,2014,BELGRAVE HEIGHTS,28.0,4.9,85.0,100.0,1058.0,Independent,Combined,586.0,-37.91890282,145.3462292
 Belgrave Heights Christian Schl,46286.0,2015,BELGRAVE HEIGHTS,27.0,2.2,63.0,100.0,1066.0,Independent,Combined,627.0,-37.91890282,145.3462292
 Belgrave Heights Christian Schl,46286.0,2016,BELGRAVE HEIGHTS,30.0,4.1,83.0,98.0,1074.0,Independent,Combined,698.0,-37.91890282,145.3462292
@@ -452,7 +453,7 @@ Belgrave Heights Christian Schl,46286.0,2019,BELGRAVE HEIGHTS,29.0,5.6,100.0,100
 Belgrave Heights Christian Schl,46286.0,2020,BELGRAVE HEIGHTS,30.0,6.3,100.0,100.0,1078.0,Independent,Combined,788.0,-37.91890282,145.3462292
 Belgrave Heights Christian Schl,46286.0,2021,BELGRAVE HEIGHTS,30.0,7.2,85.9,100.0,1081.0,Independent,Combined,778.0,-37.91890282,145.3462292
 Belgrave Heights Christian Schl,46286.0,2022,BELGRAVE HEIGHTS,31.0,4.1,96.3,100.0,1081.0,Independent,Combined,774.0,-37.91890282,145.3462292
-Belgrave Heights Christian Schl,,2023,BELGRAVE HEIGHTS,29.0,2.4,63.5,100.0,,,,,,
+Belgrave Heights Christian Schl,46286.0,2023,BELGRAVE HEIGHTS,29.0,2.4,63.5,100.0,,,,,,
 Bellarine Secondary College,45456.0,2014,DRYSDALE,26.0,2.0,64.0,99.0,989.0,Government,Secondary,1021.0,-38.191069,144.556993
 Bellarine Secondary College,45456.0,2015,DRYSDALE,25.0,0.9,74.0,97.0,991.0,Government,Secondary,1051.0,-38.191069,144.556993
 Bellarine Secondary College,45456.0,2016,DRYSDALE,26.0,2.2,71.0,97.0,992.0,Government,Secondary,1033.0,-38.191069,144.556993
@@ -462,7 +463,7 @@ Bellarine Secondary College,45456.0,2019,DRYSDALE,26.0,2.1,82.9,95.0,998.0,Gover
 Bellarine Secondary College,45456.0,2020,DRYSDALE,26.0,3.1,82.3,100.0,999.0,Government,Secondary,1280.0,-38.191069,144.556993
 Bellarine Secondary College,45456.0,2021,DRYSDALE,27.0,2.0,76.7,97.0,999.0,Government,Secondary,1268.0,-38.191069,144.556993
 Bellarine Secondary College,45456.0,2022,DRYSDALE,29.0,4.6,72.6,99.0,1002.0,Government,Secondary,1238.0,-38.191069,144.556993
-Bellarine Secondary College,,2023,DRYSDALE,28.0,2.6,62.1,99.0,,,,,,
+Bellarine Secondary College,45456.0,2023,DRYSDALE,28.0,2.6,62.1,99.0,,,,,,
 Belmont High School,45355.0,2014,BELMONT,28.0,2.9,68.0,97.0,1028.0,Government,Secondary,1215.0,-38.17555773,144.33058747
 Belmont High School,45355.0,2015,BELMONT,28.0,2.6,62.0,97.0,1025.0,Government,Secondary,1225.0,-38.17555773,144.33058747
 Belmont High School,45355.0,2016,BELMONT,30.0,6.0,71.0,98.0,1028.0,Government,Secondary,1248.0,-38.17555773,144.33058747
@@ -472,7 +473,7 @@ Belmont High School,45355.0,2019,BELMONT,28.0,4.9,68.4,97.0,1039.0,Government,Se
 Belmont High School,45355.0,2020,BELMONT,28.0,6.3,74.6,98.0,1044.0,Government,Secondary,1285.0,-38.17555773,144.33058747
 Belmont High School,45355.0,2021,BELMONT,28.0,4.3,60.8,98.0,1044.0,Government,Secondary,1282.0,-38.17555773,144.33058747
 Belmont High School,45355.0,2022,BELMONT,28.0,3.4,55.9,96.0,1042.0,Government,Secondary,1284.0,-38.17555773,144.33058747
-Belmont High School,,2023,BELMONT,29.0,2.6,57.9,97.0,,,,,,
+Belmont High School,45355.0,2023,BELMONT,29.0,2.6,57.9,97.0,,,,,,
 Benalla P-12 College,50569.0,2014,BENALLA,26.0,4.6,59.0,95.0,948.0,Government,Combined,1009.0,-36.553372,145.963847
 Benalla P-12 College,50569.0,2015,BENALLA,28.0,3.2,65.0,98.0,931.0,Government,Combined,976.0,-36.553372,145.963847
 Benalla P-12 College,50569.0,2016,BENALLA,24.0,0.8,68.0,88.0,934.0,Government,Combined,943.0,-36.553372,145.963847
@@ -482,7 +483,7 @@ Benalla P-12 College,50569.0,2019,BENALLA,24.0,0.0,57.1,100.0,934.0,Government,C
 Benalla P-12 College,50569.0,2020,BENALLA,26.0,0.0,51.7,97.0,944.0,Government,Combined,872.0,-36.553372,145.963847
 Benalla P-12 College,50569.0,2021,BENALLA,25.0,2.0,67.6,94.0,943.0,Government,Combined,857.0,-36.553372,145.963847
 Benalla P-12 College,50569.0,2022,BENALLA,23.0,0.0,34.8,100.0,935.0,Government,Combined,788.0,-36.553372,145.963847
-Benalla P-12 College,,2023,BENALLA,23.0,,35.5,84.0,,,,,,
+Benalla P-12 College,50569.0,2023,BENALLA,23.0,,35.5,84.0,,,,,,
 Bendigo Senior Sec College,40576.0,2014,BENDIGO,27.0,3.2,66.0,95.0,,Government,Secondary,1751.0,-36.7551,144.279586
 Bendigo Senior Sec College,40576.0,2015,BENDIGO,27.0,2.6,64.0,95.0,,Government,Secondary,1819.0,-36.7551,144.279586
 Bendigo Senior Sec College,40576.0,2016,BENDIGO,27.0,2.1,63.0,97.0,,Government,Secondary,1840.0,-36.7551,144.279586
@@ -492,9 +493,19 @@ Bendigo Senior Sec College,40576.0,2019,BENDIGO,26.0,2.7,55.6,97.0,997.0,Governm
 Bendigo Senior Sec College,40576.0,2020,BENDIGO,26.0,1.9,56.5,96.0,999.0,Government,Secondary,1726.0,-36.7551,144.279586
 Bendigo Senior Sec College,40576.0,2021,BENDIGO,26.0,1.9,57.0,96.0,1000.0,Government,Secondary,1765.0,-36.7551,144.279586
 Bendigo Senior Sec College,40576.0,2022,BENDIGO,26.0,2.3,58.3,96.0,1001.0,Government,Secondary,1727.0,-36.7551,144.279586
-Bendigo Senior Sec College,,2023,BENDIGO,27.0,2.1,46.5,95.0,,,,,,
+Bendigo Senior Sec College,40576.0,2023,BENDIGO,27.0,2.1,46.5,95.0,,,,,,
 Bendigo South East 7-10 SC,45387.0,2021,BENDIGO,,,,,1020.0,Government,Secondary,1376.0,-36.7761957,144.29931032
-Bendigo South East 7-10 SC,,2023,BENDIGO,,,,,,,,,,
+Bendigo South East 7-10 SC,45387.0,2023,BENDIGO,,,,,,,,,,
+Bendigo TAFE,,2014,BENDIGO,,,,,,,,,,
+Bendigo TAFE,,2015,BENDIGO,,,,,,,,,,
+Bendigo TAFE,,2016,BENDIGO,,,,,,,,,,
+Bendigo TAFE,,2017,BENDIGO,,,,,,,,,,
+Bendigo TAFE,,2018,BENDIGO,,,,,,,,,,
+Bendigo TAFE,,2019,BENDIGO,,,,,,,,,,
+Bendigo TAFE,,2020,BENDIGO,,,,,,,,,,
+Bendigo TAFE,,2021,BENDIGO,,,,,,,,,,
+Bendigo TAFE,,2022,BENDIGO,,,,,,,,,,
+Bendigo TAFE,,2023,BENDIGO,,,6.7,47.0,,,,,,
 Bentleigh Secondary College,45338.0,2014,BENTLEIGH EAST,29.0,4.0,86.0,100.0,1044.0,Government,Secondary,890.0,-37.92767095,145.05991138
 Bentleigh Secondary College,45338.0,2015,BENTLEIGH EAST,30.0,5.4,85.0,100.0,1050.0,Government,Secondary,878.0,-37.92767095,145.05991138
 Bentleigh Secondary College,45338.0,2016,BENTLEIGH EAST,28.0,2.4,85.0,100.0,1043.0,Government,Secondary,952.0,-37.92767095,145.05991138
@@ -504,7 +515,7 @@ Bentleigh Secondary College,45338.0,2019,BENTLEIGH EAST,28.0,4.1,75.0,97.0,1059.
 Bentleigh Secondary College,45338.0,2020,BENTLEIGH EAST,29.0,5.5,88.2,99.0,1064.0,Government,Secondary,1030.0,-37.92767095,145.05991138
 Bentleigh Secondary College,45338.0,2021,BENTLEIGH EAST,28.0,2.1,75.8,98.0,1067.0,Government,Secondary,982.0,-37.92767095,145.05991138
 Bentleigh Secondary College,45338.0,2022,BENTLEIGH EAST,28.0,3.1,76.7,95.0,1075.0,Government,Secondary,931.0,-37.92767095,145.05991138
-Bentleigh Secondary College,,2023,BENTLEIGH EAST,30.0,4.6,89.1,98.0,,,,,,
+Bentleigh Secondary College,45338.0,2023,BENTLEIGH EAST,30.0,4.6,89.1,98.0,,,,,,
 Berry Street Victoria,46375.0,2014,RICHMOND,,,,,,Independent,Special,134.0,-37.981547,145.190186
 Berry Street Victoria,46375.0,2015,RICHMOND,,,,,,Independent,Special,130.0,-37.981547,145.190186
 Berry Street Victoria,46375.0,2016,RICHMOND,,,,,,Independent,Special,133.0,-37.981547,145.190186
@@ -514,16 +525,16 @@ Berry Street Victoria,46375.0,2019,RICHMOND,,,,,,Independent,Special,159.0,-37.9
 Berry Street Victoria,46375.0,2020,RICHMOND,,,,,,Independent,Special,183.0,-37.981547,145.190186
 Berry Street Victoria,46375.0,2021,RICHMOND,,,,,884.0,Independent,Special,197.0,-37.981547,145.190186
 Berry Street Victoria,46375.0,2022,SEBASTOPOL,,,,,850.0,Independent,Special,194.0,-37.981547,145.190186
-Berwick Grammar School,46200.0,2014,OFFICER,30.0,5.5,100.0,100.0,1156.0,Independent,Combined,1180.0,-37.911108,144.993524
-Berwick Grammar School,46200.0,2015,OFFICER,32.0,5.1,100.0,100.0,1173.0,Independent,Combined,1187.0,-37.911108,144.993524
-Berwick Grammar School,46200.0,2016,OFFICER,32.0,8.6,100.0,100.0,1152.0,Independent,Combined,1194.0,-37.911108,144.993524
-Berwick Grammar School,46200.0,2017,OFFICER,31.0,9.1,87.0,100.0,1160.0,Independent,Combined,1218.0,-37.911108,144.993524
-Berwick Grammar School,46200.0,2018,OFFICER,33.0,10.9,88.0,100.0,1147.0,Independent,Combined,1268.0,-37.911108,144.993524
-Berwick Grammar School,46200.0,2019,OFFICER,32.0,7.1,89.3,100.0,1144.0,Independent,Combined,1301.0,-37.911108,144.993524
-Berwick Grammar School,46200.0,2020,OFFICER,31.0,12.7,86.5,100.0,1144.0,Independent,Combined,1337.0,-37.911108,144.993524
-Berwick Grammar School,46200.0,2021,OFFICER,30.0,8.9,100.0,100.0,1134.0,Independent,Combined,1329.0,-37.911108,144.993524
-Berwick Grammar School,46200.0,2022,OFFICER,31.0,13.1,92.6,100.0,1138.0,Independent,Combined,1366.0,-37.911108,144.993524
-Berwick Grammar School,,2023,OFFICER,33.0,11.4,90.9,100.0,,,,,,
+Berwick Grammar School,46203.0,2014,OFFICER,30.0,5.5,100.0,100.0,1128.0,Independent,Combined,925.0,-38.035346,145.346545
+Berwick Grammar School,46203.0,2015,OFFICER,32.0,5.1,100.0,100.0,1136.0,Independent,Combined,960.0,-38.035346,145.346545
+Berwick Grammar School,46203.0,2016,OFFICER,32.0,8.6,100.0,100.0,1136.0,Independent,Combined,943.0,-38.035346,145.346545
+Berwick Grammar School,46203.0,2017,OFFICER,31.0,9.1,87.0,100.0,1137.0,Independent,Combined,824.0,-38.035346,145.346545
+Berwick Grammar School,46203.0,2018,OFFICER,33.0,10.9,88.0,100.0,1135.0,Independent,Combined,764.0,-38.035346,145.346545
+Berwick Grammar School,46203.0,2019,OFFICER,32.0,7.1,89.3,100.0,1133.0,Independent,Combined,746.0,-38.035346,145.346545
+Berwick Grammar School,46203.0,2020,OFFICER,31.0,12.7,86.5,100.0,1133.0,Independent,Combined,736.0,-38.035346,145.346545
+Berwick Grammar School,46203.0,2021,OFFICER,30.0,8.9,100.0,100.0,1140.0,Independent,Combined,672.0,-38.035346,145.346545
+Berwick Grammar School,46203.0,2022,OFFICER,31.0,13.1,92.6,100.0,1147.0,Independent,Combined,739.0,-38.035346,145.346545
+Berwick Grammar School,46203.0,2023,OFFICER,33.0,11.4,90.9,100.0,,,,,,
 Berwick Secondary College,45356.0,2014,BERWICK,30.0,5.4,76.0,98.0,1004.0,Government,Secondary,1438.0,-38.031068,145.364182
 Berwick Secondary College,45356.0,2015,BERWICK,29.0,3.5,72.0,100.0,1006.0,Government,Secondary,1541.0,-38.031068,145.364182
 Berwick Secondary College,45356.0,2016,BERWICK,29.0,3.8,82.0,99.0,1004.0,Government,Secondary,1587.0,-38.031068,145.364182
@@ -533,7 +544,7 @@ Berwick Secondary College,45356.0,2019,BERWICK,29.0,3.8,85.1,98.0,1016.0,Governm
 Berwick Secondary College,45356.0,2020,BERWICK,31.0,5.7,64.8,97.0,1020.0,Government,Secondary,1640.0,-38.031068,145.364182
 Berwick Secondary College,45356.0,2021,BERWICK,29.0,6.4,66.4,96.0,1018.0,Government,Secondary,1646.0,-38.031068,145.364182
 Berwick Secondary College,45356.0,2022,BERWICK,29.0,5.1,69.5,97.0,1021.0,Government,Secondary,1707.0,-38.031068,145.364182
-Berwick Secondary College,,2023,BERWICK,28.0,4.9,49.6,98.0,,,,,,
+Berwick Secondary College,45356.0,2023,BERWICK,28.0,4.9,49.6,98.0,,,,,,
 Beth Rivkah Ladies College,46216.0,2014,ST KILDA EAST,35.0,30.5,95.0,100.0,1089.0,Independent,Combined,572.0,-37.869629,145.001684
 Beth Rivkah Ladies College,46216.0,2015,ST KILDA EAST,38.0,37.8,80.0,100.0,1093.0,Independent,Combined,586.0,-37.869629,145.001684
 Beth Rivkah Ladies College,46216.0,2016,ST KILDA EAST,36.0,28.9,90.0,100.0,1091.0,Independent,Combined,592.0,-37.869629,145.001684
@@ -543,7 +554,7 @@ Beth Rivkah Ladies College,46216.0,2019,ST KILDA EAST,36.0,30.5,78.9,100.0,1084.
 Beth Rivkah Ladies College,46216.0,2020,ST KILDA EAST,37.0,30.2,74.4,100.0,1084.0,Independent,Combined,583.0,-37.869629,145.001684
 Beth Rivkah Ladies College,46216.0,2021,ST KILDA EAST,34.0,20.9,73.9,100.0,1083.0,Independent,Combined,551.0,-37.869629,145.001684
 Beth Rivkah Ladies College,46216.0,2022,ST KILDA EAST,34.0,20.1,63.2,100.0,1083.0,Independent,Combined,529.0,-37.869629,145.001684
-Beth Rivkah Ladies College,,2023,ST KILDA EAST,35.0,18.9,79.5,97.0,,,,,,
+Beth Rivkah Ladies College,46216.0,2023,ST KILDA EAST,35.0,18.9,79.5,97.0,,,,,,
 Bialik College,46221.0,2014,HAWTHORN EAST,38.0,35.6,100.0,100.0,1167.0,Independent,Combined,831.0,-37.84197,145.043299
 Bialik College,46221.0,2015,HAWTHORN EAST,38.0,36.5,98.0,100.0,1172.0,Independent,Combined,851.0,-37.84197,145.043299
 Bialik College,46221.0,2016,HAWTHORN EAST,39.0,44.2,99.0,100.0,1163.0,Independent,Combined,861.0,-37.84197,145.043299
@@ -553,7 +564,7 @@ Bialik College,46221.0,2019,HAWTHORN EAST,39.0,44.3,100.0,100.0,1163.0,Independe
 Bialik College,46221.0,2020,HAWTHORN,38.0,39.9,98.8,100.0,1163.0,Independent,Combined,916.0,-37.84197,145.043299
 Bialik College,46221.0,2021,HAWTHORN,37.0,32.6,98.6,100.0,1166.0,Independent,Combined,922.0,-37.84197,145.043299
 Bialik College,46221.0,2022,HAWTHORN,37.0,32.7,97.4,99.0,1173.0,Independent,Combined,926.0,-37.84197,145.043299
-Bialik College,,2023,HAWTHORN,37.0,34.1,97.5,100.0,,,,,,
+Bialik College,46221.0,2023,HAWTHORN,37.0,34.1,97.5,100.0,,,,,,
 Billanook College,46264.0,2014,MOOROOLBARK,33.0,13.8,84.0,99.0,1097.0,Independent,Combined,760.0,-37.78785168,145.3388701
 Billanook College,46264.0,2015,MOOROOLBARK,33.0,9.9,89.0,100.0,1092.0,Independent,Combined,740.0,-37.78785168,145.3388701
 Billanook College,46264.0,2016,MOOROOLBARK,31.0,9.6,85.0,99.0,1106.0,Independent,Combined,722.0,-37.78785168,145.3388701
@@ -563,7 +574,7 @@ Billanook College,46264.0,2019,MOOROOLBARK,31.0,8.0,92.5,100.0,1097.0,Independen
 Billanook College,46264.0,2020,MOOROOLBARK,31.0,9.6,95.2,100.0,1097.0,Independent,Combined,716.0,-37.78785168,145.3388701
 Billanook College,46264.0,2021,MOOROOLBARK,31.0,5.4,96.6,99.0,1099.0,Independent,Combined,702.0,-37.78785168,145.3388701
 Billanook College,46264.0,2022,MOOROOLBARK,31.0,9.0,94.8,100.0,1103.0,Independent,Combined,708.0,-37.78785168,145.3388701
-Billanook College,,2023,MOOROOLBARK,33.0,12.5,98.4,100.0,,,,,,
+Billanook College,46264.0,2023,MOOROOLBARK,33.0,12.5,98.4,100.0,,,,,,
 Birchip P-12 School,45568.0,2014,BIRCHIP,30.0,4.2,63.0,100.0,978.0,Government,Combined,233.0,-35.98438249,142.90993654
 Birchip P-12 School,45568.0,2015,BIRCHIP,32.0,16.0,86.0,100.0,978.0,Government,Combined,222.0,-35.98438249,142.90993654
 Birchip P-12 School,45568.0,2016,BIRCHIP,31.0,13.4,88.0,100.0,976.0,Government,Combined,226.0,-35.98438249,142.90993654
@@ -573,7 +584,7 @@ Birchip P-12 School,45568.0,2019,BIRCHIP,31.0,6.1,90.0,100.0,984.0,Government,Co
 Birchip P-12 School,45568.0,2020,BIRCHIP,28.0,7.0,83.3,100.0,982.0,Government,Combined,184.0,-35.98438249,142.90993654
 Birchip P-12 School,45568.0,2021,BIRCHIP,30.0,2.4,75.0,100.0,988.0,Government,Combined,169.0,-35.98438249,142.90993654
 Birchip P-12 School,45568.0,2022,BIRCHIP,27.0,3.0,58.3,100.0,982.0,Government,Combined,177.0,-35.98438249,142.90993654
-Birchip P-12 School,,2023,BIRCHIP,31.0,2.4,50.0,100.0,,,,,,
+Birchip P-12 School,45568.0,2023,BIRCHIP,31.0,2.4,50.0,100.0,,,,,,
 Blackburn High School,45357.0,2014,BLACKBURN,29.0,7.6,85.0,98.0,1067.0,Government,Secondary,845.0,-37.81037,145.149893
 Blackburn High School,45357.0,2015,BLACKBURN,30.0,8.5,84.0,99.0,1069.0,Government,Secondary,953.0,-37.81037,145.149893
 Blackburn High School,45357.0,2016,BLACKBURN,29.0,6.0,80.0,96.0,1075.0,Government,Secondary,1084.0,-37.81037,145.149893
@@ -583,7 +594,7 @@ Blackburn High School,45357.0,2019,BLACKBURN,29.0,5.9,75.9,98.0,1081.0,Governmen
 Blackburn High School,45357.0,2020,BLACKBURN,30.0,7.1,86.3,100.0,1082.0,Government,Secondary,1342.0,-37.81037,145.149893
 Blackburn High School,45357.0,2021,BLACKBURN,29.0,5.1,83.8,99.0,1087.0,Government,Secondary,1280.0,-37.81037,145.149893
 Blackburn High School,45357.0,2022,BLACKBURN,29.0,5.2,77.6,99.0,1092.0,Government,Secondary,1283.0,-37.81037,145.149893
-Blackburn High School,,2023,BLACKBURN,30.0,6.8,80.5,99.0,,,,,,
+Blackburn High School,45357.0,2023,BLACKBURN,30.0,6.8,80.5,99.0,,,,,,
 Boort District P-12 School,50271.0,2014,BOORT,30.0,3.0,80.0,100.0,1014.0,Government,Combined,232.0,-36.11042086,143.72681422
 Boort District P-12 School,50271.0,2015,BOORT,31.0,4.6,91.0,100.0,1004.0,Government,Combined,229.0,-36.11042086,143.72681422
 Boort District P-12 School,50271.0,2016,BOORT,30.0,4.2,88.0,100.0,1019.0,Government,Combined,220.0,-36.11042086,143.72681422
@@ -593,7 +604,7 @@ Boort District P-12 School,50271.0,2019,BOORT,31.0,12.5,83.3,100.0,1005.0,Govern
 Boort District P-12 School,50271.0,2020,BOORT,29.0,3.7,86.7,100.0,1002.0,Government,Combined,215.0,-36.11042086,143.72681422
 Boort District P-12 School,50271.0,2021,BOORT,31.0,15.6,56.2,81.0,1000.0,Government,Combined,208.0,-36.11042086,143.72681422
 Boort District P-12 School,50271.0,2022,BOORT,30.0,7.7,70.0,90.0,995.0,Government,Combined,206.0,-36.11042086,143.72681422
-Boort District P-12 School,,2023,BOORT,28.0,3.6,72.2,94.0,,,,,,
+Boort District P-12 School,50271.0,2023,BOORT,28.0,3.6,72.2,94.0,,,,,,
 Boronia K-12 College,44703.0,2014,BORONIA,27.0,1.1,74.0,95.0,969.0,Government,Combined,486.0,-37.858934,145.289416
 Boronia K-12 College,44703.0,2015,BORONIA,22.0,1.9,80.0,90.0,961.0,Government,Combined,547.0,-37.858934,145.289416
 Boronia K-12 College,44703.0,2016,BORONIA,26.0,0.0,50.0,100.0,961.0,Government,Combined,609.0,-37.858934,145.289416
@@ -603,7 +614,7 @@ Boronia K-12 College,44703.0,2019,BORONIA,24.0,0.0,55.2,97.0,962.0,Government,Co
 Boronia K-12 College,44703.0,2020,BORONIA,23.0,1.3,54.8,90.0,962.0,Government,Combined,639.0,-37.858934,145.289416
 Boronia K-12 College,44703.0,2021,BORONIA,24.0,0.7,58.3,89.0,964.0,Government,Combined,632.0,-37.858934,145.289416
 Boronia K-12 College,44703.0,2022,BORONIA,21.0,0.8,64.5,97.0,966.0,Government,Combined,595.0,-37.858934,145.289416
-Boronia K-12 College,,2023,BORONIA,23.0,1.0,37.9,79.0,,,,,,
+Boronia K-12 College,44703.0,2023,BORONIA,23.0,1.0,37.9,79.0,,,,,,
 Box Hill High School,45359.0,2014,BOX HILL,33.0,15.0,91.0,96.0,1128.0,Government,Secondary,1146.0,-37.82009053,145.13753866
 Box Hill High School,45359.0,2015,BOX HILL,33.0,16.3,96.0,99.0,1127.0,Government,Secondary,1214.0,-37.82009053,145.13753866
 Box Hill High School,45359.0,2016,BOX HILL,33.0,19.0,93.0,98.0,1129.0,Government,Secondary,1233.0,-37.82009053,145.13753866
@@ -613,7 +624,22 @@ Box Hill High School,45359.0,2019,BOX HILL,33.0,14.7,95.9,100.0,1128.0,Governmen
 Box Hill High School,45359.0,2020,BOX HILL,32.0,14.8,93.3,100.0,1126.0,Government,Secondary,1376.0,-37.82009053,145.13753866
 Box Hill High School,45359.0,2021,BOX HILL,32.0,13.1,90.5,100.0,1126.0,Government,Secondary,1380.0,-37.82009053,145.13753866
 Box Hill High School,45359.0,2022,BOX HILL,32.0,12.0,87.5,98.0,1127.0,Government,Secondary,1393.0,-37.82009053,145.13753866
-Box Hill High School,,2023,BOX HILL,30.0,8.9,86.3,94.0,,,,,,
+Box Hill High School,45359.0,2023,BOX HILL,30.0,8.9,86.3,94.0,,,,,,
+Box Hill Institute,,2014,BOX HILL,24.0,2.5,24.0,67.0,,,,,,
+Box Hill Institute,,2015,BOX HILL,26.0,1.3,39.0,69.0,,,,,,
+Box Hill Institute,,2016,BOX HILL,26.0,0.0,46.0,80.0,,,,,,
+Box Hill Institute,,2017,BOX HILL,,,,,,,,,,
+Box Hill Institute,,2018,BOX HILL,,,,,,,,,,
+Box Hill Institute,,2019,BOX HILL,,,,,,,,,,
+Box Hill Institute,,2020,BOX HILL,,,,,,,,,,
+Box Hill Institute,,2021,BOX HILL,,,,,,,,,,
+Box Hill Institute,,2022,BOX HILL,,,,,,,,,,
+Box Hill Institute,,2023,BOX HILL,,,5.2,83.0,,,,,,
+Box Hill Institute - CAE campus,,2019,MELBOURNE,24.0,3.7,40.0,84.0,,,,,,
+Box Hill Institute - CAE campus,,2020,MELBOURNE,25.0,2.2,51.2,84.0,,,,,,
+Box Hill Institute - CAE campus,,2021,MELBOURNE,25.0,2.0,35.6,82.0,,,,,,
+Box Hill Institute - CAE campus,,2022,MELBOURNE,24.0,0.5,50.0,76.0,,,,,,
+Box Hill Institute - CAE campus,,2023,MELBOURNE,26.0,2.3,43.8,81.0,,,,,,
 Box Hill Senior Sec College,45326.0,2014,MONT ALBERT NORTH,25.0,1.0,65.0,98.0,1050.0,Government,Combined,706.0,-37.809243,145.111907
 Box Hill Senior Sec College,45326.0,2015,MONT ALBERT NORTH,26.0,1.5,62.0,99.0,1050.0,Government,Combined,634.0,-37.809243,145.111907
 Box Hill Senior Sec College,45326.0,2016,MONT ALBERT NORTH,25.0,0.5,64.0,98.0,1056.0,Government,Combined,545.0,-37.809243,145.111907
@@ -623,7 +649,7 @@ Box Hill Senior Sec College,45326.0,2019,MONT ALBERT NORTH,25.0,1.0,62.6,98.0,10
 Box Hill Senior Sec College,45326.0,2020,MONT ALBERT NORTH,24.0,1.4,53.5,97.0,1051.0,Government,Secondary,338.0,-37.809243,145.111907
 Box Hill Senior Sec College,45326.0,2021,MONT ALBERT NORTH,24.0,1.7,51.7,97.0,1052.0,Government,Secondary,334.0,-37.809243,145.111907
 Box Hill Senior Sec College,45326.0,2022,MONT ALBERT NORTH,25.0,0.5,56.3,97.0,1055.0,Government,Secondary,361.0,-37.809243,145.111907
-Box Hill Senior Sec College,,2023,MONT ALBERT NORTH,26.0,0.5,36.6,95.0,,,,,,
+Box Hill Senior Sec College,45326.0,2023,MONT ALBERT NORTH,26.0,0.5,36.6,95.0,,,,,,
 Braemar College,46238.0,2014,WOODEND,32.0,9.1,87.0,100.0,1125.0,Independent,Combined,748.0,-37.363765716552734,144.57632446289062
 Braemar College,46238.0,2015,WOODEND,32.0,10.5,93.0,100.0,1127.0,Independent,Combined,793.0,-37.363765716552734,144.57632446289062
 Braemar College,46238.0,2016,WOODEND,33.0,11.9,91.0,100.0,1124.0,Independent,Combined,814.0,-37.363765716552734,144.57632446289062
@@ -633,17 +659,17 @@ Braemar College,46238.0,2019,WOODEND,32.0,10.4,89.6,100.0,1128.0,Independent,Com
 Braemar College,46238.0,2020,WOODEND,32.0,12.1,94.9,100.0,1128.0,Independent,Combined,992.0,-37.363765716552734,144.57632446289062
 Braemar College,46238.0,2021,WOODEND,32.0,11.4,90.3,99.0,1127.0,Independent,Combined,1043.0,-37.363765716552734,144.57632446289062
 Braemar College,46238.0,2022,WOODEND,31.0,8.9,89.0,100.0,1125.0,Independent,Combined,1098.0,-37.363765716552734,144.57632446289062
-Braemar College,,2023,WOODEND,31.0,8.6,92.1,99.0,,,,,,
-Brauer College,46238.0,2014,WARRNAMBOOL,28.0,4.4,64.0,99.0,1125.0,Independent,Combined,748.0,-37.363765716552734,144.57632446289062
-Brauer College,46238.0,2015,WARRNAMBOOL,28.0,3.2,72.0,99.0,1127.0,Independent,Combined,793.0,-37.363765716552734,144.57632446289062
-Brauer College,46238.0,2016,WARRNAMBOOL,29.0,3.7,67.0,99.0,1124.0,Independent,Combined,814.0,-37.363765716552734,144.57632446289062
-Brauer College,46238.0,2017,WARRNAMBOOL,28.0,6.0,63.0,96.0,1129.0,Independent,Combined,845.0,-37.363765716552734,144.57632446289062
-Brauer College,46238.0,2018,WARRNAMBOOL,27.0,1.7,66.0,100.0,1127.0,Independent,Combined,888.0,-37.363765716552734,144.57632446289062
-Brauer College,46238.0,2019,WARRNAMBOOL,27.0,2.8,61.6,99.0,1128.0,Independent,Combined,938.0,-37.363765716552734,144.57632446289062
-Brauer College,46238.0,2020,WARRNAMBOOL,28.0,4.7,80.9,100.0,1128.0,Independent,Combined,992.0,-37.363765716552734,144.57632446289062
-Brauer College,46238.0,2021,WARRNAMBOOL,27.0,2.5,59.3,98.0,1127.0,Independent,Combined,1043.0,-37.363765716552734,144.57632446289062
-Brauer College,46238.0,2022,WARRNAMBOOL,28.0,3.9,67.2,96.0,1125.0,Independent,Combined,1098.0,-37.363765716552734,144.57632446289062
-Brauer College,,2023,WARRNAMBOOL,29.0,5.7,55.8,91.0,,,,,,
+Braemar College,46238.0,2023,WOODEND,31.0,8.6,92.1,99.0,,,,,,
+Brauer College,45345.0,2014,WARRNAMBOOL,28.0,4.4,64.0,99.0,979.0,Government,Secondary,847.0,-38.358714,142.458924
+Brauer College,45345.0,2015,WARRNAMBOOL,28.0,3.2,72.0,99.0,980.0,Government,Secondary,766.0,-38.358714,142.458924
+Brauer College,45345.0,2016,WARRNAMBOOL,29.0,3.7,67.0,99.0,974.0,Government,Secondary,708.0,-38.358714,142.458924
+Brauer College,45345.0,2017,WARRNAMBOOL,28.0,6.0,63.0,96.0,979.0,Government,Secondary,690.0,-38.358714,142.458924
+Brauer College,45345.0,2018,WARRNAMBOOL,27.0,1.7,66.0,100.0,977.0,Government,Secondary,710.0,-38.358714,142.458924
+Brauer College,45345.0,2019,WARRNAMBOOL,27.0,2.8,61.6,99.0,988.0,Government,Secondary,761.0,-38.358714,142.458924
+Brauer College,45345.0,2020,WARRNAMBOOL,28.0,4.7,80.9,100.0,992.0,Government,Secondary,810.0,-38.358714,142.458924
+Brauer College,45345.0,2021,WARRNAMBOOL,27.0,2.5,59.3,98.0,992.0,Government,Secondary,815.0,-38.358714,142.458924
+Brauer College,45345.0,2022,WARRNAMBOOL,28.0,3.9,67.2,96.0,987.0,Government,Secondary,817.0,-38.358714,142.458924
+Brauer College,45345.0,2023,WARRNAMBOOL,29.0,5.7,55.8,91.0,,,,,,
 Braybrook College,45360.0,2014,BRAYBROOK,32.0,9.1,89.0,99.0,921.0,Government,Secondary,1192.0,-37.777975,144.847568
 Braybrook College,45360.0,2015,BRAYBROOK,31.0,7.5,99.0,100.0,930.0,Government,Secondary,1313.0,-37.777975,144.847568
 Braybrook College,45360.0,2016,BRAYBROOK,31.0,7.3,99.0,100.0,925.0,Government,Secondary,1361.0,-37.777975,144.847568
@@ -653,7 +679,7 @@ Braybrook College,45360.0,2019,BRAYBROOK,30.0,7.0,93.0,99.0,953.0,Government,Sec
 Braybrook College,45360.0,2020,BRAYBROOK,31.0,9.4,99.4,100.0,955.0,Government,Secondary,1398.0,-37.777975,144.847568
 Braybrook College,45360.0,2021,BRAYBROOK,31.0,12.3,98.7,100.0,961.0,Government,Secondary,1365.0,-37.777975,144.847568
 Braybrook College,45360.0,2022,BRAYBROOK,31.0,9.7,93.2,98.0,960.0,Government,Secondary,1365.0,-37.777975,144.847568
-Braybrook College,,2023,BRAYBROOK,33.0,16.9,85.5,93.0,,,,,,
+Braybrook College,45360.0,2023,BRAYBROOK,33.0,16.9,85.5,93.0,,,,,,
 Brentwood Secondary College,45361.0,2014,GLEN WAVERLEY,31.0,9.4,99.0,98.0,1068.0,Government,Secondary,1439.0,-37.89950842,145.16634324
 Brentwood Secondary College,45361.0,2015,GLEN WAVERLEY,31.0,7.4,99.0,100.0,1078.0,Government,Secondary,1486.0,-37.89950842,145.16634324
 Brentwood Secondary College,45361.0,2016,GLEN WAVERLEY,30.0,7.0,99.0,100.0,1071.0,Government,Secondary,1535.0,-37.89950842,145.16634324
@@ -663,7 +689,7 @@ Brentwood Secondary College,45361.0,2019,GLEN WAVERLEY,29.0,5.5,87.0,99.0,1078.0
 Brentwood Secondary College,45361.0,2020,GLEN WAVERLEY,30.0,6.4,88.3,100.0,1080.0,Government,Secondary,1686.0,-37.89950842,145.16634324
 Brentwood Secondary College,45361.0,2021,GLEN WAVERLEY,29.0,5.7,81.4,99.0,1082.0,Government,Secondary,1667.0,-37.89950842,145.16634324
 Brentwood Secondary College,45361.0,2022,GLEN WAVERLEY,29.0,6.4,83.1,100.0,1087.0,Government,Secondary,1637.0,-37.89950842,145.16634324
-Brentwood Secondary College,,2023,GLEN WAVERLEY,30.0,4.6,75.4,99.0,,,,,,
+Brentwood Secondary College,45361.0,2023,GLEN WAVERLEY,30.0,4.6,75.4,99.0,,,,,,
 Bright P-12 College,44140.0,2014,BRIGHT,25.0,3.4,62.0,100.0,1053.0,Government,Combined,522.0,-36.733105,146.960928
 Bright P-12 College,44140.0,2015,BRIGHT,27.0,2.8,77.0,100.0,1057.0,Government,Combined,496.0,-36.733105,146.960928
 Bright P-12 College,44140.0,2016,BRIGHT,29.0,2.2,85.0,90.0,1043.0,Government,Combined,440.0,-36.733105,146.960928
@@ -673,7 +699,7 @@ Bright P-12 College,44140.0,2019,BRIGHT,28.0,2.7,57.7,100.0,1057.0,Government,Co
 Bright P-12 College,44140.0,2020,BRIGHT,30.0,2.6,90.9,100.0,1051.0,Government,Combined,572.0,-36.733105,146.960928
 Bright P-12 College,44140.0,2021,BRIGHT,28.0,4.7,83.3,100.0,1049.0,Government,Combined,583.0,-36.733105,146.960928
 Bright P-12 College,44140.0,2022,BRIGHT,28.0,0.0,65.2,96.0,1053.0,Government,Combined,563.0,-36.733105,146.960928
-Bright P-12 College,,2023,BRIGHT,29.0,4.8,20.0,95.0,,,,,,
+Bright P-12 College,44140.0,2023,BRIGHT,29.0,4.8,20.0,95.0,,,,,,
 Brighton Grammar School,46200.0,2014,BRIGHTON,34.0,15.3,94.0,100.0,1156.0,Independent,Combined,1180.0,-37.911108,144.993524
 Brighton Grammar School,46200.0,2015,BRIGHTON,33.0,15.8,92.0,100.0,1173.0,Independent,Combined,1187.0,-37.911108,144.993524
 Brighton Grammar School,46200.0,2016,BRIGHTON,34.0,22.3,98.0,100.0,1152.0,Independent,Combined,1194.0,-37.911108,144.993524
@@ -683,7 +709,7 @@ Brighton Grammar School,46200.0,2019,BRIGHTON,33.0,18.0,97.7,100.0,1144.0,Indepe
 Brighton Grammar School,46200.0,2020,BRIGHTON,35.0,25.1,99.3,100.0,1144.0,Independent,Combined,1337.0,-37.911108,144.993524
 Brighton Grammar School,46200.0,2021,BRIGHTON,34.0,17.7,93.8,100.0,1134.0,Independent,Combined,1329.0,-37.911108,144.993524
 Brighton Grammar School,46200.0,2022,BRIGHTON,35.0,19.9,98.2,100.0,1138.0,Independent,Combined,1366.0,-37.911108,144.993524
-Brighton Grammar School,,2023,BRIGHTON,36.0,24.5,95.2,100.0,,,,,,
+Brighton Grammar School,46200.0,2023,BRIGHTON,36.0,24.5,95.2,100.0,,,,,,
 Brighton Secondary College,45362.0,2014,BRIGHTON EAST,30.0,8.1,87.0,97.0,1086.0,Government,Secondary,1191.0,-37.920156,145.019119
 Brighton Secondary College,45362.0,2015,BRIGHTON EAST,30.0,8.7,89.0,98.0,1085.0,Government,Secondary,1196.0,-37.920156,145.019119
 Brighton Secondary College,45362.0,2016,BRIGHTON EAST,30.0,6.2,79.0,96.0,1097.0,Government,Secondary,1230.0,-37.920156,145.019119
@@ -693,7 +719,7 @@ Brighton Secondary College,45362.0,2019,BRIGHTON EAST,29.0,5.8,80.4,96.0,1108.0,
 Brighton Secondary College,45362.0,2020,BRIGHTON EAST,30.0,9.0,90.2,98.0,1115.0,Government,Secondary,1205.0,-37.920156,145.019119
 Brighton Secondary College,45362.0,2021,BRIGHTON EAST,29.0,7.6,87.4,98.0,1118.0,Government,Secondary,1116.0,-37.920156,145.019119
 Brighton Secondary College,45362.0,2022,BRIGHTON EAST,31.0,10.8,76.2,98.0,1119.0,Government,Secondary,1043.0,-37.920156,145.019119
-Brighton Secondary College,,2023,BRIGHTON EAST,31.0,11.2,90.8,97.0,,,,,,
+Brighton Secondary College,45362.0,2023,BRIGHTON EAST,31.0,11.2,90.8,97.0,,,,,,
 Broadford Secondary College,45363.0,2014,BROADFORD,25.0,1.1,72.0,92.0,958.0,Government,Secondary,620.0,-37.204375,145.040033
 Broadford Secondary College,45363.0,2015,BROADFORD,26.0,3.6,58.0,95.0,954.0,Government,Secondary,612.0,-37.204375,145.040033
 Broadford Secondary College,45363.0,2016,BROADFORD,25.0,0.5,56.0,94.0,966.0,Government,Secondary,642.0,-37.204375,145.040033
@@ -703,7 +729,7 @@ Broadford Secondary College,45363.0,2019,BROADFORD,28.0,1.9,48.7,90.0,968.0,Gove
 Broadford Secondary College,45363.0,2020,BROADFORD,28.0,2.7,48.7,97.0,968.0,Government,Secondary,726.0,-37.204375,145.040033
 Broadford Secondary College,45363.0,2021,BROADFORD,25.0,1.3,82.4,96.0,967.0,Government,Secondary,745.0,-37.204375,145.040033
 Broadford Secondary College,45363.0,2022,BROADFORD,23.0,0.5,58.3,98.0,967.0,Government,Secondary,753.0,-37.204375,145.040033
-Broadford Secondary College,,2023,BROADFORD,23.0,0.9,58.2,94.0,,,,,,
+Broadford Secondary College,45363.0,2023,BROADFORD,23.0,0.9,58.2,94.0,,,,,,
 Brunswick Secondary College,45545.0,2014,BRUNSWICK,32.0,10.7,87.0,95.0,1035.0,Government,Secondary,1021.0,-37.77099,144.956515
 Brunswick Secondary College,45545.0,2015,BRUNSWICK,31.0,7.1,88.0,98.0,1045.0,Government,Secondary,1010.0,-37.77099,144.956515
 Brunswick Secondary College,45545.0,2016,BRUNSWICK,29.0,4.3,87.0,99.0,1043.0,Government,Secondary,1019.0,-37.77099,144.956515
@@ -713,7 +739,7 @@ Brunswick Secondary College,45545.0,2019,BRUNSWICK,29.0,5.3,80.6,98.0,1089.0,Gov
 Brunswick Secondary College,45545.0,2020,BRUNSWICK,29.0,4.9,86.6,99.0,1100.0,Government,Secondary,988.0,-37.77099,144.956515
 Brunswick Secondary College,45545.0,2021,BRUNSWICK,30.0,9.2,86.4,99.0,1108.0,Government,Secondary,1000.0,-37.77099,144.956515
 Brunswick Secondary College,45545.0,2022,BRUNSWICK,30.0,9.4,83.7,96.0,1118.0,Government,Secondary,1034.0,-37.77099,144.956515
-Brunswick Secondary College,,2023,BRUNSWICK,31.0,8.5,82.4,96.0,,,,,,
+Brunswick Secondary College,45545.0,2023,BRUNSWICK,31.0,8.5,82.4,96.0,,,,,,
 Buckley Park College,45364.0,2014,ESSENDON,31.0,7.3,91.0,99.0,1078.0,Government,Secondary,932.0,-37.747117,144.897755
 Buckley Park College,45364.0,2015,ESSENDON,31.0,9.4,90.0,98.0,1079.0,Government,Secondary,939.0,-37.747117,144.897755
 Buckley Park College,45364.0,2016,ESSENDON,30.0,7.1,90.0,98.0,1077.0,Government,Secondary,951.0,-37.747117,144.897755
@@ -723,7 +749,7 @@ Buckley Park College,45364.0,2019,ESSENDON,30.0,8.0,91.1,99.0,1082.0,Government,
 Buckley Park College,45364.0,2020,ESSENDON,30.0,7.3,92.2,100.0,1080.0,Government,Secondary,995.0,-37.747117,144.897755
 Buckley Park College,45364.0,2021,ESSENDON,29.0,6.3,86.5,99.0,1084.0,Government,Secondary,975.0,-37.747117,144.897755
 Buckley Park College,45364.0,2022,ESSENDON,29.0,5.8,87.6,98.0,1080.0,Government,Secondary,928.0,-37.747117,144.897755
-Buckley Park College,,2023,ESSENDON,31.0,6.8,77.9,99.0,,,,,,
+Buckley Park College,45364.0,2023,ESSENDON,31.0,6.8,77.9,99.0,,,,,,
 Bundoora Secondary College,45395.0,2014,BUNDOORA,23.0,2.4,85.0,92.0,954.0,Government,Secondary,468.0,-37.70757147,145.06157901
 Bundoora Secondary College,45395.0,2015,BUNDOORA,22.0,0.9,88.0,96.0,942.0,Government,Secondary,418.0,-37.70757147,145.06157901
 Bundoora Secondary College,45395.0,2016,BUNDOORA,21.0,0.0,88.0,96.0,952.0,Government,Secondary,399.0,-37.70757147,145.06157901
@@ -733,17 +759,17 @@ Bundoora Secondary College,45395.0,2019,BUNDOORA,22.0,0.0,81.1,100.0,988.0,Gover
 Bundoora Secondary College,45395.0,2020,BUNDOORA,25.0,0.0,76.0,96.0,995.0,Government,Secondary,336.0,-37.70757147,145.06157901
 Bundoora Secondary College,45395.0,2021,BUNDOORA,28.0,1.3,77.3,95.0,1005.0,Government,Secondary,352.0,-37.70757147,145.06157901
 Bundoora Secondary College,45395.0,2022,BUNDOORA,29.0,4.4,79.2,100.0,1017.0,Government,Secondary,397.0,-37.70757147,145.06157901
-Bundoora Secondary College,,2023,BUNDOORA,23.0,0.7,55.9,100.0,,,,,,
-Camberwell Anglican Girls GS,46136.0,2014,CANTERBURY,35.0,27.3,99.0,99.0,1200.0,Independent,Combined,619.0,-37.861454,145.054637
-Camberwell Anglican Girls GS,46136.0,2015,CANTERBURY,36.0,26.4,100.0,100.0,1211.0,Independent,Combined,597.0,-37.861454,145.054637
-Camberwell Anglican Girls GS,46136.0,2016,CANTERBURY,35.0,17.7,100.0,100.0,1204.0,Independent,Combined,559.0,-37.861454,145.054637
-Camberwell Anglican Girls GS,46136.0,2017,CANTERBURY,36.0,27.4,100.0,100.0,1201.0,Independent,Combined,620.0,-37.861454,145.054637
-Camberwell Anglican Girls GS,46136.0,2018,CANTERBURY,36.0,27.6,98.7,99.0,1197.0,Independent,Combined,670.0,-37.861454,145.054637
-Camberwell Anglican Girls GS,46136.0,2019,CANTERBURY,36.0,29.8,100.0,100.0,1191.0,Independent,Combined,700.0,-37.861454,145.054637
-Camberwell Anglican Girls GS,46136.0,2020,CANTERBURY,35.0,19.2,100.0,100.0,1191.0,Independent,Combined,708.0,-37.861454,145.054637
-Camberwell Anglican Girls GS,46136.0,2021,CANTERBURY,35.0,24.1,100.0,100.0,1189.0,Independent,Combined,701.0,-37.861454,145.054637
-Camberwell Anglican Girls GS,46136.0,2022,CANTERBURY,35.0,23.9,100.0,99.0,1194.0,Independent,Combined,704.0,-37.861454,145.054637
-Camberwell Anglican Girls GS,,2023,CANTERBURY,35.0,19.5,97.8,100.0,,,,,,
+Bundoora Secondary College,45395.0,2023,BUNDOORA,23.0,0.7,55.9,100.0,,,,,,
+Camberwell Anglican Girls GS,46204.0,2014,CANTERBURY,35.0,27.3,99.0,99.0,1183.0,Independent,Combined,753.0,-37.818211,145.059705
+Camberwell Anglican Girls GS,46204.0,2015,CANTERBURY,36.0,26.4,100.0,100.0,1196.0,Independent,Combined,724.0,-37.818211,145.059705
+Camberwell Anglican Girls GS,46204.0,2016,CANTERBURY,35.0,17.7,100.0,100.0,1189.0,Independent,Combined,708.0,-37.818211,145.059705
+Camberwell Anglican Girls GS,46204.0,2017,CANTERBURY,36.0,27.4,100.0,100.0,1193.0,Independent,Combined,712.0,-37.818211,145.059705
+Camberwell Anglican Girls GS,46204.0,2018,CANTERBURY,36.0,27.6,98.7,99.0,1186.0,Independent,Combined,721.0,-37.818211,145.059705
+Camberwell Anglican Girls GS,46204.0,2019,CANTERBURY,36.0,29.8,100.0,100.0,1195.0,Independent,Combined,739.0,-37.818211,145.059705
+Camberwell Anglican Girls GS,46204.0,2020,CANTERBURY,35.0,19.2,100.0,100.0,1195.0,Independent,Combined,755.0,-37.818211,145.059705
+Camberwell Anglican Girls GS,46204.0,2021,CANTERBURY,35.0,24.1,100.0,100.0,1187.0,Independent,Combined,761.0,-37.818211,145.059705
+Camberwell Anglican Girls GS,46204.0,2022,CANTERBURY,35.0,23.9,100.0,99.0,1184.0,Independent,Combined,781.0,-37.818211,145.059705
+Camberwell Anglican Girls GS,46204.0,2023,CANTERBURY,35.0,19.5,97.8,100.0,,,,,,
 Camberwell Grammar School,46199.0,2014,CANTERBURY,35.0,24.6,98.0,100.0,1189.0,Independent,Combined,1298.0,-37.81589557,145.06726232
 Camberwell Grammar School,46199.0,2015,CANTERBURY,34.0,17.9,98.0,100.0,1187.0,Independent,Combined,1293.0,-37.81589557,145.06726232
 Camberwell Grammar School,46199.0,2016,CANTERBURY,35.0,24.0,98.0,100.0,1193.0,Independent,Combined,1301.0,-37.81589557,145.06726232
@@ -753,7 +779,7 @@ Camberwell Grammar School,46199.0,2019,CANTERBURY,35.0,25.9,98.2,100.0,1178.0,In
 Camberwell Grammar School,46199.0,2020,CANTERBURY,34.0,21.4,98.8,100.0,1178.0,Independent,Combined,1325.0,-37.81589557,145.06726232
 Camberwell Grammar School,46199.0,2021,CANTERBURY,33.0,17.1,98.2,99.0,1175.0,Independent,Combined,1343.0,-37.81589557,145.06726232
 Camberwell Grammar School,46199.0,2022,CANTERBURY,34.0,21.3,95.5,100.0,1195.0,Independent,Combined,1327.0,-37.81589557,145.06726232
-Camberwell Grammar School,,2023,CANTERBURY,35.0,21.0,98.3,99.0,,,,,,
+Camberwell Grammar School,46199.0,2023,CANTERBURY,35.0,21.0,98.3,99.0,,,,,,
 Camberwell High School,45365.0,2014,CANTERBURY,32.0,10.1,95.0,98.0,1110.0,Government,Secondary,1264.0,-37.830441,145.073035
 Camberwell High School,45365.0,2015,CANTERBURY,30.0,7.2,93.0,98.0,1110.0,Government,Secondary,1269.0,-37.830441,145.073035
 Camberwell High School,45365.0,2016,CANTERBURY,31.0,7.3,94.0,99.0,1108.0,Government,Secondary,1276.0,-37.830441,145.073035
@@ -763,7 +789,7 @@ Camberwell High School,45365.0,2019,CANTERBURY,30.0,5.6,86.1,100.0,1119.0,Govern
 Camberwell High School,45365.0,2020,CANTERBURY,30.0,5.8,93.9,99.0,1123.0,Government,Secondary,1173.0,-37.830441,145.073035
 Camberwell High School,45365.0,2021,CANTERBURY,30.0,7.6,92.1,99.0,1122.0,Government,Secondary,1057.0,-37.830441,145.073035
 Camberwell High School,45365.0,2022,CANTERBURY,30.0,7.7,84.8,97.0,1127.0,Government,Secondary,984.0,-37.830441,145.073035
-Camberwell High School,,2023,CANTERBURY,29.0,5.0,89.1,100.0,,,,,,
+Camberwell High School,45365.0,2023,CANTERBURY,29.0,5.0,89.1,100.0,,,,,,
 Camperdown College,45319.0,2014,CAMPERDOWN,27.0,1.1,82.0,100.0,973.0,Government,Combined,284.0,-38.239731,143.145435
 Camperdown College,45319.0,2015,CAMPERDOWN,31.0,5.2,82.0,100.0,973.0,Government,Combined,274.0,-38.239731,143.145435
 Camperdown College,45319.0,2016,CAMPERDOWN,29.0,5.4,100.0,100.0,973.0,Government,Combined,280.0,-38.239731,143.145435
@@ -773,7 +799,7 @@ Camperdown College,45319.0,2019,CAMPERDOWN,32.0,8.8,66.7,100.0,972.0,Government,
 Camperdown College,45319.0,2020,CAMPERDOWN,29.0,8.1,66.7,100.0,975.0,Government,Combined,351.0,-38.239731,143.145435
 Camperdown College,45319.0,2021,CAMPERDOWN,27.0,0.0,80.0,100.0,977.0,Government,Combined,362.0,-38.239731,143.145435
 Camperdown College,45319.0,2022,CAMPERDOWN,27.0,0.0,100.0,100.0,982.0,Government,Combined,367.0,-38.239731,143.145435
-Camperdown College,,2023,CAMPERDOWN,27.0,,63.6,91.0,,,,,,
+Camperdown College,45319.0,2023,CAMPERDOWN,27.0,,63.6,91.0,,,,,,
 Cann River P-12 College,44670.0,2014,CANN RIVER,31.0,0.0,50.0,50.0,944.0,Government,Combined,44.0,-37.5697,149.153022
 Cann River P-12 College,44670.0,2015,CANN RIVER,29.0,0.0,100.0,100.0,941.0,Government,Combined,43.0,-37.5697,149.153022
 Cann River P-12 College,44670.0,2016,CANN RIVER,27.0,0.0,100.0,100.0,950.0,Government,Combined,38.0,-37.5697,149.153022
@@ -783,7 +809,7 @@ Cann River P-12 College,44670.0,2019,CANN RIVER,29.0,0.0,100.0,100.0,975.0,Gover
 Cann River P-12 College,44670.0,2020,CANN RIVER,24.0,0.0,40.0,80.0,965.0,Government,Combined,47.0,-37.5697,149.153022
 Cann River P-12 College,44670.0,2021,CANN RIVER,26.0,0.0,100.0,100.0,956.0,Government,Combined,47.0,-37.5697,149.153022
 Cann River P-12 College,44670.0,2022,CANN RIVER,30.0,25.0,,,955.0,Government,Combined,41.0,-37.5697,149.153022
-Cann River P-12 College,,2023,CANN RIVER,24.0,,66.7,100.0,,,,,,
+Cann River P-12 College,44670.0,2023,CANN RIVER,24.0,,66.7,100.0,,,,,,
 Canterbury Girls Sec College,45366.0,2014,CANTERBURY,32.0,12.1,97.0,100.0,1125.0,Government,Secondary,1002.0,-37.819878,145.070325
 Canterbury Girls Sec College,45366.0,2015,CANTERBURY,33.0,15.2,95.0,99.0,1126.0,Government,Secondary,972.0,-37.819878,145.070325
 Canterbury Girls Sec College,45366.0,2016,CANTERBURY,32.0,15.8,96.0,99.0,1125.0,Government,Secondary,984.0,-37.819878,145.070325
@@ -793,7 +819,7 @@ Canterbury Girls Sec College,45366.0,2019,CANTERBURY,32.0,12.4,86.9,100.0,1124.0
 Canterbury Girls Sec College,45366.0,2020,CANTERBURY,33.0,12.1,87.7,100.0,1122.0,Government,Secondary,1018.0,-37.819878,145.070325
 Canterbury Girls Sec College,45366.0,2021,CANTERBURY,33.0,13.7,89.9,100.0,1127.0,Government,Secondary,980.0,-37.819878,145.070325
 Canterbury Girls Sec College,45366.0,2022,CANTERBURY,32.0,14.3,85.2,99.0,1131.0,Government,Secondary,876.0,-37.819878,145.070325
-Canterbury Girls Sec College,,2023,CANTERBURY,32.0,12.8,83.4,100.0,,,,,,
+Canterbury Girls Sec College,45366.0,2023,CANTERBURY,32.0,12.8,83.4,100.0,,,,,,
 Carey Baptist Grammar School,46186.0,2014,KEW,33.0,15.0,97.0,100.0,1179.0,Independent,Combined,2166.0,-37.8158,145.048
 Carey Baptist Grammar School,46186.0,2015,KEW,34.0,14.5,99.0,100.0,1181.0,Independent,Combined,2174.0,-37.8158,145.048
 Carey Baptist Grammar School,46186.0,2016,KEW,34.0,13.6,99.0,99.0,1185.0,Independent,Combined,2161.0,-37.8158,145.048
@@ -803,7 +829,7 @@ Carey Baptist Grammar School,46186.0,2019,KEW,33.0,12.9,94.9,100.0,1164.0,Indepe
 Carey Baptist Grammar School,46186.0,2020,KEW,33.0,11.9,97.8,100.0,1164.0,Independent,Combined,2400.0,-37.8158,145.048
 Carey Baptist Grammar School,46186.0,2021,KEW,34.0,17.2,97.3,100.0,1167.0,Independent,Combined,2434.0,-37.8158,145.048
 Carey Baptist Grammar School,46186.0,2022,KEW,33.0,14.2,96.7,100.0,1182.0,Independent,Combined,2509.0,-37.8158,145.048
-Carey Baptist Grammar School,,2023,KEW,33.0,11.2,96.7,100.0,,,,,,
+Carey Baptist Grammar School,46186.0,2023,KEW,33.0,11.2,96.7,100.0,,,,,,
 Caroline Chisholm Catholic Coll,40900.0,2014,BRAYBROOK,29.0,4.0,97.0,100.0,957.0,Catholic,Secondary,1485.0,-37.7862764343929,144.84960932540906
 Caroline Chisholm Catholic Coll,40900.0,2015,BRAYBROOK,29.0,5.2,94.0,100.0,980.0,Catholic,Secondary,1469.0,-37.7862764343929,144.84960932540906
 Caroline Chisholm Catholic Coll,40900.0,2016,BRAYBROOK,30.0,4.4,91.0,99.0,979.0,Catholic,Secondary,1461.0,-37.7862764343929,144.84960932540906
@@ -812,7 +838,7 @@ Caroline Chisholm Catholic Coll,40900.0,2019,BRAYBROOK,28.0,2.6,94.0,98.0,1002.0
 Caroline Chisholm Catholic Coll,40900.0,2020,BRAYBROOK,28.0,4.0,89.4,98.0,1011.0,Catholic,Secondary,1398.0,-37.7862764343929,144.84960932540906
 Caroline Chisholm Catholic Coll,40900.0,2021,BRAYBROOK,28.0,4.3,90.5,99.0,1017.0,Catholic,Secondary,1449.0,-37.7862764343929,144.84960932540906
 Caroline Chisholm Catholic Coll,40900.0,2022,BRAYBROOK,29.0,4.5,91.5,99.0,1022.0,Catholic,Secondary,1452.0,-37.7862764343929,144.84960932540906
-Caroline Chisholm Catholic Coll,,2023,BRAYBROOK,30.0,5.9,83.4,98.0,,,,,,
+Caroline Chisholm Catholic Coll,40900.0,2023,BRAYBROOK,30.0,5.9,83.4,98.0,,,,,,
 Caroline Chisholm Catholic College,40900.0,2017,BRAYBROOK,30.0,5.1,89.0,99.0,985.0,Catholic,Secondary,1451.0,-37.7862764343929,144.84960932540906
 Carrum Downs Sec College,45482.0,2014,CARRUM DOWNS,25.0,0.6,89.0,97.0,961.0,Government,Secondary,922.0,-38.094091,145.198245
 Carrum Downs Sec College,45482.0,2015,CARRUM DOWNS,24.0,0.7,87.0,93.0,964.0,Government,Secondary,914.0,-38.094091,145.198245
@@ -823,7 +849,7 @@ Carrum Downs Sec College,45482.0,2019,CARRUM DOWNS,25.0,0.0,76.1,97.0,970.0,Gove
 Carrum Downs Sec College,45482.0,2020,CARRUM DOWNS,25.0,0.6,80.0,98.0,970.0,Government,Secondary,912.0,-38.094091,145.198245
 Carrum Downs Sec College,45482.0,2021,CARRUM DOWNS,23.0,0.0,55.8,88.0,969.0,Government,Secondary,860.0,-38.094091,145.198245
 Carrum Downs Sec College,45482.0,2022,CARRUM DOWNS,24.0,1.6,60.4,99.0,968.0,Government,Secondary,869.0,-38.094091,145.198245
-Carrum Downs Sec College,,2023,CARRUM DOWNS,24.0,0.4,45.9,94.0,,,,,,
+Carrum Downs Sec College,45482.0,2023,CARRUM DOWNS,24.0,0.4,45.9,94.0,,,,,,
 Carwatha College P-12,45225.0,2014,NOBLE PARK NORTH,26.0,1.9,84.0,91.0,962.0,Government,Combined,840.0,-37.94245361,145.1891273
 Carwatha College P-12,45225.0,2015,NOBLE PARK NORTH,25.0,1.6,89.0,97.0,958.0,Government,Combined,752.0,-37.94245361,145.1891273
 Carwatha College P-12,45225.0,2016,NOBLE PARK NORTH,24.0,2.2,85.0,94.0,963.0,Government,Combined,692.0,-37.94245361,145.1891273
@@ -833,7 +859,7 @@ Carwatha College P-12,45225.0,2019,NOBLE PARK NORTH,26.0,3.5,81.0,98.0,970.0,Gov
 Carwatha College P-12,45225.0,2020,NOBLE PARK NORTH,27.0,2.6,80.8,100.0,970.0,Government,Combined,505.0,-37.94245361,145.1891273
 Carwatha College P-12,45225.0,2021,NOBLE PARK NORTH,27.0,3.0,79.1,95.0,961.0,Government,Combined,480.0,-37.94245361,145.1891273
 Carwatha College P-12,45225.0,2022,NOBLE PARK NORTH,27.0,3.4,83.7,100.0,965.0,Government,Combined,523.0,-37.94245361,145.1891273
-Carwatha College P-12,,2023,NOBLE PARK NORTH,26.0,1.8,70.0,98.0,,,,,,
+Carwatha College P-12,45225.0,2023,NOBLE PARK NORTH,26.0,1.8,70.0,98.0,,,,,,
 Casey Grammar School,46326.0,2014,CRANBOURNE,28.0,3.4,85.0,100.0,1043.0,Independent,Combined,778.0,-38.11029539,145.29289885
 Casey Grammar School,46326.0,2015,CRANBOURNE,27.0,3.7,88.0,100.0,1062.0,Independent,Combined,798.0,-38.11029539,145.29289885
 Casey Grammar School,46326.0,2016,CRANBOURNE,29.0,4.5,86.0,100.0,1060.0,Independent,Combined,817.0,-38.11029539,145.29289885
@@ -843,7 +869,7 @@ Casey Grammar School,46326.0,2019,CRANBOURNE,30.0,8.9,72.2,100.0,1073.0,Independ
 Casey Grammar School,46326.0,2020,CRANBOURNE,30.0,5.7,83.6,100.0,1073.0,Independent,Combined,973.0,-38.11029539,145.29289885
 Casey Grammar School,46326.0,2021,CRANBOURNE,31.0,8.3,88.6,100.0,1085.0,Independent,Combined,1025.0,-38.11029539,145.29289885
 Casey Grammar School,46326.0,2022,CRANBOURNE,29.0,5.2,81.7,100.0,1089.0,Independent,Combined,1059.0,-38.11029539,145.29289885
-Casey Grammar School,,2023,CRANBOURNE,29.0,6.4,85.6,100.0,,,,,,
+Casey Grammar School,46326.0,2023,CRANBOURNE,29.0,6.4,85.6,100.0,,,,,,
 Casterton Secondary College,45367.0,2014,CASTERTON,28.0,3.7,71.0,100.0,948.0,Government,Secondary,153.0,-37.588796,141.387493
 Casterton Secondary College,45367.0,2015,CASTERTON,30.0,10.5,75.0,100.0,941.0,Government,Secondary,160.0,-37.588796,141.387493
 Casterton Secondary College,45367.0,2016,CASTERTON,29.0,0.0,78.0,89.0,954.0,Government,Secondary,159.0,-37.588796,141.387493
@@ -853,7 +879,7 @@ Casterton Secondary College,45367.0,2019,CASTERTON,32.0,0.0,75.0,100.0,950.0,Gov
 Casterton Secondary College,45367.0,2020,CASTERTON,33.0,4.2,87.5,100.0,943.0,Government,Secondary,117.0,-37.588796,141.387493
 Casterton Secondary College,45367.0,2021,CASTERTON,29.0,10.5,55.6,100.0,941.0,Government,Secondary,121.0,-37.588796,141.387493
 Casterton Secondary College,45367.0,2022,CASTERTON,32.0,4.3,66.7,100.0,948.0,Government,Secondary,110.0,-37.588796,141.387493
-Casterton Secondary College,,2023,CASTERTON,29.0,5.5,72.7,100.0,,,,,,
+Casterton Secondary College,45367.0,2023,CASTERTON,29.0,5.5,72.7,100.0,,,,,,
 Castlemaine Secondary College,45561.0,2014,CASTLEMAINE,28.0,3.6,59.0,96.0,1020.0,Government,Secondary,655.0,-37.077088,144.214549
 Castlemaine Secondary College,45561.0,2015,CASTLEMAINE,27.0,3.1,74.0,98.0,1025.0,Government,Secondary,653.0,-37.077088,144.214549
 Castlemaine Secondary College,45561.0,2016,CASTLEMAINE,28.0,5.7,74.0,99.0,1025.0,Government,Secondary,646.0,-37.077088,144.214549
@@ -863,27 +889,27 @@ Castlemaine Secondary College,45561.0,2019,CASTLEMAINE,28.0,4.6,54.1,97.0,1028.0
 Castlemaine Secondary College,45561.0,2020,CASTLEMAINE,28.0,6.5,65.2,96.0,1033.0,Government,Secondary,714.0,-37.077088,144.214549
 Castlemaine Secondary College,45561.0,2021,CASTLEMAINE,26.0,0.7,64.5,95.0,1036.0,Government,Secondary,744.0,-37.077088,144.214549
 Castlemaine Secondary College,45561.0,2022,CASTLEMAINE,26.0,2.4,50.0,87.0,1047.0,Government,Secondary,722.0,-37.077088,144.214549
-Castlemaine Secondary College,,2023,CASTLEMAINE,27.0,2.5,50.8,97.0,,,,,,
-Cathedral College,46223.0,2014,WANGARATTA,28.0,4.6,79.0,100.0,1118.0,Independent,Secondary,1180.0,-37.783056,145.272743
-Cathedral College,46223.0,2015,WANGARATTA,26.0,0.0,91.0,100.0,1115.0,Independent,Secondary,1172.0,-37.783056,145.272743
-Cathedral College,46223.0,2016,WANGARATTA,28.0,3.2,91.0,100.0,1110.0,Independent,Secondary,1178.0,-37.783056,145.272743
-Cathedral College,46223.0,2017,WANGARATTA,29.0,5.6,65.0,97.0,1111.0,Independent,Secondary,1181.0,-37.783056,145.272743
-Cathedral College,46223.0,2018,WANGARATTA,29.0,6.6,69.7,97.0,1110.0,Independent,Secondary,1180.0,-37.783056,145.272743
-Cathedral College,46223.0,2019,WANGARATTA,27.0,1.7,85.5,100.0,1113.0,Independent,Secondary,1187.0,-37.783056,145.272743
-Cathedral College,46223.0,2020,WANGARATTA,29.0,3.3,71.8,99.0,1113.0,Independent,Secondary,1192.0,-37.783056,145.272743
-Cathedral College,46223.0,2021,WANGARATTA,30.0,4.4,59.4,100.0,1117.0,Independent,Secondary,1171.0,-37.783056,145.272743
-Cathedral College,46223.0,2022,WANGARATTA,29.0,4.2,62.0,99.0,1130.0,Independent,Secondary,1169.0,-37.783056,145.272743
-Cathedral College,,2023,WANGARATTA,29.0,2.5,69.7,100.0,,,,,,
+Castlemaine Secondary College,45561.0,2023,CASTLEMAINE,27.0,2.5,50.8,97.0,,,,,,
+Cathedral College,46373.0,2014,WANGARATTA,28.0,4.6,79.0,100.0,1057.0,Independent,Combined,388.0,-36.355626,146.321634
+Cathedral College,46373.0,2015,WANGARATTA,26.0,0.0,91.0,100.0,1053.0,Independent,Combined,547.0,-36.355626,146.321634
+Cathedral College,46373.0,2016,WANGARATTA,28.0,3.2,91.0,100.0,1055.0,Independent,Combined,718.0,-36.355626,146.321634
+Cathedral College,46373.0,2017,WANGARATTA,29.0,5.6,65.0,97.0,1055.0,Independent,Combined,814.0,-36.355626,146.321634
+Cathedral College,46373.0,2018,WANGARATTA,29.0,6.6,69.7,97.0,1060.0,Independent,Combined,890.0,-36.355626,146.321634
+Cathedral College,46373.0,2019,WANGARATTA,27.0,1.7,85.5,100.0,1059.0,Independent,Combined,970.0,-36.355626,146.321634
+Cathedral College,46373.0,2020,WANGARATTA,29.0,3.3,71.8,99.0,1069.0,Independent,Combined,1018.0,-36.355626,146.321634
+Cathedral College,46373.0,2021,WANGARATTA,30.0,4.4,59.4,100.0,1069.0,Independent,Combined,1047.0,-36.355626,146.321634
+Cathedral College,46373.0,2022,WANGARATTA,29.0,4.2,62.0,99.0,1078.0,Independent,Combined,1026.0,-36.355626,146.321634
+Cathedral College,46373.0,2023,WANGARATTA,29.0,2.5,69.7,100.0,,,,,,
 Catherine McAuley College,40412.0,2018,BENDIGO,29.0,6.5,84.6,100.0,1040.0,Catholic,Secondary,1437.0,-36.753444,144.273362
 Catherine McAuley College,40412.0,2019,BENDIGO,29.0,8.1,85.2,100.0,1038.0,Catholic,Secondary,1403.0,-36.753444,144.273362
 Catherine McAuley College,40412.0,2020,BENDIGO,29.0,6.2,78.4,99.0,1040.0,Catholic,Secondary,1406.0,-36.753444,144.273362
 Catherine McAuley College,40412.0,2021,BENDIGO,28.0,6.2,77.9,99.0,1040.0,Catholic,Secondary,1445.0,-36.753444,144.273362
 Catherine McAuley College,40412.0,2022,BENDIGO,29.0,6.5,82.3,100.0,1044.0,Catholic,Secondary,1480.0,-36.753444,144.273362
-Catherine McAuley College,,2023,BENDIGO,29.0,4.0,77.7,100.0,,,,,,
-Catholic College Bendigo,45737.0,2014,BENDIGO,30.0,5.5,95.0,100.0,922.0,Catholic,Secondary,918.0,-38.108707,147.063779
-Catholic College Bendigo,45737.0,2015,BENDIGO,29.0,4.7,87.0,99.0,995.0,Catholic,Secondary,874.0,-38.108707,147.063779
-Catholic College Bendigo,45737.0,2016,BENDIGO,29.0,4.7,88.0,99.0,917.0,Catholic,Secondary,864.0,-38.108707,147.063779
-Catholic College Bendigo,45737.0,2017,BENDIGO,29.0,4.3,88.0,100.0,1000.0,Catholic,Secondary,825.0,-38.108707,147.063779
+Catherine McAuley College,40412.0,2023,BENDIGO,29.0,4.0,77.7,100.0,,,,,,
+Catholic College Bendigo,40412.0,2014,BENDIGO,30.0,5.5,95.0,100.0,1023.0,Catholic,Secondary,1995.0,-36.753444,144.273362
+Catholic College Bendigo,40412.0,2015,BENDIGO,29.0,4.7,87.0,99.0,1041.0,Catholic,Secondary,1813.0,-36.753444,144.273362
+Catholic College Bendigo,40412.0,2016,BENDIGO,29.0,4.7,88.0,99.0,1037.0,Catholic,Secondary,1673.0,-36.753444,144.273362
+Catholic College Bendigo,40412.0,2017,BENDIGO,29.0,4.3,88.0,100.0,1038.0,Catholic,Secondary,1561.0,-36.753444,144.273362
 Catholic College Sale,45737.0,2014,SALE,29.0,3.4,76.0,99.0,922.0,Catholic,Secondary,918.0,-38.108707,147.063779
 Catholic College Sale,45737.0,2015,SALE,27.0,4.6,70.0,98.0,995.0,Catholic,Secondary,874.0,-38.108707,147.063779
 Catholic College Sale,45737.0,2016,SALE,31.0,12.1,84.0,100.0,917.0,Catholic,Secondary,864.0,-38.108707,147.063779
@@ -893,7 +919,7 @@ Catholic College Sale,45737.0,2019,SALE,29.0,8.1,68.3,100.0,1007.0,Catholic,Seco
 Catholic College Sale,45737.0,2020,SALE,28.0,5.2,68.4,99.0,996.0,Catholic,Secondary,835.0,-38.108707,147.063779
 Catholic College Sale,45737.0,2021,SALE,28.0,5.7,63.4,99.0,989.0,Catholic,Secondary,859.0,-38.108707,147.063779
 Catholic College Sale,45737.0,2022,SALE,29.0,8.4,78.0,100.0,990.0,Catholic,Secondary,870.0,-38.108707,147.063779
-Catholic College Sale,,2023,SALE,28.0,6.5,57.9,99.0,,,,,,
+Catholic College Sale,45737.0,2023,SALE,28.0,6.5,57.9,99.0,,,,,,
 Catholic College Wodonga,46043.0,2014,WODONGA,31.0,7.2,74.0,99.0,1046.0,Catholic,Secondary,1061.0,-36.12961895,146.86239014
 Catholic College Wodonga,46043.0,2015,WODONGA,31.0,4.5,75.0,100.0,964.0,Catholic,Secondary,1088.0,-36.12961895,146.86239014
 Catholic College Wodonga,46043.0,2016,WODONGA,29.0,4.9,62.0,99.0,1034.0,Catholic,Secondary,1118.0,-36.12961895,146.86239014
@@ -903,7 +929,7 @@ Catholic College Wodonga,46043.0,2019,WODONGA,28.0,2.8,65.9,100.0,1042.0,Catholi
 Catholic College Wodonga,46043.0,2020,WODONGA,29.0,3.2,64.0,99.0,1042.0,Catholic,Secondary,1210.0,-36.12961895,146.86239014
 Catholic College Wodonga,46043.0,2021,WODONGA,28.0,3.7,50.8,99.0,1046.0,Catholic,Secondary,1214.0,-36.12961895,146.86239014
 Catholic College Wodonga,46043.0,2022,WODONGA,29.0,3.8,53.0,96.0,1057.0,Catholic,Secondary,1213.0,-36.12961895,146.86239014
-Catholic College Wodonga,,2023,WODONGA,28.0,3.4,60.9,99.0,,,,,,
+Catholic College Wodonga,46043.0,2023,WODONGA,28.0,3.4,60.9,99.0,,,,,,
 Catholic Ladies College,45726.0,2014,ELTHAM,32.0,9.1,94.0,100.0,1092.0,Catholic,Secondary,947.0,-37.711525,145.143563
 Catholic Ladies College,45726.0,2015,ELTHAM,31.0,5.6,93.0,99.0,1099.0,Catholic,Secondary,916.0,-37.711525,145.143563
 Catholic Ladies College,45726.0,2016,ELTHAM,32.0,10.6,97.0,100.0,1100.0,Catholic,Secondary,912.0,-37.711525,145.143563
@@ -913,38 +939,38 @@ Catholic Ladies College,45726.0,2019,ELTHAM,31.0,7.7,94.5,100.0,1102.0,Catholic,
 Catholic Ladies College,45726.0,2020,ELTHAM,32.0,9.3,95.9,99.0,1102.0,Catholic,Secondary,755.0,-37.711525,145.143563
 Catholic Ladies College,45726.0,2021,ELTHAM,31.0,7.7,95.0,99.0,1108.0,Catholic,Secondary,765.0,-37.711525,145.143563
 Catholic Ladies College,45726.0,2022,ELTHAM,31.0,8.8,93.5,100.0,1111.0,Catholic,Secondary,762.0,-37.711525,145.143563
-Catholic Ladies College,,2023,ELTHAM,32.0,9.3,91.5,100.0,,,,,,
-Catholic Regional College,40406.0,2014,MELTON WEST,28.0,4.0,84.0,100.0,,Catholic,Secondary,756.0,-37.699136,144.771012
-Catholic Regional College,40406.0,2014,SYDENHAM,29.0,2.7,89.0,99.0,,Catholic,Secondary,756.0,-37.699136,144.771012
-Catholic Regional College,40406.0,2015,MELTON WEST,29.0,4.7,87.0,100.0,,Catholic,Secondary,793.0,-37.699136,144.771012
-Catholic Regional College,40406.0,2015,SYDENHAM,30.0,4.0,92.0,99.0,,Catholic,Secondary,793.0,-37.699136,144.771012
-Catholic Regional College,40406.0,2016,MELTON WEST,28.0,3.4,87.0,98.0,,Catholic,Secondary,902.0,-37.699136,144.771012
-Catholic Regional College,40406.0,2016,SYDENHAM,30.0,4.3,89.0,99.0,,Catholic,Secondary,902.0,-37.699136,144.771012
-Catholic Regional College,40406.0,2017,CAROLINE SPRINGS,,,,,,Catholic,Secondary,905.0,-37.699136,144.771012
-Catholic Regional College,40406.0,2017,MELTON WEST,28.0,1.8,77.0,99.0,,Catholic,Secondary,905.0,-37.699136,144.771012
-Catholic Regional College,40406.0,2017,SYDENHAM,30.0,4.0,89.0,100.0,,Catholic,Secondary,905.0,-37.699136,144.771012
-Catholic Regional College,40406.0,2018,CAROLINE SPRINGS,,,,,1015.0,Catholic,Secondary,883.0,-37.699136,144.771012
-Catholic Regional College,40406.0,2018,KEILOR NORTH,,,,,1015.0,Catholic,Secondary,883.0,-37.699136,144.771012
-Catholic Regional College,40406.0,2018,ST ALBANS,,,,,1015.0,Catholic,Secondary,883.0,-37.699136,144.771012
-Catholic Regional College,40406.0,2018,MELTON WEST,29.0,1.4,82.6,100.0,1015.0,Catholic,Secondary,883.0,-37.699136,144.771012
-Catholic Regional College,40406.0,2018,SYDENHAM,29.0,4.3,84.0,99.0,1015.0,Catholic,Secondary,883.0,-37.699136,144.771012
-Catholic Regional College,40406.0,2019,CAROLINE SPRINGS,,,,,1019.0,Catholic,Secondary,865.0,-37.699136,144.771012
-Catholic Regional College,40406.0,2019,MELTON WEST,28.0,1.2,90.1,100.0,1019.0,Catholic,Secondary,865.0,-37.699136,144.771012
-Catholic Regional College,40406.0,2019,SYDENHAM,29.0,3.9,84.6,99.0,1019.0,Catholic,Secondary,865.0,-37.699136,144.771012
-Catholic Regional College,40406.0,2020,CAROLINE SPRINGS,,,,,1015.0,Catholic,Secondary,859.0,-37.699136,144.771012
-Catholic Regional College,40406.0,2020,MELTON WEST,28.0,2.0,92.4,100.0,1015.0,Catholic,Secondary,859.0,-37.699136,144.771012
-Catholic Regional College,40406.0,2020,SYDENHAM,29.0,3.7,77.7,99.0,1015.0,Catholic,Secondary,859.0,-37.699136,144.771012
-Catholic Regional College,40406.0,2021,CAROLINE SPRINGS,,,,,1018.0,Catholic,Secondary,902.0,-37.699136,144.771012
-Catholic Regional College,40406.0,2021,MELTON WEST,28.0,3.0,74.5,99.0,1018.0,Catholic,Secondary,902.0,-37.699136,144.771012
-Catholic Regional College,40406.0,2021,SYDENHAM,28.0,2.5,81.4,100.0,1018.0,Catholic,Secondary,902.0,-37.699136,144.771012
-Catholic Regional College,40406.0,2022,CAROLINE SPRINGS,,,,,1018.0,Catholic,Secondary,903.0,-37.699136,144.771012
-Catholic Regional College,40406.0,2022,MELTON WEST,28.0,1.8,83.7,99.0,1018.0,Catholic,Secondary,903.0,-37.699136,144.771012
-Catholic Regional College,40406.0,2022,SYDENHAM,28.0,2.2,79.5,98.0,1018.0,Catholic,Secondary,903.0,-37.699136,144.771012
-Catholic Regional College,,2023,CAROLINE SPRINGS,,,,,,,,,,
-Catholic Regional College,,2023,KEILOR NORTH,,,,,,,,,,
-Catholic Regional College,,2023,ST ALBANS,,,,,,,,,,
-Catholic Regional College,,2023,SYDENHAM,27.0,2.0,73.5,99.0,,,,,,
-Catholic Regional College,,2023,MELTON WEST,27.0,1.4,67.7,98.0,,,,,,
+Catholic Ladies College,45726.0,2023,ELTHAM,32.0,9.3,91.5,100.0,,,,,,
+Catholic Regional College,46121.0,2014,MELTON WEST,28.0,4.0,84.0,100.0,1041.0,Catholic,Secondary,699.0,-37.728879,144.739602
+Catholic Regional College,46121.0,2014,SYDENHAM,29.0,2.7,89.0,99.0,1041.0,Catholic,Secondary,699.0,-37.728879,144.739602
+Catholic Regional College,46121.0,2015,MELTON WEST,29.0,4.7,87.0,100.0,1040.0,Catholic,Secondary,735.0,-37.728879,144.739602
+Catholic Regional College,46121.0,2015,SYDENHAM,30.0,4.0,92.0,99.0,1040.0,Catholic,Secondary,735.0,-37.728879,144.739602
+Catholic Regional College,46121.0,2016,MELTON WEST,28.0,3.4,87.0,98.0,1034.0,Catholic,Secondary,756.0,-37.728879,144.739602
+Catholic Regional College,46121.0,2016,SYDENHAM,30.0,4.3,89.0,99.0,1034.0,Catholic,Secondary,756.0,-37.728879,144.739602
+Catholic Regional College,46121.0,2017,CAROLINE SPRINGS,,,,,1039.0,Catholic,Secondary,812.0,-37.728879,144.739602
+Catholic Regional College,46121.0,2017,MELTON WEST,28.0,1.8,77.0,99.0,1039.0,Catholic,Secondary,812.0,-37.728879,144.739602
+Catholic Regional College,46121.0,2017,SYDENHAM,30.0,4.0,89.0,100.0,1039.0,Catholic,Secondary,812.0,-37.728879,144.739602
+Catholic Regional College,46121.0,2018,CAROLINE SPRINGS,,,,,1040.0,Catholic,Secondary,825.0,-37.728879,144.739602
+Catholic Regional College,46121.0,2018,KEILOR NORTH,,,,,1040.0,Catholic,Secondary,825.0,-37.728879,144.739602
+Catholic Regional College,46121.0,2018,ST ALBANS,,,,,1040.0,Catholic,Secondary,825.0,-37.728879,144.739602
+Catholic Regional College,46121.0,2018,MELTON WEST,29.0,1.4,82.6,100.0,1040.0,Catholic,Secondary,825.0,-37.728879,144.739602
+Catholic Regional College,46121.0,2018,SYDENHAM,29.0,4.3,84.0,99.0,1040.0,Catholic,Secondary,825.0,-37.728879,144.739602
+Catholic Regional College,46121.0,2019,CAROLINE SPRINGS,,,,,1041.0,Catholic,Secondary,880.0,-37.728879,144.739602
+Catholic Regional College,46121.0,2019,MELTON WEST,28.0,1.2,90.1,100.0,1041.0,Catholic,Secondary,880.0,-37.728879,144.739602
+Catholic Regional College,46121.0,2019,SYDENHAM,29.0,3.9,84.6,99.0,1041.0,Catholic,Secondary,880.0,-37.728879,144.739602
+Catholic Regional College,46121.0,2020,CAROLINE SPRINGS,,,,,1043.0,Catholic,Secondary,924.0,-37.728879,144.739602
+Catholic Regional College,46121.0,2020,MELTON WEST,28.0,2.0,92.4,100.0,1043.0,Catholic,Secondary,924.0,-37.728879,144.739602
+Catholic Regional College,46121.0,2020,SYDENHAM,29.0,3.7,77.7,99.0,1043.0,Catholic,Secondary,924.0,-37.728879,144.739602
+Catholic Regional College,46121.0,2021,CAROLINE SPRINGS,,,,,1040.0,Catholic,Secondary,963.0,-37.728879,144.739602
+Catholic Regional College,46121.0,2021,MELTON WEST,28.0,3.0,74.5,99.0,1040.0,Catholic,Secondary,963.0,-37.728879,144.739602
+Catholic Regional College,46121.0,2021,SYDENHAM,28.0,2.5,81.4,100.0,1040.0,Catholic,Secondary,963.0,-37.728879,144.739602
+Catholic Regional College,46121.0,2022,CAROLINE SPRINGS,,,,,1037.0,Catholic,Secondary,1001.0,-37.728879,144.739602
+Catholic Regional College,46121.0,2022,MELTON WEST,28.0,1.8,83.7,99.0,1037.0,Catholic,Secondary,1001.0,-37.728879,144.739602
+Catholic Regional College,46121.0,2022,SYDENHAM,28.0,2.2,79.5,98.0,1037.0,Catholic,Secondary,1001.0,-37.728879,144.739602
+Catholic Regional College,46121.0,2023,CAROLINE SPRINGS,,,,,,,,,,
+Catholic Regional College,46121.0,2023,KEILOR NORTH,,,,,,,,,,
+Catholic Regional College,46121.0,2023,ST ALBANS,,,,,,,,,,
+Catholic Regional College,46121.0,2023,SYDENHAM,27.0,2.0,73.5,99.0,,,,,,
+Catholic Regional College,46121.0,2023,MELTON WEST,27.0,1.4,67.7,98.0,,,,,,
 Caulfield Grammar School,46139.0,2014,WHEELERS HILL,35.0,21.9,99.0,100.0,1144.0,Independent,Combined,3059.0,-37.877377,145.004887
 Caulfield Grammar School,46139.0,2014,ST KILDA EAST,35.0,23.0,94.0,100.0,1144.0,Independent,Combined,3059.0,-37.877377,145.004887
 Caulfield Grammar School,46139.0,2015,WHEELERS HILL,34.0,21.1,99.0,100.0,1141.0,Independent,Combined,3071.0,-37.877377,145.004887
@@ -963,9 +989,10 @@ Caulfield Grammar School,46139.0,2021,WHEELERS HILL,34.0,19.6,98.2,100.0,1130.0,
 Caulfield Grammar School,46139.0,2021,ST KILDA EAST,34.0,19.4,94.3,100.0,1130.0,Independent,Combined,3148.0,-37.877377,145.004887
 Caulfield Grammar School,46139.0,2022,WHEELERS HILL,34.0,22.4,93.9,100.0,1149.0,Independent,Combined,3228.0,-37.877377,145.004887
 Caulfield Grammar School,46139.0,2022,ST KILDA EAST,34.0,19.3,96.9,100.0,1149.0,Independent,Combined,3228.0,-37.877377,145.004887
-Caulfield Grammar School,,2023,WHEELERS HILL,33.0,18.8,98.3,99.0,,,,,,
-Caulfield Grammar School,,2023,ST KILDA EAST,33.0,17.2,96.3,99.0,,,,,,
-Caulfield Park Comm School,46139.0,2014,CAULFIELD NORTH,,,,,1144.0,Independent,Combined,3059.0,-37.877377,145.004887
+Caulfield Grammar School,46139.0,2023,WHEELERS HILL,33.0,18.8,98.3,99.0,,,,,,
+Caulfield Grammar School,46139.0,2023,ST KILDA EAST,33.0,17.2,96.3,99.0,,,,,,
+Caulfield Park Comm School,45468.0,2014,CAULFIELD NORTH,,,,,917.0,Government,Secondary,431.0,-37.87398,145.034173
+Central Gippsland Inst of TAFE,,2014,NEWBOROUGH,22.0,0.0,36.0,93.0,,,,,,
 Centre for Adult Education,,2014,MELBOURNE,26.0,1.8,33.0,83.0,,,,,,
 Centre for Adult Education,,2015,MELBOURNE,26.0,2.6,35.0,87.0,,,,,,
 Centre for Adult Education,,2016,MELBOURNE,27.0,3.5,37.0,82.0,,,,,,
@@ -976,7 +1003,7 @@ Chaffey Secondary College,45337.0,2016,MILDURA,,,,,873.0,Government,Secondary,52
 Chaffey Secondary College,45337.0,2017,MILDURA,,,,,868.0,Government,Secondary,467.0,-34.19573,142.147985
 Chaffey Secondary College,45337.0,2018,MILDURA,,,,,862.0,Government,Secondary,463.0,-34.19573,142.147985
 Chaffey Secondary College,45337.0,2019,MILDURA,,,,,869.0,Government,Secondary,460.0,-34.19573,142.147985
-Chaffey Secondary College,,2023,MILDURA,,,,,,,,,,
+Chaffey Secondary College,45337.0,2023,MILDURA,,,,,,,,,,
 Chairo Christian School,46295.0,2014,DROUIN,31.0,3.2,84.0,100.0,1033.0,Independent,Combined,1181.0,-38.142837,145.877116
 Chairo Christian School,46295.0,2015,DROUIN,30.0,6.5,75.0,98.0,1033.0,Independent,Combined,1227.0,-38.142837,145.877116
 Chairo Christian School,46295.0,2016,DROUIN,29.0,4.3,76.0,98.0,1031.0,Independent,Combined,1352.0,-38.142837,145.877116
@@ -989,8 +1016,8 @@ Chairo Christian School,46295.0,2021,DROUIN,29.0,4.5,72.2,100.0,1047.0,Independe
 Chairo Christian School,46295.0,2021,NAR NAR GOON,28.0,3.5,72.7,95.0,1047.0,Independent,Combined,1553.0,-38.142837,145.877116
 Chairo Christian School,46295.0,2022,NAR NAR GOON,27.0,3.7,87.8,100.0,1051.0,Independent,Combined,1568.0,-38.142837,145.877116
 Chairo Christian School,46295.0,2022,DROUIN,28.0,4.7,66.7,100.0,1051.0,Independent,Combined,1568.0,-38.142837,145.877116
-Chairo Christian School,,2023,DROUIN,29.0,5.1,58.7,98.0,,,,,,
-Chairo Christian School,,2023,NAR NAR GOON,30.0,3.4,60.0,100.0,,,,,,
+Chairo Christian School,46295.0,2023,DROUIN,29.0,5.1,58.7,98.0,,,,,,
+Chairo Christian School,46295.0,2023,NAR NAR GOON,30.0,3.4,60.0,100.0,,,,,,
 Charles La Trobe P-12 College,45616.0,2014,PRESTON,,,,,919.0,Government,Combined,657.0,-37.72915436,145.05979101
 Charles La Trobe P-12 College,45616.0,2014,MACLEOD WEST,29.0,2.3,92.0,96.0,919.0,Government,Combined,657.0,-37.72915436,145.05979101
 Charles La Trobe P-12 College,45616.0,2015,PRESTON,,,,,922.0,Government,Combined,683.0,-37.72915436,145.05979101
@@ -1009,8 +1036,8 @@ Charles La Trobe P-12 College,45616.0,2021,PRESTON,,,,,952.0,Government,Combined
 Charles La Trobe P-12 College,45616.0,2021,MACLEOD WEST,23.0,1.3,97.1,97.0,952.0,Government,Combined,722.0,-37.72915436,145.05979101
 Charles La Trobe P-12 College,45616.0,2022,PRESTON,,,,,942.0,Government,Combined,708.0,-37.72915436,145.05979101
 Charles La Trobe P-12 College,45616.0,2022,MACLEOD WEST,24.0,1.0,95.7,96.0,942.0,Government,Combined,708.0,-37.72915436,145.05979101
-Charles La Trobe P-12 College,,2023,PRESTON,,,14.3,71.0,,,,,,
-Charles La Trobe P-12 College,,2023,MACLEOD WEST,25.0,,94.9,97.0,,,,,,
+Charles La Trobe P-12 College,45616.0,2023,PRESTON,,,14.3,71.0,,,,,,
+Charles La Trobe P-12 College,45616.0,2023,MACLEOD WEST,25.0,,94.9,97.0,,,,,,
 Charlton College,45566.0,2014,CHARLTON,31.0,8.2,78.0,100.0,967.0,Government,Combined,138.0,-36.270312,143.359633
 Charlton College,45566.0,2015,CHARLTON,33.0,17.3,100.0,100.0,967.0,Government,Combined,144.0,-36.270312,143.359633
 Charlton College,45566.0,2016,CHARLTON,31.0,21.2,100.0,100.0,963.0,Government,Combined,136.0,-36.270312,143.359633
@@ -1020,7 +1047,7 @@ Charlton College,45566.0,2019,CHARLTON,30.0,0.0,100.0,100.0,985.0,Government,Com
 Charlton College,45566.0,2020,CHARLTON,31.0,11.1,40.0,100.0,978.0,Government,Combined,143.0,-36.270312,143.359633
 Charlton College,45566.0,2021,CHARLTON,28.0,6.5,50.0,100.0,991.0,Government,Combined,156.0,-36.270312,143.359633
 Charlton College,45566.0,2022,CHARLTON,31.0,0.0,85.7,100.0,976.0,Government,Combined,140.0,-36.270312,143.359633
-Charlton College,,2023,CHARLTON,31.0,7.1,44.4,100.0,,,,,,
+Charlton College,45566.0,2023,CHARLTON,31.0,7.1,44.4,100.0,,,,,,
 Cheltenham Secondary College,45368.0,2014,CHELTENHAM,30.0,3.2,96.0,99.0,1037.0,Government,Secondary,1035.0,-37.953335,145.068585
 Cheltenham Secondary College,45368.0,2015,CHELTENHAM,29.0,5.9,90.0,100.0,1034.0,Government,Secondary,996.0,-37.953335,145.068585
 Cheltenham Secondary College,45368.0,2016,CHELTENHAM,30.0,5.1,82.0,98.0,1037.0,Government,Secondary,963.0,-37.953335,145.068585
@@ -1030,14 +1057,35 @@ Cheltenham Secondary College,45368.0,2019,CHELTENHAM,29.0,6.4,89.2,100.0,1046.0,
 Cheltenham Secondary College,45368.0,2020,CHELTENHAM,29.0,5.7,83.0,99.0,1047.0,Government,Secondary,928.0,-37.953335,145.068585
 Cheltenham Secondary College,45368.0,2021,CHELTENHAM,30.0,5.5,80.2,100.0,1045.0,Government,Secondary,893.0,-37.953335,145.068585
 Cheltenham Secondary College,45368.0,2022,CHELTENHAM,29.0,5.9,89.9,100.0,1052.0,Government,Secondary,883.0,-37.953335,145.068585
-Cheltenham Secondary College,,2023,CHELTENHAM,30.0,4.2,67.9,98.0,,,,,,
-Christian Brothers' College,46255.0,2014,ST KILDA EAST,30.0,7.2,88.0,100.0,1078.0,Independent,Combined,844.0,-37.76293666,145.3043162
-Christian Brothers' College,46255.0,2015,ST KILDA EAST,29.0,5.5,84.0,98.0,1087.0,Independent,Combined,825.0,-37.76293666,145.3043162
-Christian Brothers' College,46255.0,2016,ST KILDA EAST,29.0,2.6,85.0,99.0,1086.0,Independent,Combined,809.0,-37.76293666,145.3043162
-Christian Brothers' College,46255.0,2017,ST KILDA EAST,30.0,5.1,90.0,98.0,1088.0,Independent,Combined,827.0,-37.76293666,145.3043162
-Christian Brothers' College,46255.0,2018,ST KILDA EAST,31.0,6.7,86.7,100.0,1095.0,Independent,Combined,821.0,-37.76293666,145.3043162
-Christian Brothers' College,46255.0,2019,ST KILDA EAST,29.0,5.2,90.5,100.0,1102.0,Independent,Combined,832.0,-37.76293666,145.3043162
-Christian Brothers' College,46255.0,2020,ST KILDA EAST,29.0,4.7,90.0,100.0,1102.0,Independent,Combined,838.0,-37.76293666,145.3043162
+Cheltenham Secondary College,45368.0,2023,CHELTENHAM,30.0,4.2,67.9,98.0,,,,,,
+Chisholm Institute,,2014,FRANKSTON,23.0,0.4,47.0,86.0,,,,,,
+Chisholm Institute,,2015,FRANKSTON,24.0,0.0,44.0,82.0,,,,,,
+Chisholm Institute,,2016,FRANKSTON,24.0,0.0,43.0,75.0,,,,,,
+Chisholm Institute,,2017,FRANKSTON,25.0,0.0,50.0,82.0,,,,,,
+Chisholm Institute,,2018,FRANKSTON,24.0,0.7,52.5,83.0,,,,,,
+Chisholm Institute,,2019,FRANKSTON,25.0,0.0,46.8,82.0,,,,,,
+Chisholm Institute,,2020,FRANKSTON,23.0,2.5,29.3,72.0,,,,,,
+Chisholm Institute,,2021,FRANKSTON,23.0,0.0,47.1,90.0,,,,,,
+Chisholm Institute,,2022,FRANKSTON,23.0,0.0,45.9,100.0,,,,,,
+Chisholm Institute,,2023,FRANKSTON,22.0,3.0,25.3,89.0,,,,,,
+Chisholm Institute of TAFE,,2014,DANDENONG,23.0,0.6,48.0,80.0,,,,,,
+Chisholm Institute of TAFE,,2015,DANDENONG,22.0,0.3,47.0,87.0,,,,,,
+Chisholm Institute of TAFE,,2016,DANDENONG,19.0,0.4,39.0,91.0,,,,,,
+Chisholm Institute of TAFE,,2017,DANDENONG,21.0,0.8,44.0,78.0,,,,,,
+Chisholm Institute of TAFE,,2018,DANDENONG,20.0,0.6,36.5,87.0,,,,,,
+Chisholm Institute of TAFE,,2019,DANDENONG,21.0,0.0,53.7,98.0,,,,,,
+Chisholm Institute of TAFE,,2020,DANDENONG,21.0,0.9,54.5,100.0,,,,,,
+Chisholm Institute of TAFE,,2021,DANDENONG,23.0,0.0,28.8,75.0,,,,,,
+Chisholm Institute of TAFE,,2022,DANDENONG,24.0,0.6,65.2,93.0,,,,,,
+Chisholm Institute of TAFE,,2023,DANDENONG,20.0,0.4,28.6,86.0,,,,,,
+Christ the King Anglican Coll,46356.0,2014,COBRAM,26.0,0.0,100.0,100.0,1003.0,Independent,Combined,232.0,-35.924283,145.660055
+Christian Brothers' College,45660.0,2014,ST KILDA EAST,30.0,7.2,88.0,100.0,985.0,Catholic,Combined,396.0,-37.019895,145.140924
+Christian Brothers' College,45660.0,2015,ST KILDA EAST,29.0,5.5,84.0,98.0,1006.0,Catholic,Combined,406.0,-37.019895,145.140924
+Christian Brothers' College,45660.0,2016,ST KILDA EAST,29.0,2.6,85.0,99.0,1004.0,Catholic,Combined,388.0,-37.019895,145.140924
+Christian Brothers' College,45660.0,2017,ST KILDA EAST,30.0,5.1,90.0,98.0,996.0,Catholic,Combined,410.0,-37.019895,145.140924
+Christian Brothers' College,45660.0,2018,ST KILDA EAST,31.0,6.7,86.7,100.0,997.0,Catholic,Combined,409.0,-37.019895,145.140924
+Christian Brothers' College,45660.0,2019,ST KILDA EAST,29.0,5.2,90.5,100.0,1001.0,Catholic,Combined,400.0,-37.019895,145.140924
+Christian Brothers' College,45660.0,2020,ST KILDA EAST,29.0,4.7,90.0,100.0,998.0,Catholic,Combined,436.0,-37.019895,145.140924
 Christian College Institute,46262.0,2014,WAURN PONDS,31.0,10.2,89.0,99.0,,Independent,Combined,974.0,-38.185241,144.313073
 Christian College Institute,46262.0,2015,WAURN PONDS,32.0,8.6,84.0,99.0,,Independent,Combined,963.0,-38.185241,144.313073
 Christian College Institute,46262.0,2016,WAURN PONDS,32.0,11.1,83.0,99.0,,Independent,Combined,980.0,-38.185241,144.313073
@@ -1047,7 +1095,7 @@ Christian College Institute,46262.0,2019,WAURN PONDS,30.0,5.5,80.6,100.0,1099.0,
 Christian College Institute,46262.0,2020,WAURN PONDS,30.0,7.1,83.0,99.0,1099.0,Independent,Combined,1007.0,-38.185241,144.313073
 Christian College Institute,46262.0,2021,WAURN PONDS,30.0,5.9,86.3,100.0,1097.0,Independent,Combined,1990.0,-38.185241,144.313073
 Christian College Institute,46262.0,2022,WAURN PONDS,30.0,6.1,82.9,99.0,1094.0,Independent,Combined,1990.0,-38.185241,144.313073
-Christian College Institute,,2023,WAURN PONDS,30.0,5.9,78.2,100.0,,,,,,
+Christian College Institute,46262.0,2023,WAURN PONDS,30.0,5.9,78.2,100.0,,,,,,
 Cire Community School,51484.0,2016,YARRA JUNCTION,,,,,,Independent,Special,111.0,-37.781467,145.614423
 Cire Community School,51484.0,2017,YARRA JUNCTION,,,,,,Independent,Special,119.0,-37.781467,145.614423
 Cire Community School,51484.0,2018,YARRA JUNCTION,,,,,,Independent,Special,138.0,-37.781467,145.614423
@@ -1055,7 +1103,7 @@ Cire Community School,51484.0,2019,YARRA JUNCTION,,,,,,Independent,Special,151.0
 Cire Community School,51484.0,2020,YARRA JUNCTION,,,,,,Independent,Special,184.0,-37.7573,145.3506
 Cire Community School,51484.0,2021,YARRA JUNCTION,,,,,985.0,Independent,Special,266.0,-37.7573,145.3506
 Cire Community School,51484.0,2022,YARRA JUNCTION,,,,,983.0,Independent,Special,363.0,-37.7573,145.3506
-Cire Community School,,2023,YARRA JUNCTION,,,,31.0,,,,,,
+Cire Community School,51484.0,2023,YARRA JUNCTION,,,,31.0,,,,,,
 Clonard College,45909.0,2014,GEELONG WEST,30.0,5.9,89.0,99.0,1001.0,Catholic,Secondary,822.0,-38.129766,144.33003
 Clonard College,45909.0,2015,GEELONG WEST,32.0,6.8,84.0,97.0,1023.0,Catholic,Secondary,817.0,-38.129766,144.33003
 Clonard College,45909.0,2016,GEELONG WEST,30.0,4.6,88.0,98.0,1028.0,Catholic,Secondary,844.0,-38.129766,144.33003
@@ -1065,7 +1113,7 @@ Clonard College,45909.0,2019,HERNE HILL,30.0,7.0,71.7,99.0,1040.0,Catholic,Secon
 Clonard College,45909.0,2020,HERNE HILL,30.0,5.6,80.7,100.0,1043.0,Catholic,Secondary,919.0,-38.129766,144.33003
 Clonard College,45909.0,2021,HERNE HILL,29.0,5.9,71.2,99.0,1047.0,Catholic,Secondary,929.0,-38.129766,144.33003
 Clonard College,45909.0,2022,HERNE HILL,29.0,4.5,79.5,98.0,1046.0,Catholic,Secondary,935.0,-38.129766,144.33003
-Clonard College,,2023,HERNE HILL,30.0,5.8,70.0,98.0,,,,,,
+Clonard College,45909.0,2023,HERNE HILL,30.0,5.8,70.0,98.0,,,,,,
 Cobden Technical School,45327.0,2014,COBDEN,24.0,0.0,95.0,100.0,942.0,Government,Secondary,320.0,-38.32403633,143.06360586
 Cobden Technical School,45327.0,2015,COBDEN,22.0,0.5,87.0,97.0,939.0,Government,Secondary,294.0,-38.32403633,143.06360586
 Cobden Technical School,45327.0,2016,COBDEN,20.0,0.0,64.0,100.0,940.0,Government,Secondary,262.0,-38.32403633,143.06360586
@@ -1075,7 +1123,7 @@ Cobden Technical School,45327.0,2019,COBDEN,23.0,0.0,75.0,100.0,955.0,Government
 Cobden Technical School,45327.0,2020,COBDEN,25.0,0.0,75.0,100.0,938.0,Government,Secondary,117.0,-38.32403633,143.06360586
 Cobden Technical School,45327.0,2021,COBDEN,31.0,0.0,0.0,100.0,942.0,Government,Secondary,128.0,-38.32403633,143.06360586
 Cobden Technical School,45327.0,2022,COBDEN,22.0,0.0,16.7,92.0,922.0,Government,Secondary,102.0,-38.32403633,143.06360586
-Cobden Technical School,,2023,COBDEN,27.0,,40.0,100.0,,,,,,
+Cobden Technical School,45327.0,2023,COBDEN,27.0,,40.0,100.0,,,,,,
 Cobram Anglican Grammar School,46356.0,2015,COBRAM,25.0,1.9,89.0,100.0,1027.0,Independent,Combined,232.0,-35.924283,145.660055
 Cobram Anglican Grammar School,46356.0,2016,COBRAM,28.0,8.3,85.0,100.0,1020.0,Independent,Combined,270.0,-35.924283,145.660055
 Cobram Anglican Grammar School,46356.0,2017,COBRAM,26.0,3.1,80.0,100.0,1012.0,Independent,Combined,329.0,-35.924283,145.660055
@@ -1084,7 +1132,7 @@ Cobram Anglican Grammar School,46356.0,2019,COBRAM,27.0,0.0,88.9,78.0,1014.0,Ind
 Cobram Anglican Grammar School,46356.0,2020,COBRAM,27.0,1.5,76.9,92.0,1014.0,Independent,Combined,391.0,-35.924283,145.660055
 Cobram Anglican Grammar School,46356.0,2021,COBRAM,27.0,6.3,76.5,100.0,1009.0,Independent,Combined,402.0,-35.924283,145.660055
 Cobram Anglican Grammar School,46356.0,2022,COBRAM,26.0,2.8,61.5,100.0,1005.0,Independent,Combined,394.0,-35.924283,145.660055
-Cobram Anglican Grammar School,,2023,COBRAM,28.0,9.7,59.1,95.0,,,,,,
+Cobram Anglican Grammar School,46356.0,2023,COBRAM,28.0,9.7,59.1,95.0,,,,,,
 Cobram Secondary College,45369.0,2014,COBRAM,28.0,5.6,90.0,100.0,955.0,Government,Secondary,455.0,-35.913605,145.654121
 Cobram Secondary College,45369.0,2015,COBRAM,29.0,2.2,71.0,90.0,950.0,Government,Secondary,439.0,-35.913605,145.654121
 Cobram Secondary College,45369.0,2016,COBRAM,28.0,0.5,88.0,98.0,944.0,Government,Secondary,404.0,-35.913605,145.654121
@@ -1094,7 +1142,7 @@ Cobram Secondary College,45369.0,2019,COBRAM,28.0,1.7,71.4,100.0,954.0,Governmen
 Cobram Secondary College,45369.0,2020,COBRAM,26.0,0.9,78.6,100.0,959.0,Government,Secondary,361.0,-35.913605,145.654121
 Cobram Secondary College,45369.0,2021,COBRAM,28.0,0.0,70.0,95.0,963.0,Government,Secondary,355.0,-35.913605,145.654121
 Cobram Secondary College,45369.0,2022,COBRAM,24.0,2.0,56.5,83.0,956.0,Government,Secondary,384.0,-35.913605,145.654121
-Cobram Secondary College,,2023,COBRAM,27.0,2.6,43.3,100.0,,,,,,
+Cobram Secondary College,45369.0,2023,COBRAM,27.0,2.6,43.3,100.0,,,,,,
 Coburg High School,40780.0,2015,COBURG,28.0,4.3,83.0,100.0,1039.0,Government,Secondary,256.0,-37.740781,144.972778
 Coburg High School,40780.0,2016,COBURG,29.0,3.4,67.0,100.0,1044.0,Government,Secondary,406.0,-37.740781,144.972778
 Coburg High School,40780.0,2017,COBURG,30.0,8.0,63.0,100.0,1045.0,Government,Secondary,532.0,-37.740781,144.972778
@@ -1103,7 +1151,7 @@ Coburg High School,40780.0,2019,COBURG,29.0,9.1,,,1061.0,Government,Secondary,86
 Coburg High School,40780.0,2020,COBURG,28.0,3.2,92.5,100.0,1062.0,Government,Secondary,1048.0,-37.740781,144.972778
 Coburg High School,40780.0,2021,COBURG,29.0,6.1,89.6,95.0,1072.0,Government,Secondary,1125.0,-37.740781,144.972778
 Coburg High School,40780.0,2022,COBURG,28.0,2.8,85.3,99.0,1088.0,Government,Secondary,1211.0,-37.740781,144.972778
-Coburg High School,,2023,COBURG,29.0,2.7,82.7,97.0,,,,,,
+Coburg High School,40780.0,2023,COBURG,29.0,2.7,82.7,97.0,,,,,,
 Coburg Senior High School,40780.0,2014,COBURG,28.0,4.1,87.0,92.0,,Government,Secondary,129.0,-37.740781,144.972778
 Cohuna Secondary College,45370.0,2014,COHUNA,28.0,3.4,83.0,97.0,990.0,Government,Secondary,287.0,-35.813503,144.226425
 Cohuna Secondary College,45370.0,2015,COHUNA,28.0,3.5,93.0,100.0,995.0,Government,Secondary,269.0,-35.813503,144.226425
@@ -1114,7 +1162,7 @@ Cohuna Secondary College,45370.0,2019,COHUNA,29.0,9.9,76.7,97.0,972.0,Government
 Cohuna Secondary College,45370.0,2020,COHUNA,27.0,2.7,75.0,93.0,978.0,Government,Secondary,191.0,-35.813503,144.226425
 Cohuna Secondary College,45370.0,2021,COHUNA,26.0,1.9,71.4,95.0,981.0,Government,Secondary,194.0,-35.813503,144.226425
 Cohuna Secondary College,45370.0,2022,COHUNA,28.0,8.5,73.3,100.0,975.0,Government,Secondary,185.0,-35.813503,144.226425
-Cohuna Secondary College,,2023,COHUNA,28.0,2.3,85.7,100.0,,,,,,
+Cohuna Secondary College,45370.0,2023,COHUNA,28.0,2.3,85.7,100.0,,,,,,
 Colac Secondary College,45593.0,2014,COLAC,26.0,2.1,56.0,94.0,944.0,Government,Secondary,556.0,-38.35149548,143.59010207
 Colac Secondary College,45593.0,2015,COLAC,22.0,0.0,39.0,78.0,935.0,Government,Secondary,532.0,-38.35149548,143.59010207
 Colac Secondary College,45593.0,2016,COLAC,24.0,1.5,48.0,89.0,937.0,Government,Secondary,519.0,-38.35149548,143.59010207
@@ -1124,7 +1172,7 @@ Colac Secondary College,45593.0,2019,COLAC,24.0,1.3,27.5,95.0,935.0,Government,S
 Colac Secondary College,45593.0,2020,COLAC,24.0,1.1,46.5,88.0,936.0,Government,Secondary,462.0,-38.35149548,143.59010207
 Colac Secondary College,45593.0,2021,COLAC,24.0,0.0,38.9,92.0,939.0,Government,Secondary,469.0,-38.35149548,143.59010207
 Colac Secondary College,45593.0,2022,COLAC,23.0,0.6,72.2,94.0,932.0,Government,Secondary,475.0,-38.35149548,143.59010207
-Colac Secondary College,,2023,COLAC,25.0,,41.5,90.0,,,,,,
+Colac Secondary College,45593.0,2023,COLAC,25.0,,41.5,90.0,,,,,,
 Collingwood College,45296.0,2014,COLLINGWOOD,25.0,1.0,60.0,80.0,1061.0,Government,Combined,686.0,-37.802985,144.990497
 Collingwood College,45296.0,2015,COLLINGWOOD,26.0,8.4,74.0,89.0,1067.0,Government,Combined,728.0,-37.802985,144.990497
 Collingwood College,45296.0,2016,COLLINGWOOD,27.0,4.9,66.0,84.0,1071.0,Government,Combined,809.0,-37.802985,144.990497
@@ -1134,8 +1182,8 @@ Collingwood College,45296.0,2019,COLLINGWOOD,27.0,7.5,65.6,97.0,1048.0,Governmen
 Collingwood College,45296.0,2020,COLLINGWOOD,28.0,4.5,85.2,96.0,1041.0,Government,Combined,806.0,-37.802985,144.990497
 Collingwood College,45296.0,2021,COLLINGWOOD,27.0,3.8,89.1,98.0,1041.0,Government,Combined,742.0,-37.802985,144.990497
 Collingwood College,45296.0,2022,COLLINGWOOD,27.0,2.8,55.7,93.0,1037.0,Government,Combined,730.0,-37.802985,144.990497
-Collingwood College,,2023,FITZROY NORTH,26.0,2.2,63.5,98.0,,,,,,
-Community College Gippsland,45710.0,2022,WARRAGUL,,,,,1018.0,Catholic,Secondary,762.0,-38.35120596,143.57874347
+Collingwood College,45296.0,2023,FITZROY NORTH,26.0,2.2,63.5,98.0,,,,,,
+Community College Gippsland,,2022,WARRAGUL,,,,,,,,,,
 Community College Gippsland,,2023,WARRAGUL,,,,44.0,,,,,,
 Copperfield College,40689.0,2014,DELAHEY,28.0,1.5,93.0,94.0,938.0,Government,Secondary,1829.0,-37.719607,144.772454
 Copperfield College,40689.0,2015,DELAHEY,28.0,2.0,97.0,99.0,944.0,Government,Secondary,1919.0,-37.719607,144.772454
@@ -1146,7 +1194,7 @@ Copperfield College,40689.0,2019,DELAHEY,28.0,1.7,80.1,91.0,959.0,Government,Sec
 Copperfield College,40689.0,2020,DELAHEY,27.0,2.2,87.2,97.0,959.0,Government,Secondary,2232.0,-37.719607,144.772454
 Copperfield College,40689.0,2021,DELAHEY,28.0,3.0,86.9,94.0,958.0,Government,Secondary,2148.0,-37.719607,144.772454
 Copperfield College,40689.0,2022,DELAHEY,28.0,1.9,80.6,95.0,952.0,Government,Secondary,2036.0,-37.719607,144.772454
-Copperfield College,,2023,DELAHEY,27.0,2.7,55.7,94.0,,,,,,
+Copperfield College,40689.0,2023,DELAHEY,27.0,2.7,55.7,94.0,,,,,,
 Cornish College,50513.0,2014,BANGHOLME,33.0,25.0,,,,Independent,Combined,426.0,-38.046915,145.149807
 Cornish College,50513.0,2015,BANGHOLME,31.0,15.3,100.0,100.0,,Independent,Combined,500.0,-38.046915,145.149807
 Cornish College,50513.0,2016,BANGHOLME,29.0,3.6,100.0,100.0,,Independent,Combined,572.0,-38.046915,145.149807
@@ -1156,7 +1204,7 @@ Cornish College,50513.0,2019,BANGHOLME,28.0,2.0,91.9,98.0,1089.0,Independent,Com
 Cornish College,50513.0,2020,BANGHOLME,29.0,5.3,91.9,100.0,1089.0,Independent,Combined,631.0,-38.048641,145.150451
 Cornish College,50513.0,2021,BANGHOLME,30.0,3.2,70.9,100.0,1120.0,Independent,Combined,643.0,-38.048641,145.150451
 Cornish College,50513.0,2022,BANGHOLME,31.0,4.5,94.5,100.0,1121.0,Independent,Combined,646.0,-38.048641,145.150451
-Cornish College,,2023,BANGHOLME,28.0,3.6,85.2,100.0,,,,,,
+Cornish College,50513.0,2023,BANGHOLME,28.0,3.6,85.2,100.0,,,,,,
 Corryong College,45576.0,2014,CORRYONG,32.0,9.6,100.0,100.0,997.0,Government,Combined,316.0,-36.192938,147.910757
 Corryong College,45576.0,2015,CORRYONG,31.0,13.4,78.0,96.0,984.0,Government,Combined,328.0,-36.192938,147.910757
 Corryong College,45576.0,2016,CORRYONG,32.0,11.0,78.0,100.0,992.0,Government,Combined,321.0,-36.192938,147.910757
@@ -1166,7 +1214,7 @@ Corryong College,45576.0,2019,CORRYONG,30.0,7.5,68.8,100.0,981.0,Government,Comb
 Corryong College,45576.0,2020,CORRYONG,31.0,9.2,29.4,88.0,986.0,Government,Combined,279.0,-36.192938,147.910757
 Corryong College,45576.0,2021,CORRYONG,31.0,10.0,46.7,100.0,982.0,Government,Combined,286.0,-36.192938,147.910757
 Corryong College,45576.0,2022,CORRYONG,34.0,16.3,23.1,100.0,979.0,Government,Combined,290.0,-36.192938,147.910757
-Corryong College,,2023,CORRYONG,34.0,15.4,50.0,100.0,,,,,,
+Corryong College,45576.0,2023,CORRYONG,34.0,15.4,50.0,100.0,,,,,,
 Covenant College,46257.0,2014,BELL POST HILL,30.0,8.3,68.0,100.0,1056.0,Independent,Combined,492.0,-38.0976,144.318015
 Covenant College,46257.0,2015,BELL POST HILL,30.0,7.2,68.0,93.0,1058.0,Independent,Combined,529.0,-38.0976,144.318015
 Covenant College,46257.0,2016,BELL POST HILL,28.0,5.4,64.0,100.0,1051.0,Independent,Combined,564.0,-38.0976,144.318015
@@ -1176,7 +1224,7 @@ Covenant College,46257.0,2019,BELL POST HILL,30.0,9.5,81.1,100.0,1050.0,Independ
 Covenant College,46257.0,2020,BELL POST HILL,30.0,8.0,74.3,100.0,1050.0,Independent,Combined,687.0,-38.0976,144.318015
 Covenant College,46257.0,2021,BELL POST HILL,30.0,9.6,75.0,100.0,1053.0,Independent,Combined,702.0,-38.0976,144.318015
 Covenant College,46257.0,2022,BELL POST HILL,28.0,6.4,70.3,100.0,1060.0,Independent,Combined,688.0,-38.0976,144.318015
-Covenant College,,2023,BELL POST HILL,28.0,1.1,62.2,96.0,,,,,,
+Covenant College,46257.0,2023,BELL POST HILL,28.0,1.1,62.2,96.0,,,,,,
 Craigieburn Secondary College,45496.0,2014,CRAIGIEBURN,25.0,1.0,78.0,97.0,935.0,Government,Secondary,793.0,-37.60861754,144.93558169
 Craigieburn Secondary College,45496.0,2015,CRAIGIEBURN,24.0,0.5,73.0,96.0,936.0,Government,Secondary,771.0,-37.60861754,144.93558169
 Craigieburn Secondary College,45496.0,2016,CRAIGIEBURN,24.0,1.8,84.0,98.0,936.0,Government,Secondary,811.0,-37.60861754,144.93558169
@@ -1186,7 +1234,7 @@ Craigieburn Secondary College,45496.0,2019,CRAIGIEBURN,23.0,1.5,83.3,94.0,939.0,
 Craigieburn Secondary College,45496.0,2020,CRAIGIEBURN,22.0,1.1,78.3,96.0,938.0,Government,Secondary,1151.0,-37.60861754,144.93558169
 Craigieburn Secondary College,45496.0,2021,CRAIGIEBURN,22.0,1.4,59.8,96.0,934.0,Government,Secondary,1185.0,-37.60861754,144.93558169
 Craigieburn Secondary College,45496.0,2022,CRAIGIEBURN,22.0,0.0,79.8,98.0,925.0,Government,Secondary,1098.0,-37.60861754,144.93558169
-Craigieburn Secondary College,,2023,CRAIGIEBURN,21.0,0.2,68.2,95.0,,,,,,
+Craigieburn Secondary College,45496.0,2023,CRAIGIEBURN,21.0,0.2,68.2,95.0,,,,,,
 Cranbourne East Sec College,50278.0,2014,CRANBOURNE EAST,,,,,977.0,Government,Secondary,810.0,-38.104873,145.306032
 Cranbourne East Sec College,50278.0,2015,CRANBOURNE EAST,26.0,3.2,,,976.0,Government,Secondary,994.0,-38.104873,145.306032
 Cranbourne East Sec College,50278.0,2016,CRANBOURNE EAST,27.0,0.7,88.0,97.0,982.0,Government,Secondary,1089.0,-38.104873,145.306032
@@ -1196,7 +1244,7 @@ Cranbourne East Sec College,50278.0,2019,CRANBOURNE EAST,30.0,2.1,96.9,97.0,984.
 Cranbourne East Sec College,50278.0,2020,CRANBOURNE EAST,31.0,8.3,94.1,100.0,982.0,Government,Secondary,1539.0,-38.104873,145.306032
 Cranbourne East Sec College,50278.0,2021,CRANBOURNE EAST,32.0,9.4,97.4,99.0,977.0,Government,Secondary,1702.0,-38.104873,145.306032
 Cranbourne East Sec College,50278.0,2022,CRANBOURNE EAST,33.0,10.6,97.7,100.0,976.0,Government,Secondary,1829.0,-38.104873,145.306032
-Cranbourne East Sec College,,2023,CRANBOURNE EAST,33.0,9.5,52.3,98.0,,,,,,
+Cranbourne East Sec College,50278.0,2023,CRANBOURNE EAST,33.0,9.5,52.3,98.0,,,,,,
 Cranbourne Secondary College,45372.0,2014,CRANBOURNE,27.0,1.1,80.0,99.0,945.0,Government,Secondary,1340.0,-38.108126,145.286641
 Cranbourne Secondary College,45372.0,2015,CRANBOURNE,27.0,2.3,86.0,97.0,946.0,Government,Secondary,1365.0,-38.108126,145.286641
 Cranbourne Secondary College,45372.0,2016,CRANBOURNE,27.0,2.7,79.0,95.0,937.0,Government,Secondary,1359.0,-38.108126,145.286641
@@ -1206,7 +1254,7 @@ Cranbourne Secondary College,45372.0,2019,CRANBOURNE,27.0,1.5,97.4,100.0,938.0,G
 Cranbourne Secondary College,45372.0,2020,CRANBOURNE,28.0,2.9,89.0,99.0,933.0,Government,Secondary,1428.0,-38.108126,145.286641
 Cranbourne Secondary College,45372.0,2021,CRANBOURNE,25.0,0.7,80.0,99.0,930.0,Government,Secondary,1357.0,-38.108126,145.286641
 Cranbourne Secondary College,45372.0,2022,CRANBOURNE,26.0,0.9,92.5,99.0,918.0,Government,Secondary,1272.0,-38.108126,145.286641
-Cranbourne Secondary College,,2023,CRANBOURNE,25.0,0.2,54.4,92.0,,,,,,
+Cranbourne Secondary College,45372.0,2023,CRANBOURNE,25.0,0.2,54.4,92.0,,,,,,
 Croydon Community School,45374.0,2014,CROYDON,,,,,708.0,Government,Secondary,110.0,-37.798422,145.278928
 Croydon Community School,45374.0,2015,CROYDON,,,,,938.0,Government,Secondary,118.0,-37.798422,145.278928
 Croydon Community School,45374.0,2016,CROYDON,,,,,937.0,Government,Secondary,125.0,-37.798422,145.278928
@@ -1216,10 +1264,10 @@ Croydon Community School,45374.0,2019,CROYDON,,,,,936.0,Government,Secondary,144
 Croydon Community School,45374.0,2020,CROYDON,,,,,940.0,Government,Secondary,146.0,-37.798422,145.278928
 Croydon Community School,45374.0,2021,CROYDON,,,,,935.0,Government,Secondary,131.0,-37.7893876,145.2807261
 Croydon Community School,45374.0,2022,CROYDON,,,,,936.0,Government,Secondary,117.0,-37.7893876,145.2807261
-Croydon Community School,,2023,CROYDON,,,,75.0,,,,,,
+Croydon Community School,45374.0,2023,CROYDON,,,,75.0,,,,,,
 Crusoe 7-10 Secondary College,45333.0,2021,KANGAROO FLAT,,,,,965.0,Government,Secondary,811.0,-36.79075,144.234183
 Crusoe 7-10 Secondary College,45333.0,2022,KANGAROO FLAT,,,,,961.0,Government,Secondary,856.0,-36.79075,144.234183
-Crusoe 7-10 Secondary College,,2023,KANGAROO FLAT,,,,,,,,,,
+Crusoe 7-10 Secondary College,45333.0,2023,KANGAROO FLAT,,,,,,,,,,
 Damascus College,45679.0,2014,MOUNT CLEAR,27.0,2.7,65.0,98.0,1032.0,Catholic,Secondary,1029.0,-37.611456,143.870347
 Damascus College,45679.0,2015,MOUNT CLEAR,28.0,3.6,70.0,100.0,1039.0,Catholic,Secondary,990.0,-37.611456,143.870347
 Damascus College,45679.0,2016,MOUNT CLEAR,28.0,3.0,69.0,100.0,1038.0,Catholic,Secondary,1029.0,-37.611456,143.870347
@@ -1229,7 +1277,7 @@ Damascus College,45679.0,2019,MOUNT CLEAR,28.0,3.7,70.8,98.0,1049.0,Catholic,Sec
 Damascus College,45679.0,2020,MOUNT CLEAR,28.0,2.9,77.7,99.0,1051.0,Catholic,Secondary,1117.0,-37.611456,143.870347
 Damascus College,45679.0,2021,MOUNT CLEAR,28.0,3.0,76.0,99.0,1052.0,Catholic,Secondary,1143.0,-37.611456,143.870347
 Damascus College,45679.0,2022,MOUNT CLEAR,28.0,3.7,80.0,98.0,1052.0,Catholic,Secondary,1140.0,-37.611456,143.870347
-Damascus College,,2023,MOUNT CLEAR,28.0,3.8,62.7,99.0,,,,,,
+Damascus College,45679.0,2023,MOUNT CLEAR,28.0,3.8,62.7,99.0,,,,,,
 Dandenong High School,45588.0,2014,DANDENONG,25.0,1.0,94.0,98.0,922.0,Government,Secondary,1931.0,-37.979418,145.209011
 Dandenong High School,45588.0,2015,DANDENONG,25.0,1.3,91.0,96.0,920.0,Government,Secondary,1920.0,-37.979418,145.209011
 Dandenong High School,45588.0,2016,DANDENONG,24.0,0.8,88.0,96.0,910.0,Government,Secondary,1823.0,-37.979418,145.209011
@@ -1239,7 +1287,7 @@ Dandenong High School,45588.0,2019,DANDENONG,24.0,0.8,88.5,98.0,909.0,Government
 Dandenong High School,45588.0,2020,DANDENONG,24.0,1.6,88.2,97.0,911.0,Government,Secondary,1603.0,-37.979418,145.209011
 Dandenong High School,45588.0,2021,DANDENONG,26.0,1.3,78.2,93.0,907.0,Government,Secondary,1555.0,-37.979418,145.209011
 Dandenong High School,45588.0,2022,DANDENONG,25.0,0.7,74.8,92.0,895.0,Government,Secondary,1519.0,-37.979418,145.209011
-Dandenong High School,,2023,DANDENONG,25.0,1.1,67.3,94.0,,,,,,
+Dandenong High School,45588.0,2023,DANDENONG,25.0,1.1,67.3,94.0,,,,,,
 Darul Ulum College of Victoria,46345.0,2014,FAWKNER,29.0,2.2,71.0,97.0,,Independent,Combined,950.0,-37.705621,144.971191
 Darul Ulum College of Victoria,46345.0,2015,FAWKNER,27.0,1.8,55.0,100.0,,Independent,Combined,943.0,-37.705621,144.971191
 Darul Ulum College of Victoria,46345.0,2016,FAWKNER,29.0,2.5,71.0,98.0,,Independent,Combined,1010.0,-37.705621,144.971191
@@ -1249,8 +1297,8 @@ Darul Ulum College of Victoria,46345.0,2019,FAWKNER,31.0,8.2,51.3,100.0,1031.0,I
 Darul Ulum College of Victoria,46345.0,2020,FAWKNER,31.0,14.0,59.1,100.0,1030.0,Independent,Combined,1189.0,-37.705621,144.971191
 Darul Ulum College of Victoria,46345.0,2021,FAWKNER,31.0,6.8,67.8,98.0,1026.0,Independent,Combined,1260.0,-37.705621,144.971191
 Darul Ulum College of Victoria,46345.0,2022,FAWKNER,32.0,7.9,59.7,100.0,1027.0,Independent,Combined,1321.0,-37.705621,144.971191
-Darul Ulum College of Victoria,,2023,FAWKNER,32.0,13.4,53.4,100.0,,,,,,
-Daylesford Neighb'hood Centre,45329.0,2014,DAYLESFORD,,,,,989.0,Government,Secondary,462.0,-37.33466597,144.15185097
+Darul Ulum College of Victoria,46345.0,2023,FAWKNER,32.0,13.4,53.4,100.0,,,,,,
+Daylesford Neighb'hood Centre,,2014,DAYLESFORD,,,,,,,,,,
 Daylesford Secondary College,45329.0,2014,DAYLESFORD,25.0,0.5,56.0,90.0,989.0,Government,Secondary,462.0,-37.33466597,144.15185097
 Daylesford Secondary College,45329.0,2015,DAYLESFORD,27.0,2.3,75.0,93.0,996.0,Government,Secondary,450.0,-37.33466597,144.15185097
 Daylesford Secondary College,45329.0,2016,DAYLESFORD,26.0,4.3,73.0,88.0,994.0,Government,Secondary,470.0,-37.33466597,144.15185097
@@ -1260,7 +1308,7 @@ Daylesford Secondary College,45329.0,2019,DAYLESFORD,26.0,3.2,70.0,95.0,998.0,Go
 Daylesford Secondary College,45329.0,2020,DAYLESFORD,27.0,2.0,60.9,100.0,1003.0,Government,Secondary,485.0,-37.33466597,144.15185097
 Daylesford Secondary College,45329.0,2021,DAYLESFORD,29.0,6.7,75.0,91.0,997.0,Government,Secondary,487.0,-37.33466597,144.15185097
 Daylesford Secondary College,45329.0,2022,DAYLESFORD,26.0,0.0,61.9,95.0,997.0,Government,Secondary,465.0,-37.33466597,144.15185097
-Daylesford Secondary College,,2023,DAYLESFORD,27.0,3.8,42.3,90.0,,,,,,
+Daylesford Secondary College,45329.0,2023,DAYLESFORD,27.0,3.8,42.3,90.0,,,,,,
 De La Salle College,45771.0,2014,MALVERN,30.0,6.4,97.0,100.0,1106.0,Catholic,Combined,1142.0,-37.857677,145.032183
 De La Salle College,45771.0,2015,MALVERN,30.0,6.7,90.0,99.0,1112.0,Catholic,Combined,1149.0,-37.857677,145.032183
 De La Salle College,45771.0,2016,MALVERN,29.0,5.3,93.0,99.0,1108.0,Catholic,Combined,1150.0,-37.857677,145.032183
@@ -1270,7 +1318,7 @@ De La Salle College,45771.0,2019,MALVERN,31.0,7.8,96.5,100.0,1114.0,Catholic,Com
 De La Salle College,45771.0,2020,MALVERN,30.0,8.5,90.8,99.0,1117.0,Catholic,Combined,1042.0,-37.857677,145.032183
 De La Salle College,45771.0,2021,MALVERN,31.0,10.3,91.1,100.0,1118.0,Catholic,Combined,1035.0,-37.857677,145.032183
 De La Salle College,45771.0,2022,MALVERN,29.0,5.4,85.8,99.0,1126.0,Catholic,Combined,989.0,-37.857677,145.032183
-De La Salle College,,2023,MALVERN,31.0,7.5,76.4,100.0,,,,,,
+De La Salle College,45771.0,2023,MALVERN,31.0,7.5,76.4,100.0,,,,,,
 Derrinallum P12 College,45183.0,2014,DERRINALLUM,32.0,0.0,67.0,100.0,993.0,Government,Combined,72.0,-37.939591,143.216741
 Derrinallum P12 College,45183.0,2015,DERRINALLUM,29.0,0.0,50.0,100.0,973.0,Government,Combined,74.0,-37.939591,143.216741
 Derrinallum P12 College,45183.0,2016,DERRINALLUM,29.0,5.0,25.0,100.0,974.0,Government,Combined,72.0,-37.939591,143.216741
@@ -1280,7 +1328,7 @@ Derrinallum P12 College,45183.0,2019,DERRINALLUM,26.0,0.0,40.0,100.0,961.0,Gover
 Derrinallum P12 College,45183.0,2020,DERRINALLUM,29.0,0.0,0.0,100.0,974.0,Government,Combined,75.0,-37.939591,143.216741
 Derrinallum P12 College,45183.0,2021,DERRINALLUM,32.0,0.0,0.0,100.0,973.0,Government,Combined,83.0,-37.939591,143.216741
 Derrinallum P12 College,45183.0,2022,DERRINALLUM,31.0,0.0,50.0,100.0,980.0,Government,Combined,80.0,-37.939591,143.216741
-Derrinallum P12 College,,2023,DERRINALLUM,31.0,,20.0,100.0,,,,,,
+Derrinallum P12 College,45183.0,2023,DERRINALLUM,31.0,,20.0,100.0,,,,,,
 Diamond Valley College,45521.0,2014,DIAMOND CREEK,28.0,3.0,73.0,99.0,1016.0,Government,Secondary,803.0,-37.672433,145.167704
 Diamond Valley College,45521.0,2015,DIAMOND CREEK,28.0,5.3,78.0,98.0,1014.0,Government,Secondary,779.0,-37.672433,145.167704
 Diamond Valley College,45521.0,2016,DIAMOND CREEK,28.0,2.7,89.0,99.0,1019.0,Government,Secondary,714.0,-37.672433,145.167704
@@ -1290,15 +1338,15 @@ Diamond Valley College,45521.0,2019,DIAMOND CREEK,28.0,3.7,92.6,96.0,1016.0,Gove
 Diamond Valley College,45521.0,2020,DIAMOND CREEK,25.0,2.0,78.3,98.0,1018.0,Government,Secondary,646.0,-37.672433,145.167704
 Diamond Valley College,45521.0,2021,DIAMOND CREEK,27.0,2.8,63.8,98.0,1023.0,Government,Secondary,728.0,-37.672433,145.167704
 Diamond Valley College,45521.0,2022,DIAMOND CREEK,25.0,0.0,66.0,77.0,1021.0,Government,Secondary,762.0,-37.672433,145.167704
-Diamond Valley College,,2023,DIAMOND CREEK,26.0,1.8,56.3,98.0,,,,,,
-Diamond Valley Learn Centre,45521.0,2014,GREENSBOROUGH,,,,,1016.0,Government,Secondary,803.0,-37.672433,145.167704
-Diamond Valley Learn Centre,45521.0,2015,GREENSBOROUGH,,,,,1014.0,Government,Secondary,779.0,-37.672433,145.167704
-Diamond Valley Learn Centre,45521.0,2016,GREENSBOROUGH,,,,,1019.0,Government,Secondary,714.0,-37.672433,145.167704
-Diamond Valley Learn Centre,45521.0,2017,GREENSBOROUGH,,,,,1009.0,Government,Secondary,669.0,-37.672433,145.167704
-Diamond Valley Learn Centre,45521.0,2018,GREENSBOROUGH,,,,,1013.0,Government,Secondary,600.0,-37.672433,145.167704
-Diamond Valley Learn Centre,45521.0,2019,GREENSBOROUGH,,,,,1016.0,Government,Secondary,604.0,-37.672433,145.167704
-Diamond Valley Learn Centre,45521.0,2020,GREENSBOROUGH,,,,,1018.0,Government,Secondary,646.0,-37.672433,145.167704
-Diamond Valley Learn Centre,45521.0,2021,GREENSBOROUGH,,,,,1023.0,Government,Secondary,728.0,-37.672433,145.167704
+Diamond Valley College,45521.0,2023,DIAMOND CREEK,26.0,1.8,56.3,98.0,,,,,,
+Diamond Valley Learn Centre,,2014,GREENSBOROUGH,,,,,,,,,,
+Diamond Valley Learn Centre,,2015,GREENSBOROUGH,,,,,,,,,,
+Diamond Valley Learn Centre,,2016,GREENSBOROUGH,,,,,,,,,,
+Diamond Valley Learn Centre,,2017,GREENSBOROUGH,,,,,,,,,,
+Diamond Valley Learn Centre,,2018,GREENSBOROUGH,,,,,,,,,,
+Diamond Valley Learn Centre,,2019,GREENSBOROUGH,,,,,,,,,,
+Diamond Valley Learn Centre,,2020,GREENSBOROUGH,,,,,,,,,,
+Diamond Valley Learn Centre,,2021,GREENSBOROUGH,,,,,,,,,,
 Dimboola Memorial Sec College,45376.0,2014,DIMBOOLA,29.0,2.5,100.0,100.0,936.0,Government,Secondary,200.0,-36.449839,142.034409
 Dimboola Memorial Sec College,45376.0,2015,DIMBOOLA,27.0,1.2,85.0,100.0,935.0,Government,Secondary,181.0,-36.449839,142.034409
 Dimboola Memorial Sec College,45376.0,2016,DIMBOOLA,30.0,2.8,54.0,92.0,958.0,Government,Secondary,171.0,-36.449839,142.034409
@@ -1308,12 +1356,29 @@ Dimboola Memorial Sec College,45376.0,2019,DIMBOOLA,31.0,6.8,70.0,100.0,949.0,Go
 Dimboola Memorial Sec College,45376.0,2020,DIMBOOLA,31.0,5.9,70.0,100.0,944.0,Government,Secondary,149.0,-36.449839,142.034409
 Dimboola Memorial Sec College,45376.0,2021,DIMBOOLA,31.0,6.3,50.0,100.0,947.0,Government,Secondary,141.0,-36.449839,142.034409
 Dimboola Memorial Sec College,45376.0,2022,DIMBOOLA,29.0,2.0,45.5,100.0,943.0,Government,Secondary,122.0,-36.449839,142.034409
-Dimboola Memorial Sec College,,2023,DIMBOOLA,28.0,,75.0,100.0,,,,,,
+Dimboola Memorial Sec College,45376.0,2023,DIMBOOLA,28.0,,75.0,100.0,,,,,,
+Distance Education Victoria,,2014,THORNBURY,28.0,5.6,34.0,89.0,,,,,,
+Distance Education Victoria,,2015,THORNBURY,28.0,5.2,46.0,91.0,,,,,,
+Distance Education Victoria,,2016,THORNBURY,27.0,3.4,36.0,86.0,,,,,,
+Distance Education Victoria,,2017,THORNBURY,28.0,3.9,41.0,89.0,,,,,,
+Distance Education Victoria,,2018,THORNBURY,28.0,7.4,40.1,85.0,,,,,,
+Diversitat,,2014,GEELONG,,,,,,,,,,
+Diversitat,,2015,GEELONG,,,,,,,,,,
+Diversitat,,2016,GEELONG,,,,,,,,,,
+Diversitat,,2017,GEELONG,,,,,,,,,,
+Diversitat,,2018,GEELONG,,,,,,,,,,
+Diversitat,,2019,GEELONG,,,,,,,,,,
 Divrei Emineh,50505.0,2022,ORMOND,,,,,922.0,Independent,Combined,173.0,-37.903565,145.035018
-Divrei Emineh,,2023,ORMOND,,,,100.0,,,,,,
-Djerriwarrh Community College,45223.0,2021,MELTON,,,,,999.0,Government,Combined,89.0,-35.26557452,141.17733647
-Djerriwarrh Community College,45223.0,2022,MELTON,,,,,992.0,Government,Combined,82.0,-35.26557452,141.17733647
-Djerriwarrh Community College,,2023,MELTON,,,7.7,77.0,,,,,,
+Divrei Emineh,50505.0,2023,ORMOND,,,,100.0,,,,,,
+Djerriwarrh Community College,53016.0,2021,MELTON,,,,,955.0,Independent,Secondary,44.0,-37.68626984,144.577811
+Djerriwarrh Community College,53016.0,2022,MELTON,,,,,947.0,Independent,Secondary,44.0,-37.68626984,144.577811
+Djerriwarrh Community College,53016.0,2023,MELTON,,,7.7,77.0,,,,,,
+Djerriwarrh Emp. & Edu. Servic.,53016.0,2015,MELTON,,,,,,,,,,
+Djerriwarrh Emp. & Edu. Servic.,53016.0,2016,MELTON,,,,,,,,,,
+Djerriwarrh Emp. & Edu. Servic.,53016.0,2017,MELTON,,,,,,,,,,
+Djerriwarrh Emp. & Edu. Servic.,53016.0,2018,MELTON,,,,,,,,,,
+Djerriwarrh Emp. & Edu. Servic.,53016.0,2019,MELTON,,,,,,,,,,
+Djerriwarrh Emp. & Edu. Servic.,53016.0,2020,MELTON,,,,,,,,,,
 Donald High School,45378.0,2014,DONALD,31.0,4.8,84.0,100.0,997.0,Government,Secondary,179.0,-36.370594,142.977163
 Donald High School,45378.0,2015,DONALD,30.0,2.8,81.0,100.0,985.0,Government,Secondary,173.0,-36.370594,142.977163
 Donald High School,45378.0,2016,DONALD,31.0,2.7,100.0,100.0,989.0,Government,Secondary,155.0,-36.370594,142.977163
@@ -1323,7 +1388,7 @@ Donald High School,45378.0,2019,DONALD,28.0,2.4,70.6,100.0,990.0,Government,Seco
 Donald High School,45378.0,2020,DONALD,28.0,8.8,69.2,100.0,989.0,Government,Secondary,137.0,-36.370594,142.977163
 Donald High School,45378.0,2021,DONALD,30.0,7.7,87.5,100.0,988.0,Government,Secondary,119.0,-36.370594,142.977163
 Donald High School,45378.0,2022,DONALD,30.0,1.5,68.8,100.0,983.0,Government,Secondary,110.0,-36.370594,142.977163
-Donald High School,,2023,DONALD,31.0,5.9,100.0,100.0,,,,,,
+Donald High School,45378.0,2023,DONALD,31.0,5.9,100.0,100.0,,,,,,
 Doncaster Secondary College,45379.0,2014,DONCASTER,30.0,7.3,92.0,100.0,1047.0,Government,Secondary,1294.0,-37.784581,145.138053
 Doncaster Secondary College,45379.0,2015,DONCASTER,29.0,6.4,89.0,100.0,1053.0,Government,Secondary,1393.0,-37.784581,145.138053
 Doncaster Secondary College,45379.0,2016,DONCASTER,29.0,7.3,87.0,99.0,1054.0,Government,Secondary,1449.0,-37.784581,145.138053
@@ -1333,7 +1398,7 @@ Doncaster Secondary College,45379.0,2019,DONCASTER,29.0,4.2,89.8,100.0,1060.0,Go
 Doncaster Secondary College,45379.0,2020,DONCASTER,30.0,5.5,87.8,100.0,1061.0,Government,Secondary,1494.0,-37.784581,145.138053
 Doncaster Secondary College,45379.0,2021,DONCASTER,29.0,5.3,85.2,99.0,1060.0,Government,Secondary,1441.0,-37.784581,145.138053
 Doncaster Secondary College,45379.0,2022,DONCASTER,30.0,6.6,80.6,98.0,1064.0,Government,Secondary,1319.0,-37.784581,145.138053
-Doncaster Secondary College,,2023,DONCASTER,30.0,8.9,78.7,96.0,,,,,,
+Doncaster Secondary College,45379.0,2023,DONCASTER,30.0,8.9,78.7,96.0,,,,,,
 Donvale Christian College,46235.0,2014,DONVALE,33.0,13.5,87.0,99.0,1147.0,Independent,Combined,1130.0,-37.774028,145.193451
 Donvale Christian College,46235.0,2015,DONVALE,32.0,10.6,90.0,100.0,1148.0,Independent,Combined,1148.0,-37.774028,145.193451
 Donvale Christian College,46235.0,2016,DONVALE,31.0,9.4,85.0,100.0,1148.0,Independent,Combined,1199.0,-37.774028,145.193451
@@ -1343,7 +1408,7 @@ Donvale Christian College,46235.0,2019,DONVALE,33.0,12.3,91.7,100.0,1158.0,Indep
 Donvale Christian College,46235.0,2020,DONVALE,32.0,10.0,89.0,100.0,1158.0,Independent,Combined,1463.0,-37.774028,145.193451
 Donvale Christian College,46235.0,2021,DONVALE,32.0,9.4,85.1,100.0,1156.0,Independent,Combined,1514.0,-37.774028,145.193451
 Donvale Christian College,46235.0,2022,DONVALE,32.0,9.5,81.8,99.0,1157.0,Independent,Combined,1529.0,-37.774028,145.193451
-Donvale Christian College,,2023,DONVALE,31.0,6.8,84.5,100.0,,,,,,
+Donvale Christian College,46235.0,2023,DONVALE,31.0,6.8,84.5,100.0,,,,,,
 Dromana Secondary College,45330.0,2014,DROMANA,30.0,6.6,79.0,100.0,989.0,Government,Secondary,1243.0,-38.342636,145.013582
 Dromana Secondary College,45330.0,2015,DROMANA,30.0,5.2,82.0,97.0,991.0,Government,Secondary,1291.0,-38.342636,145.013582
 Dromana Secondary College,45330.0,2016,DROMANA,31.0,4.8,75.0,100.0,989.0,Government,Secondary,1413.0,-38.342636,145.013582
@@ -1353,7 +1418,7 @@ Dromana Secondary College,45330.0,2019,DROMANA,31.0,3.6,75.5,99.0,1001.0,Governm
 Dromana Secondary College,45330.0,2020,DROMANA,30.0,5.0,70.7,100.0,1007.0,Government,Secondary,1780.0,-38.342636,145.013582
 Dromana Secondary College,45330.0,2021,DROMANA,31.0,9.5,64.8,100.0,1011.0,Government,Secondary,1812.0,-38.342636,145.013582
 Dromana Secondary College,45330.0,2022,DROMANA,31.0,9.3,66.7,99.0,1010.0,Government,Secondary,1819.0,-38.342636,145.013582
-Dromana Secondary College,,2023,DROMANA,32.0,8.7,44.8,98.0,,,,,,
+Dromana Secondary College,45330.0,2023,DROMANA,32.0,8.7,44.8,98.0,,,,,,
 Drouin Secondary College,45380.0,2014,DROUIN,29.0,2.9,82.0,97.0,967.0,Government,Secondary,957.0,-38.144659,145.850978
 Drouin Secondary College,45380.0,2015,DROUIN,28.0,2.1,62.0,100.0,967.0,Government,Secondary,955.0,-38.144659,145.850978
 Drouin Secondary College,45380.0,2016,DROUIN,27.0,1.6,79.0,100.0,962.0,Government,Secondary,941.0,-38.144659,145.850978
@@ -1363,8 +1428,8 @@ Drouin Secondary College,45380.0,2019,DROUIN,28.0,2.9,79.7,97.0,978.0,Government
 Drouin Secondary College,45380.0,2020,DROUIN,27.0,1.5,72.9,99.0,980.0,Government,Secondary,1161.0,-38.144659,145.850978
 Drouin Secondary College,45380.0,2021,DROUIN,29.0,1.8,69.0,93.0,981.0,Government,Secondary,1220.0,-38.144659,145.850978
 Drouin Secondary College,45380.0,2022,DROUIN,27.0,1.2,77.6,98.0,971.0,Government,Secondary,1251.0,-38.144659,145.850978
-Drouin Secondary College,,2023,DROUIN,25.0,0.5,49.6,97.0,,,,,,
-Eaglehawk Secondary College,,2023,EAGLEHAWK,,,,,,,,,,
+Drouin Secondary College,45380.0,2023,DROUIN,25.0,0.5,49.6,97.0,,,,,,
+Eaglehawk Secondary College,45381.0,2023,EAGLEHAWK,,,,,,,,,,
 East Doncaster Sec College,45377.0,2014,DONCASTER EAST,31.0,7.3,95.0,99.0,1076.0,Government,Secondary,1532.0,-37.782173,145.158872
 East Doncaster Sec College,45377.0,2015,DONCASTER EAST,32.0,12.0,94.0,99.0,1079.0,Government,Secondary,1516.0,-37.782173,145.158872
 East Doncaster Sec College,45377.0,2016,DONCASTER EAST,32.0,11.6,95.0,98.0,1077.0,Government,Secondary,1569.0,-37.782173,145.158872
@@ -1374,7 +1439,7 @@ East Doncaster Sec College,45377.0,2019,DONCASTER EAST,32.0,10.2,99.2,99.0,1094.
 East Doncaster Sec College,45377.0,2020,DONCASTER EAST,33.0,13.0,99.1,100.0,1095.0,Government,Secondary,1622.0,-37.782173,145.158872
 East Doncaster Sec College,45377.0,2021,DONCASTER EAST,33.0,16.7,96.2,98.0,1098.0,Government,Secondary,1599.0,-37.782173,145.158872
 East Doncaster Sec College,45377.0,2022,DONCASTER EAST,34.0,17.1,97.1,99.0,1107.0,Government,Secondary,1630.0,-37.782173,145.158872
-East Doncaster Sec College,,2023,DONCASTER EAST,33.0,16.0,98.4,99.0,,,,,,
+East Doncaster Sec College,45377.0,2023,DONCASTER EAST,33.0,16.0,98.4,99.0,,,,,,
 East Loddon P-12 College,45299.0,2014,DINGEE,27.0,7.1,43.0,100.0,975.0,Government,Combined,239.0,-36.372222,144.141446
 East Loddon P-12 College,45299.0,2015,DINGEE,28.0,0.0,78.0,100.0,955.0,Government,Combined,248.0,-36.372222,144.141446
 East Loddon P-12 College,45299.0,2016,DINGEE,30.0,3.6,100.0,100.0,990.0,Government,Combined,236.0,-36.372222,144.141446
@@ -1384,7 +1449,7 @@ East Loddon P-12 College,45299.0,2019,DINGEE,34.0,17.8,88.9,100.0,986.0,Governme
 East Loddon P-12 College,45299.0,2020,DINGEE,34.0,13.9,80.0,100.0,982.0,Government,Combined,232.0,-36.372222,144.141446
 East Loddon P-12 College,45299.0,2021,DINGEE,33.0,9.5,92.9,100.0,985.0,Government,Combined,248.0,-36.372222,144.141446
 East Loddon P-12 College,45299.0,2022,DINGEE,33.0,10.2,88.9,89.0,975.0,Government,Combined,265.0,-36.372222,144.141446
-East Loddon P-12 College,,2023,DINGEE,30.0,5.4,76.9,100.0,,,,,,
+East Loddon P-12 College,45299.0,2023,DINGEE,30.0,5.4,76.9,100.0,,,,,,
 East Preston Islamic College,46349.0,2014,EAST PRESTON,28.0,4.5,93.0,100.0,950.0,Independent,Combined,506.0,-37.73395221,145.03438975
 East Preston Islamic College,46349.0,2015,EAST PRESTON,26.0,0.0,88.0,88.0,969.0,Independent,Combined,586.0,-37.73395221,145.03438975
 East Preston Islamic College,46349.0,2016,EAST PRESTON,28.0,2.9,100.0,100.0,969.0,Independent,Combined,617.0,-37.73395221,145.03438975
@@ -1394,7 +1459,7 @@ East Preston Islamic College,46349.0,2019,PRESTON EAST,23.0,0.9,100.0,95.0,981.0
 East Preston Islamic College,46349.0,2020,PRESTON EAST,21.0,0.0,100.0,93.0,982.0,Independent,Combined,745.0,-37.73395221,145.03438975
 East Preston Islamic College,46349.0,2021,PRESTON,21.0,2.2,69.6,91.0,976.0,Independent,Combined,767.0,-37.73395221,145.03438975
 East Preston Islamic College,46349.0,2022,PRESTON,21.0,0.0,74.2,81.0,987.0,Independent,Combined,764.0,-37.73395221,145.03438975
-East Preston Islamic College,,2023,PRESTON,22.0,,74.2,94.0,,,,,,
+East Preston Islamic College,46349.0,2023,PRESTON,22.0,,74.2,94.0,,,,,,
 Echuca College,40434.0,2014,ECHUCA,27.0,2.5,66.0,94.0,952.0,Government,Secondary,677.0,-36.132394,144.732423
 Echuca College,40434.0,2015,ECHUCA,27.0,1.9,78.0,100.0,953.0,Government,Secondary,648.0,-36.132394,144.732423
 Echuca College,40434.0,2016,ECHUCA,25.0,1.7,56.0,99.0,958.0,Government,Secondary,645.0,-36.132394,144.732423
@@ -1404,7 +1469,7 @@ Echuca College,40434.0,2019,ECHUCA,27.0,2.1,52.6,91.0,957.0,Government,Secondary
 Echuca College,40434.0,2020,ECHUCA,27.0,2.0,55.6,93.0,953.0,Government,Secondary,776.0,-36.132394,144.732423
 Echuca College,40434.0,2021,ECHUCA,26.0,1.1,50.0,100.0,950.0,Government,Secondary,813.0,-36.132394,144.732423
 Echuca College,40434.0,2022,ECHUCA,26.0,2.5,43.1,91.0,945.0,Government,Secondary,779.0,-36.132394,144.732423
-Echuca College,,2023,ECHUCA,24.0,1.2,33.3,94.0,,,,,,
+Echuca College,40434.0,2023,ECHUCA,24.0,1.2,33.3,94.0,,,,,,
 Edenhope College,45222.0,2014,EDENHOPE,27.0,1.5,58.0,100.0,970.0,Government,Combined,209.0,-37.03342876,141.29856271
 Edenhope College,45222.0,2015,EDENHOPE,28.0,0.0,92.0,100.0,965.0,Government,Combined,191.0,-37.03342876,141.29856271
 Edenhope College,45222.0,2016,EDENHOPE,28.0,4.6,100.0,100.0,963.0,Government,Combined,185.0,-37.03342876,141.29856271
@@ -1414,9 +1479,9 @@ Edenhope College,45222.0,2019,EDENHOPE,25.0,0.0,71.4,100.0,966.0,Government,Comb
 Edenhope College,45222.0,2020,EDENHOPE,27.0,3.0,83.3,100.0,976.0,Government,Combined,148.0,-37.03342876,141.29856271
 Edenhope College,45222.0,2021,EDENHOPE,28.0,0.0,100.0,100.0,974.0,Government,Combined,116.0,-37.03342876,141.29856271
 Edenhope College,45222.0,2022,EDENHOPE,27.0,0.0,50.0,67.0,974.0,Government,Combined,123.0,-37.03342876,141.29856271
-Edenhope College,,2023,EDENHOPE,30.0,,83.3,100.0,,,,,,
+Edenhope College,45222.0,2023,EDENHOPE,30.0,,83.3,100.0,,,,,,
 Edgars Creek Secondary College,52591.0,2022,WOLLERT,,,,,1002.0,Government,Secondary,1004.0,-37.616208,145.004876
-Edgars Creek Secondary College,,2023,WOLLERT,25.0,0.7,54.5,88.0,,,,,,
+Edgars Creek Secondary College,52591.0,2023,WOLLERT,25.0,0.7,54.5,88.0,,,,,,
 Edinburgh College,46222.0,2014,LILYDALE,29.0,3.3,100.0,100.0,1071.0,Independent,Combined,304.0,-37.78495788574219,145.3518829345703
 Edinburgh College,46222.0,2015,LILYDALE,28.0,5.8,86.0,100.0,1053.0,Independent,Combined,315.0,-37.78495788574219,145.3518829345703
 Edinburgh College,46222.0,2016,LILYDALE,28.0,0.8,79.0,100.0,1059.0,Independent,Combined,306.0,-37.78495788574219,145.3518829345703
@@ -1426,7 +1491,15 @@ Edinburgh College,46222.0,2019,LILYDALE,31.0,11.8,45.5,100.0,1072.0,Independent,
 Edinburgh College,46222.0,2020,LILYDALE,30.0,2.3,84.2,100.0,1072.0,Independent,Combined,390.0,-37.78495788574219,145.3518829345703
 Edinburgh College,46222.0,2021,LILYDALE,28.0,0.0,87.5,100.0,1075.0,Independent,Combined,429.0,-37.78495788574219,145.3518829345703
 Edinburgh College,46222.0,2022,LILYDALE,28.0,10.3,66.7,100.0,1072.0,Independent,Combined,449.0,-37.78495788574219,145.3518829345703
-Edinburgh College,,2023,LILYDALE,27.0,2.7,55.6,100.0,,,,,,
+Edinburgh College,46222.0,2023,LILYDALE,27.0,2.7,55.6,100.0,,,,,,
+Education Centre Gippsland,40835.0,2014,WARRAGUL,,,,,,Independent,Secondary,52.0,-38.178231,145.926224
+Education Centre Gippsland,40835.0,2015,WARRAGUL,,,,,,Independent,Secondary,82.0,-38.178231,145.926224
+Education Centre Gippsland,40835.0,2016,WARRAGUL,,,,,,Independent,Special,115.0,-38.178231,145.926224
+Education Centre Gippsland,40835.0,2017,WARRAGUL,,,,,,Independent,Special,117.0,-38.178231,145.926224
+Education Centre Gippsland,40835.0,2018,WARRAGUL,,,,,,Independent,Special,102.0,-38.178231,145.926224
+Education Centre Gippsland,40835.0,2019,WARRAGUL,,,,,,Independent,Special,128.0,-38.178231,145.926224
+Education Centre Gippsland,40835.0,2020,WARRAGUL,,,,,,Independent,Special,151.0,-38.178231,145.926224
+Education Centre Gippsland,40835.0,2021,WARRAGUL,,,,,965.0,Independent,Special,166.0,-38.178231,145.926224
 Elisabeth Murdoch College,45506.0,2014,LANGWARRIN,29.0,5.6,76.0,99.0,981.0,Government,Secondary,1362.0,-38.159291,145.19018
 Elisabeth Murdoch College,45506.0,2015,LANGWARRIN,29.0,5.3,69.0,97.0,983.0,Government,Secondary,1437.0,-38.159291,145.19018
 Elisabeth Murdoch College,45506.0,2016,LANGWARRIN,28.0,5.1,59.0,99.0,982.0,Government,Secondary,1576.0,-38.159291,145.19018
@@ -1436,7 +1509,7 @@ Elisabeth Murdoch College,45506.0,2019,LANGWARRIN,27.0,2.7,65.0,99.0,999.0,Gover
 Elisabeth Murdoch College,45506.0,2020,LANGWARRIN,28.0,3.2,74.4,100.0,1001.0,Government,Secondary,1791.0,-38.159291,145.19018
 Elisabeth Murdoch College,45506.0,2021,LANGWARRIN,26.0,2.0,61.4,97.0,1004.0,Government,Secondary,1808.0,-38.159291,145.19018
 Elisabeth Murdoch College,45506.0,2022,LANGWARRIN,29.0,4.5,53.2,97.0,1001.0,Government,Secondary,1698.0,-38.159291,145.19018
-Elisabeth Murdoch College,,2023,LANGWARRIN,31.0,6.3,39.0,98.0,,,,,,
+Elisabeth Murdoch College,45506.0,2023,LANGWARRIN,31.0,6.3,39.0,98.0,,,,,,
 Eltham College,46232.0,2014,RESEARCH,31.0,7.9,91.0,100.0,1135.0,Independent,Combined,635.0,-37.70044311,145.192232
 Eltham College,46232.0,2015,RESEARCH,31.0,12.9,90.0,100.0,1122.0,Independent,Combined,639.0,-37.70044311,145.192232
 Eltham College,46232.0,2016,RESEARCH,31.0,10.8,97.0,100.0,1129.0,Independent,Combined,616.0,-37.70044311,145.192232
@@ -1446,7 +1519,7 @@ Eltham College,46232.0,2019,RESEARCH,34.0,20.0,96.6,100.0,1135.0,Independent,Com
 Eltham College,46232.0,2020,RESEARCH,32.0,9.3,93.5,100.0,1137.0,Independent,Combined,603.0,-37.70044311,145.192232
 Eltham College,46232.0,2021,RESEARCH,32.0,8.9,93.1,100.0,1140.0,Independent,Combined,623.0,-37.70044311,145.192232
 Eltham College,46232.0,2022,RESEARCH,33.0,15.0,89.7,100.0,1144.0,Independent,Combined,629.0,-37.70044311,145.192232
-Eltham College,,2023,RESEARCH,32.0,12.6,94.5,100.0,,,,,,
+Eltham College,46232.0,2023,RESEARCH,32.0,12.6,94.5,100.0,,,,,,
 Eltham High School,45382.0,2014,ELTHAM,30.0,7.1,86.0,99.0,1081.0,Government,Secondary,1335.0,-37.72464493,145.14248575
 Eltham High School,45382.0,2015,ELTHAM,28.0,4.6,76.0,100.0,1079.0,Government,Secondary,1379.0,-37.72464493,145.14248575
 Eltham High School,45382.0,2016,ELTHAM,30.0,6.2,83.0,100.0,1083.0,Government,Secondary,1374.0,-37.72464493,145.14248575
@@ -1456,7 +1529,7 @@ Eltham High School,45382.0,2019,ELTHAM,30.0,4.8,68.1,98.0,1087.0,Government,Seco
 Eltham High School,45382.0,2020,ELTHAM,29.0,5.1,76.8,98.0,1089.0,Government,Secondary,1437.0,-37.72464493,145.14248575
 Eltham High School,45382.0,2021,ELTHAM,29.0,3.6,73.8,98.0,1092.0,Government,Secondary,1432.0,-37.72464493,145.14248575
 Eltham High School,45382.0,2022,ELTHAM,30.0,5.7,70.7,99.0,1097.0,Government,Secondary,1471.0,-37.72464493,145.14248575
-Eltham High School,,2023,ELTHAM,29.0,4.3,63.1,98.0,,,,,,
+Eltham High School,45382.0,2023,ELTHAM,29.0,4.3,63.1,98.0,,,,,,
 Elwood College,45383.0,2014,ELWOOD,28.0,4.5,81.0,96.0,1092.0,Government,Secondary,503.0,-37.881989,144.984486
 Elwood College,45383.0,2015,ELWOOD,28.0,5.7,75.0,97.0,1096.0,Government,Secondary,565.0,-37.881989,144.984486
 Elwood College,45383.0,2016,ELWOOD,29.0,6.4,74.0,93.0,1093.0,Government,Secondary,595.0,-37.881989,144.984486
@@ -1466,7 +1539,7 @@ Elwood College,45383.0,2019,ELWOOD,30.0,12.6,75.6,96.0,1097.0,Government,Seconda
 Elwood College,45383.0,2020,ELWOOD,30.0,3.7,80.0,99.0,1099.0,Government,Secondary,822.0,-37.881989,144.984486
 Elwood College,45383.0,2021,ELWOOD,29.0,6.7,68.5,100.0,1101.0,Government,Secondary,814.0,-37.881989,144.984486
 Elwood College,45383.0,2022,ELWOOD,31.0,11.2,73.6,99.0,1105.0,Government,Secondary,795.0,-37.881989,144.984486
-Elwood College,,2023,ELWOOD,30.0,6.7,69.4,98.0,,,,,,
+Elwood College,45383.0,2023,ELWOOD,30.0,6.7,69.4,98.0,,,,,,
 Emerald Secondary College,45497.0,2014,EMERALD,29.0,2.5,87.0,100.0,999.0,Government,Secondary,898.0,-37.92427055,145.45874374
 Emerald Secondary College,45497.0,2015,EMERALD,28.0,2.6,74.0,94.0,995.0,Government,Secondary,881.0,-37.92427055,145.45874374
 Emerald Secondary College,45497.0,2016,EMERALD,28.0,2.7,82.0,99.0,1002.0,Government,Secondary,777.0,-37.92427055,145.45874374
@@ -1476,7 +1549,7 @@ Emerald Secondary College,45497.0,2019,EMERALD,29.0,4.3,56.6,99.0,1013.0,Governm
 Emerald Secondary College,45497.0,2020,EMERALD,28.0,2.9,51.9,99.0,1018.0,Government,Secondary,710.0,-37.92427055,145.45874374
 Emerald Secondary College,45497.0,2021,EMERALD,29.0,4.8,57.4,98.0,1016.0,Government,Secondary,720.0,-37.92427055,145.45874374
 Emerald Secondary College,45497.0,2022,EMERALD,29.0,3.2,47.3,96.0,1012.0,Government,Secondary,708.0,-37.92427055,145.45874374
-Emerald Secondary College,,2023,EMERALD,28.0,1.5,42.3,96.0,,,,,,
+Emerald Secondary College,45497.0,2023,EMERALD,28.0,1.5,42.3,96.0,,,,,,
 Emmanuel College,45979.0,2014,ALTONA NORTH,28.0,3.4,89.0,100.0,1037.0,Catholic,Secondary,1800.0,-37.831623,144.842389
 Emmanuel College,45979.0,2014,WARRNAMBOOL,28.0,2.9,87.0,96.0,1037.0,Catholic,Secondary,1800.0,-37.831623,144.842389
 Emmanuel College,45979.0,2015,ALTONA NORTH,28.0,4.0,90.0,100.0,1048.0,Catholic,Secondary,1789.0,-37.831623,144.842389
@@ -1495,8 +1568,8 @@ Emmanuel College,45979.0,2021,ALTONA NORTH,28.0,3.6,87.0,100.0,1063.0,Catholic,S
 Emmanuel College,45979.0,2021,WARRNAMBOOL,29.0,4.7,69.7,97.0,1063.0,Catholic,Secondary,2184.0,-37.831623,144.842389
 Emmanuel College,45979.0,2022,ALTONA NORTH,28.0,3.3,82.1,100.0,1066.0,Catholic,Secondary,2271.0,-37.831623,144.842389
 Emmanuel College,45979.0,2022,WARRNAMBOOL,29.0,5.6,75.8,97.0,1066.0,Catholic,Secondary,2271.0,-37.831623,144.842389
-Emmanuel College,,2023,WARRNAMBOOL,29.0,5.3,59.9,99.0,,,,,,
-Emmanuel College,,2023,ALTONA NORTH,28.0,4.5,73.1,100.0,,,,,,
+Emmanuel College,45979.0,2023,WARRNAMBOOL,29.0,5.3,59.9,99.0,,,,,,
+Emmanuel College,45979.0,2023,ALTONA NORTH,28.0,4.5,73.1,100.0,,,,,,
 Emmaus College,45936.0,2014,VERMONT SOUTH,31.0,5.2,94.0,100.0,1072.0,Catholic,Secondary,1265.0,-37.847990854423244,145.17444779150486
 Emmaus College,45936.0,2015,VERMONT SOUTH,31.0,8.0,91.0,100.0,1075.0,Catholic,Secondary,1251.0,-37.847990854423244,145.17444779150486
 Emmaus College,45936.0,2016,VERMONT SOUTH,31.0,7.0,90.0,100.0,1071.0,Catholic,Secondary,1263.0,-37.847990854423244,145.17444779150486
@@ -1506,7 +1579,7 @@ Emmaus College,45936.0,2019,VERMONT SOUTH,31.0,9.3,86.2,100.0,1064.0,Catholic,Se
 Emmaus College,45936.0,2020,VERMONT SOUTH,31.0,7.2,88.1,99.0,1067.0,Catholic,Secondary,1326.0,-37.847990854423244,145.17444779150486
 Emmaus College,45936.0,2021,VERMONT SOUTH,30.0,7.7,86.4,100.0,1067.0,Catholic,Secondary,1380.0,-37.847990854423244,145.17444779150486
 Emmaus College,45936.0,2022,VERMONT SOUTH,30.0,5.5,89.2,100.0,1071.0,Catholic,Secondary,1392.0,-37.847990854423244,145.17444779150486
-Emmaus College,,2023,VERMONT SOUTH,30.0,6.1,80.2,99.0,,,,,,
+Emmaus College,45936.0,2023,VERMONT SOUTH,30.0,6.1,80.2,99.0,,,,,,
 Epping Secondary College,45384.0,2014,EPPING,27.0,3.1,90.0,97.0,957.0,Government,Secondary,980.0,-37.64428686,145.03283433
 Epping Secondary College,45384.0,2015,EPPING,27.0,1.6,94.0,98.0,958.0,Government,Secondary,1025.0,-37.64428686,145.03283433
 Epping Secondary College,45384.0,2016,EPPING,27.0,2.9,84.0,95.0,955.0,Government,Secondary,1153.0,-37.64428686,145.03283433
@@ -1516,7 +1589,7 @@ Epping Secondary College,45384.0,2019,EPPING,29.0,3.0,85.7,98.0,974.0,Government
 Epping Secondary College,45384.0,2020,EPPING,28.0,2.3,85.1,96.0,975.0,Government,Secondary,1240.0,-37.64428686,145.03283433
 Epping Secondary College,45384.0,2021,EPPING,28.0,1.8,81.3,95.0,975.0,Government,Secondary,1245.0,-37.64428686,145.03283433
 Epping Secondary College,45384.0,2022,EPPING,27.0,1.1,86.7,99.0,971.0,Government,Secondary,1208.0,-37.64428686,145.03283433
-Epping Secondary College,,2023,EPPING,28.0,2.0,65.4,96.0,,,,,,
+Epping Secondary College,45384.0,2023,EPPING,28.0,2.0,65.4,96.0,,,,,,
 Essendon Keilor College,45543.0,2014,ESSENDON,25.0,1.9,87.0,95.0,988.0,Government,Secondary,978.0,-37.744074,144.868237
 Essendon Keilor College,45543.0,2015,ESSENDON,24.0,1.4,95.0,97.0,986.0,Government,Secondary,973.0,-37.744074,144.868237
 Essendon Keilor College,45543.0,2016,ESSENDON,23.0,1.9,89.0,94.0,987.0,Government,Secondary,908.0,-37.744074,144.868237
@@ -1526,7 +1599,7 @@ Essendon Keilor College,45543.0,2019,ESSENDON,25.0,1.9,90.5,97.0,991.0,Governmen
 Essendon Keilor College,45543.0,2020,ESSENDON,24.0,1.2,82.7,98.0,992.0,Government,Secondary,675.0,-37.744074,144.868237
 Essendon Keilor College,45543.0,2021,ESSENDON,27.0,3.3,94.3,96.0,989.0,Government,Secondary,630.0,-37.744074,144.868237
 Essendon Keilor College,45543.0,2022,ESSENDON,26.0,2.5,98.1,100.0,990.0,Government,Secondary,625.0,-37.744074,144.868237
-Essendon Keilor College,,2023,ESSENDON,25.0,1.8,66.7,94.0,,,,,,
+Essendon Keilor College,45543.0,2023,ESSENDON,25.0,1.8,66.7,94.0,,,,,,
 Euroa Secondary College,45385.0,2014,EUROA,25.0,1.8,71.0,90.0,950.0,Government,Secondary,386.0,-36.758203,145.5648
 Euroa Secondary College,45385.0,2015,EUROA,25.0,1.2,77.0,93.0,942.0,Government,Secondary,360.0,-36.758203,145.5648
 Euroa Secondary College,45385.0,2016,EUROA,25.0,5.5,71.0,100.0,954.0,Government,Secondary,350.0,-36.758203,145.5648
@@ -1536,7 +1609,7 @@ Euroa Secondary College,45385.0,2019,EUROA,26.0,2.9,58.1,97.0,948.0,Government,S
 Euroa Secondary College,45385.0,2020,EUROA,27.0,3.3,68.8,97.0,951.0,Government,Secondary,316.0,-36.758203,145.5648
 Euroa Secondary College,45385.0,2021,EUROA,24.0,0.0,44.4,100.0,955.0,Government,Secondary,308.0,-36.758203,145.5648
 Euroa Secondary College,45385.0,2022,EUROA,26.0,2.5,50.0,83.0,960.0,Government,Secondary,318.0,-36.758203,145.5648
-Euroa Secondary College,,2023,EUROA,24.0,2.0,63.6,100.0,,,,,,
+Euroa Secondary College,45385.0,2023,EUROA,24.0,2.0,63.6,100.0,,,,,,
 F.C.J. College,45693.0,2014,BENALLA,28.0,2.0,80.0,100.0,976.0,Catholic,Secondary,371.0,-36.552769,145.975389
 F.C.J. College,45693.0,2015,BENALLA,27.0,0.5,65.0,100.0,1016.0,Catholic,Secondary,340.0,-36.552769,145.975389
 F.C.J. College,45693.0,2016,BENALLA,29.0,4.0,59.0,97.0,1013.0,Catholic,Secondary,343.0,-36.552769,145.975389
@@ -1546,7 +1619,7 @@ F.C.J. College,45693.0,2019,BENALLA,30.0,8.7,65.2,100.0,1034.0,Catholic,Secondar
 F.C.J. College,45693.0,2020,BENALLA,30.0,6.0,63.2,100.0,1027.0,Catholic,Secondary,358.0,-36.552769,145.975389
 F.C.J. College,45693.0,2021,BENALLA,30.0,2.7,56.8,100.0,1031.0,Catholic,Secondary,377.0,-36.552769,145.975389
 F.C.J. College,45693.0,2022,BENALLA,29.0,5.8,62.9,100.0,1032.0,Catholic,Secondary,381.0,-36.552769,145.975389
-F.C.J. College,,2023,BENALLA,29.0,4.4,61.9,98.0,,,,,,
+F.C.J. College,45693.0,2023,BENALLA,29.0,4.4,61.9,98.0,,,,,,
 Fairhills High School,45386.0,2014,KNOXFIELD,28.0,3.7,87.0,100.0,990.0,Government,Secondary,839.0,-37.87289402,145.25755674
 Fairhills High School,45386.0,2015,KNOXFIELD,26.0,1.8,74.0,100.0,984.0,Government,Secondary,809.0,-37.87289402,145.25755674
 Fairhills High School,45386.0,2016,KNOXFIELD,26.0,2.3,73.0,96.0,993.0,Government,Secondary,756.0,-37.87289402,145.25755674
@@ -1556,7 +1629,22 @@ Fairhills High School,45386.0,2019,KNOXFIELD,26.0,2.3,60.7,97.0,991.0,Government
 Fairhills High School,45386.0,2020,KNOXFIELD,24.0,1.0,60.0,96.0,993.0,Government,Secondary,470.0,-37.87289402,145.25755674
 Fairhills High School,45386.0,2021,KNOXFIELD,25.0,1.0,72.5,96.0,992.0,Government,Secondary,427.0,-37.87289402,145.25755674
 Fairhills High School,45386.0,2022,KNOXFIELD,24.0,0.0,65.9,95.0,980.0,Government,Secondary,380.0,-37.87289402,145.25755674
-Fairhills High School,,2023,KNOXFIELD,26.0,0.7,51.1,87.0,,,,,,
+Fairhills High School,45386.0,2023,KNOXFIELD,26.0,0.7,51.1,87.0,,,,,,
+Federation Training,,2015,MORWELL,22.0,5.5,18.0,68.0,,,,,,
+Federation Training,,2016,NEWBOROUGH,22.0,0.0,20.0,73.0,,,,,,
+Federation Training,,2017,NEWBOROUGH,22.0,0.0,13.0,42.0,,,,,,
+Federation Training,,2018,NEWBOROUGH,24.0,0.0,33.3,67.0,,,,,,
+Federation Training,,2019,NEWBOROUGH,23.0,0.0,4.5,59.0,,,,,,
+Federation University Australia,,2014,BALLARAT,,,,,,,,,,
+Federation University Australia,,2015,BALLARAT,,,,,,,,,,
+Federation University Australia,,2016,BALLARAT,,,,,,,,,,
+Federation University Australia,,2017,BALLARAT,,,,,,,,,,
+Federation University Australia,,2018,BALLARAT,,,,,,,,,,
+Federation University Australia,,2019,BALLARAT,,,,,,,,,,
+Federation University Australia,,2020,BALLARAT,,,,,,,,,,
+Federation University Australia,,2021,BALLARAT,,,,,,,,,,
+Federation University Australia,,2022,BALLARAT,,,,,,,,,,
+Federation University Australia,,2023,BALLARAT,,,,50.0,,,,,,
 Fintona Girls School,46149.0,2014,BALWYN,37.0,37.2,98.0,100.0,1187.0,Independent,Combined,456.0,-37.814798,145.080763
 Fintona Girls School,46149.0,2015,BALWYN,36.0,34.9,100.0,100.0,1210.0,Independent,Combined,462.0,-37.814798,145.080763
 Fintona Girls School,46149.0,2016,BALWYN,35.0,24.8,98.0,100.0,1201.0,Independent,Combined,452.0,-37.814798,145.080763
@@ -1566,7 +1654,7 @@ Fintona Girls School,46149.0,2019,BALWYN,34.0,18.2,95.5,100.0,1147.0,Independent
 Fintona Girls School,46149.0,2020,BALWYN,35.0,21.3,96.3,100.0,1177.0,Independent,Combined,448.0,-37.814798,145.080763
 Fintona Girls School,46149.0,2021,BALWYN,36.0,27.8,100.0,100.0,1180.0,Independent,Combined,433.0,-37.814798,145.080763
 Fintona Girls School,46149.0,2022,BALWYN,36.0,28.3,100.0,100.0,1186.0,Independent,Combined,456.0,-37.814798,145.080763
-Fintona Girls School,,2023,BALWYN,35.0,27.7,100.0,100.0,,,,,,
+Fintona Girls School,46149.0,2023,BALWYN,35.0,27.7,100.0,100.0,,,,,,
 Firbank Grammar School,46164.0,2014,BRIGHTON,35.0,19.3,100.0,100.0,1172.0,Independent,Combined,1068.0,-37.906118,144.996936
 Firbank Grammar School,46164.0,2015,BRIGHTON,35.0,21.3,100.0,100.0,1183.0,Independent,Combined,1109.0,-37.906118,144.996936
 Firbank Grammar School,46164.0,2016,BRIGHTON,35.0,23.4,99.0,100.0,1172.0,Independent,Combined,1107.0,-37.906118,144.996936
@@ -1576,7 +1664,7 @@ Firbank Grammar School,46164.0,2019,BRIGHTON,36.0,24.1,99.1,100.0,1163.0,Indepen
 Firbank Grammar School,46164.0,2020,BRIGHTON,35.0,22.9,100.0,100.0,1163.0,Independent,Combined,1115.0,-37.906118,144.996936
 Firbank Grammar School,46164.0,2021,BRIGHTON,34.0,18.1,98.5,100.0,1157.0,Independent,Combined,1054.0,-37.906118,144.996936
 Firbank Grammar School,46164.0,2022,BRIGHTON,34.0,20.4,99.2,100.0,1150.0,Independent,Combined,1033.0,-37.906118,144.996936
-Firbank Grammar School,,2023,BRIGHTON,34.0,18.9,97.6,98.0,,,,,,
+Firbank Grammar School,46164.0,2023,BRIGHTON,34.0,18.9,97.6,98.0,,,,,,
 Fitzroy High School,45517.0,2014,FITZROY NORTH,29.0,7.5,87.0,97.0,1095.0,Government,Secondary,501.0,-37.784911,144.987476
 Fitzroy High School,45517.0,2015,FITZROY NORTH,30.0,6.0,95.0,100.0,1089.0,Government,Secondary,537.0,-37.784911,144.987476
 Fitzroy High School,45517.0,2016,FITZROY NORTH,29.0,3.5,96.0,100.0,1089.0,Government,Secondary,588.0,-37.784911,144.987476
@@ -1586,7 +1674,7 @@ Fitzroy High School,45517.0,2019,FITZROY NORTH,28.0,3.9,92.1,100.0,1085.0,Govern
 Fitzroy High School,45517.0,2020,FITZROY NORTH,29.0,3.3,69.1,89.0,1086.0,Government,Secondary,593.0,-37.784911,144.987476
 Fitzroy High School,45517.0,2021,FITZROY NORTH,29.0,3.7,83.3,98.0,1088.0,Government,Secondary,587.0,-37.784911,144.987476
 Fitzroy High School,45517.0,2022,FITZROY NORTH,30.0,5.6,68.5,93.0,1093.0,Government,Secondary,573.0,-37.784911,144.987476
-Fitzroy High School,,2023,FITZROY NORTH,27.0,5.3,68.9,98.0,,,,,,
+Fitzroy High School,45517.0,2023,FITZROY NORTH,27.0,5.3,68.9,98.0,,,,,,
 Flinders Christian Comm College,46299.0,2014,TYABB,29.0,5.9,89.0,100.0,1076.0,Independent,Combined,2150.0,-38.26334,145.167227
 Flinders Christian Comm College,46299.0,2014,CARRUM DOWNS,30.0,4.0,84.0,97.0,1076.0,Independent,Combined,2150.0,-38.26334,145.167227
 Flinders Christian Comm College,46299.0,2014,TRARALGON,29.0,5.4,95.0,100.0,1076.0,Independent,Combined,2150.0,-38.26334,145.167227
@@ -1609,18 +1697,18 @@ Flinders Christian Comm College,46299.0,2021,TYABB,29.0,5.0,86.4,100.0,1086.0,In
 Flinders Christian Comm College,46299.0,2021,CARRUM DOWNS,29.0,4.5,96.0,92.0,1086.0,Independent,Combined,1491.0,-38.26334,145.167227
 Flinders Christian Comm College,46299.0,2022,TYABB,29.0,2.6,75.3,100.0,1085.0,Independent,Combined,1500.0,-38.26334,145.167227
 Flinders Christian Comm College,46299.0,2022,CARRUM DOWNS,31.0,3.0,97.8,100.0,1085.0,Independent,Combined,1500.0,-38.26334,145.167227
-Flinders Christian Comm College,,2023,TYABB,29.0,2.3,77.0,100.0,,,,,,
-Flinders Christian Comm College,,2023,CARRUM DOWNS,30.0,4.4,70.6,100.0,,,,,,
-Footscray City College,46177.0,2014,FOOTSCRAY,27.0,1.4,80.0,98.0,1131.0,Independent,Combined,636.0,-38.17324124,145.09322974
-Footscray City College,46177.0,2015,FOOTSCRAY,30.0,3.2,70.0,96.0,1140.0,Independent,Combined,670.0,-38.17324124,145.09322974
-Footscray City College,46177.0,2016,FOOTSCRAY,28.0,5.3,79.0,98.0,1136.0,Independent,Combined,693.0,-38.17324124,145.09322974
-Footscray City College,46177.0,2017,FOOTSCRAY,29.0,4.7,80.0,99.0,1140.0,Independent,Combined,737.0,-38.17324124,145.09322974
-Footscray City College,46177.0,2018,FOOTSCRAY,30.0,9.1,72.0,99.0,1137.0,Independent,Combined,763.0,-38.17324124,145.09322974
-Footscray City College,46177.0,2019,FOOTSCRAY,29.0,5.6,88.8,99.0,1145.0,Independent,Combined,748.0,-38.17324124,145.09322974
+Flinders Christian Comm College,46299.0,2023,TYABB,29.0,2.3,77.0,100.0,,,,,,
+Flinders Christian Comm College,46299.0,2023,CARRUM DOWNS,30.0,4.4,70.6,100.0,,,,,,
+Footscray City College,52813.0,2014,FOOTSCRAY,27.0,1.4,80.0,98.0,,,,,,
+Footscray City College,52813.0,2015,FOOTSCRAY,30.0,3.2,70.0,96.0,,,,,,
+Footscray City College,52813.0,2016,FOOTSCRAY,28.0,5.3,79.0,98.0,,,,,,
+Footscray City College,52813.0,2017,FOOTSCRAY,29.0,4.7,80.0,99.0,,,,,,
+Footscray City College,52813.0,2018,FOOTSCRAY,30.0,9.1,72.0,99.0,,,,,,
+Footscray City College,52813.0,2019,FOOTSCRAY,29.0,5.6,88.8,99.0,,,,,,
 Footscray High School,52813.0,2020,FOOTSCRAY,28.0,3.4,89.3,99.0,1024.0,Government,Secondary,1436.0,-37.79107126,144.89401314
 Footscray High School,52813.0,2021,FOOTSCRAY,29.0,4.6,73.5,99.0,1037.0,Government,Secondary,1468.0,-37.7911,144.894
 Footscray High School,52813.0,2022,FOOTSCRAY,29.0,3.0,83.0,99.0,1066.0,Government,Secondary,1400.0,-37.7911,144.894
-Footscray High School,,2023,FOOTSCRAY,29.0,3.0,74.9,100.0,,,,,,
+Footscray High School,52813.0,2023,FOOTSCRAY,29.0,3.0,74.9,100.0,,,,,,
 Forest Hill College,45508.0,2014,BURWOOD EAST,26.0,2.3,69.0,95.0,1000.0,Government,Secondary,556.0,-37.847965,145.163859
 Forest Hill College,45508.0,2015,BURWOOD EAST,25.0,2.1,92.0,98.0,1013.0,Government,Secondary,642.0,-37.847965,145.163859
 Forest Hill College,45508.0,2016,BURWOOD EAST,24.0,0.7,92.0,96.0,1010.0,Government,Secondary,670.0,-37.847965,145.163859
@@ -1630,18 +1718,18 @@ Forest Hill College,45508.0,2019,BURWOOD EAST,25.0,0.0,89.6,99.0,1033.0,Governme
 Forest Hill College,45508.0,2020,BURWOOD EAST,25.0,3.7,96.2,95.0,1035.0,Government,Secondary,620.0,-37.847965,145.163859
 Forest Hill College,45508.0,2021,BURWOOD EAST,28.0,0.8,97.7,98.0,1036.0,Government,Secondary,575.0,-37.847965,145.163859
 Forest Hill College,45508.0,2022,BURWOOD EAST,27.0,2.3,100.0,100.0,1034.0,Government,Secondary,526.0,-37.847965,145.163859
-Forest Hill College,,2023,BURWOOD EAST,27.0,3.7,95.2,84.0,,,,,,
+Forest Hill College,45508.0,2023,BURWOOD EAST,27.0,3.7,95.2,84.0,,,,,,
 Foster Secondary College,45389.0,2017,FOSTER,27.0,3.5,92.0,100.0,992.0,Government,Secondary,273.0,-38.651737,146.197413
 Foster Secondary College,45389.0,2018,FOSTER,25.0,2.5,54.1,89.0,1016.0,Government,Secondary,260.0,-38.651737,146.197413
 Foster Secondary College,45389.0,2019,FOSTER,29.0,7.2,90.5,100.0,1003.0,Government,Secondary,265.0,-38.651737,146.197413
 Foster Secondary College,45389.0,2020,FOSTER,28.0,5.4,60.5,95.0,1009.0,Government,Secondary,272.0,-38.651737,146.197413
 Foster Secondary College,45389.0,2021,FOSTER,31.0,9.5,77.8,97.0,1008.0,Government,Secondary,257.0,-38.651737,146.197413
 Foster Secondary College,45389.0,2022,FOSTER,30.0,3.9,72.2,100.0,1016.0,Government,Secondary,256.0,-38.651737,146.197413
-Foster Secondary College,,2023,FOSTER,29.0,4.6,57.1,100.0,,,,,,
+Foster Secondary College,45389.0,2023,FOSTER,29.0,4.6,57.1,100.0,,,,,,
 Foundation Learning Centre,,2019,NARRE WARREN,,,,,,,,,,
 Foundation Learning Centre,,2020,NARRE WARREN,,,,,,,,,,
-Foundation Learning Centre,53015.0,2021,NARRE WARREN,,,,,,Catholic,Secondary,23.0,-37.82215686,144.9981578
-Foundation Learning Centre,53015.0,2022,NARRE WARREN,,,,,,Catholic,Secondary,28.0,-37.82215686,144.9981578
+Foundation Learning Centre,,2021,NARRE WARREN,,,,,,,,,,
+Foundation Learning Centre,,2022,NARRE WARREN,,,,,,,,,,
 Foundation Learning Centre,,2023,NARRE WARREN,,,,58.0,,,,,,
 Fountain Gate Sec College,45600.0,2014,FOUNTAIN GATE,28.0,3.5,83.0,99.0,970.0,Government,Secondary,1055.0,-38.00620519,145.2950967
 Fountain Gate Sec College,45600.0,2015,FOUNTAIN GATE,28.0,2.3,84.0,96.0,965.0,Government,Secondary,1082.0,-38.00620519,145.2950967
@@ -1652,7 +1740,7 @@ Fountain Gate Sec College,45600.0,2019,FOUNTAIN GATE,26.0,1.0,74.5,99.0,945.0,Go
 Fountain Gate Sec College,45600.0,2020,FOUNTAIN GATE,26.0,0.8,68.4,99.0,949.0,Government,Secondary,1375.0,-38.00620519,145.2950967
 Fountain Gate Sec College,45600.0,2021,FOUNTAIN GATE,25.0,0.3,57.7,96.0,948.0,Government,Secondary,1395.0,-38.00620519,145.2950967
 Fountain Gate Sec College,45600.0,2022,FOUNTAIN GATE,25.0,1.3,46.0,96.0,942.0,Government,Secondary,1364.0,-38.00620519,145.2950967
-Fountain Gate Sec College,,2023,FOUNTAIN GATE,27.0,1.5,63.8,99.0,,,,,,
+Fountain Gate Sec College,45600.0,2023,FOUNTAIN GATE,27.0,1.5,63.8,99.0,,,,,,
 Frankston High School,45390.0,2014,FRANKSTON,30.0,8.7,84.0,99.0,1042.0,Government,Secondary,1743.0,-38.16056162,145.1284347
 Frankston High School,45390.0,2015,FRANKSTON,31.0,11.6,81.0,99.0,1038.0,Government,Secondary,1749.0,-38.16056162,145.1284347
 Frankston High School,45390.0,2016,FRANKSTON,31.0,9.0,81.0,99.0,1052.0,Government,Secondary,1773.0,-38.16056162,145.1284347
@@ -1662,17 +1750,17 @@ Frankston High School,45390.0,2019,FRANKSTON,32.0,11.8,78.0,99.0,1061.0,Governme
 Frankston High School,45390.0,2020,FRANKSTON,31.0,9.8,73.3,99.0,1062.0,Government,Secondary,1959.0,-38.16056162,145.1284347
 Frankston High School,45390.0,2021,FRANKSTON,31.0,10.0,69.7,97.0,1065.0,Government,Secondary,1964.0,-38.16056162,145.1284347
 Frankston High School,45390.0,2022,FRANKSTON,31.0,10.2,62.5,97.0,1069.0,Government,Secondary,1973.0,-38.16056162,145.1284347
-Frankston High School,,2023,FRANKSTON,32.0,9.8,74.5,98.0,,,,,,
-Galen College,40726.0,2014,WANGARATTA,29.0,5.1,91.0,100.0,932.0,Government,Secondary,704.0,-38.108921,147.068006
-Galen College,40726.0,2015,WANGARATTA,29.0,3.1,80.0,98.0,931.0,Government,Secondary,756.0,-38.108921,147.068006
-Galen College,40726.0,2016,WANGARATTA,30.0,5.0,83.0,100.0,941.0,Government,Secondary,744.0,-38.108921,147.068006
-Galen College,40726.0,2017,WANGARATTA,30.0,4.2,88.0,100.0,932.0,Government,Secondary,757.0,-38.108921,147.068006
-Galen College,40726.0,2018,WANGARATTA,29.0,1.9,78.0,100.0,942.0,Government,Secondary,768.0,-38.108921,147.068006
-Galen College,40726.0,2019,WANGARATTA,29.0,4.5,75.8,100.0,946.0,Government,Secondary,798.0,-38.108921,147.068006
-Galen College,40726.0,2020,WANGARATTA,29.0,3.6,66.2,97.0,946.0,Government,Secondary,843.0,-38.108921,147.068006
-Galen College,40726.0,2021,WANGARATTA,28.0,2.5,70.7,99.0,944.0,Government,Secondary,802.0,-38.108921,147.068006
-Galen College,40726.0,2022,WANGARATTA,29.0,4.4,68.5,100.0,938.0,Government,Secondary,789.0,-38.108921,147.068006
-Galen College,,2023,WANGARATTA,28.0,3.7,56.9,100.0,,,,,,
+Frankston High School,45390.0,2023,FRANKSTON,32.0,9.8,74.5,98.0,,,,,,
+Galen College,46023.0,2014,WANGARATTA,29.0,5.1,91.0,100.0,1037.0,Catholic,Secondary,1075.0,-36.338747,146.310537
+Galen College,46023.0,2015,WANGARATTA,29.0,3.1,80.0,98.0,1031.0,Catholic,Secondary,1093.0,-36.338747,146.310537
+Galen College,46023.0,2016,WANGARATTA,30.0,5.0,83.0,100.0,1033.0,Catholic,Secondary,1135.0,-36.338747,146.310537
+Galen College,46023.0,2017,WANGARATTA,30.0,4.2,88.0,100.0,1031.0,Catholic,Secondary,1147.0,-36.338747,146.310537
+Galen College,46023.0,2018,WANGARATTA,29.0,1.9,78.0,100.0,1030.0,Catholic,Secondary,1157.0,-36.338747,146.310537
+Galen College,46023.0,2019,WANGARATTA,29.0,4.5,75.8,100.0,1029.0,Catholic,Secondary,1150.0,-36.338747,146.310537
+Galen College,46023.0,2020,WANGARATTA,29.0,3.6,66.2,97.0,1030.0,Catholic,Secondary,1141.0,-36.338747,146.310537
+Galen College,46023.0,2021,WANGARATTA,28.0,2.5,70.7,99.0,1030.0,Catholic,Secondary,1098.0,-36.338747,146.310537
+Galen College,46023.0,2022,WANGARATTA,29.0,4.4,68.5,100.0,1034.0,Catholic,Secondary,1060.0,-36.338747,146.310537
+Galen College,46023.0,2023,WANGARATTA,28.0,3.7,56.9,100.0,,,,,,
 Geelong Baptist College,46370.0,2014,LOVELY BANKS,26.0,0.0,56.0,100.0,1030.0,Independent,Combined,246.0,-38.067137,144.330286
 Geelong Baptist College,46370.0,2015,LOVELY BANKS,27.0,0.0,88.0,100.0,1028.0,Independent,Combined,281.0,-38.067137,144.330286
 Geelong Baptist College,46370.0,2016,LOVELY BANKS,26.0,0.0,67.0,100.0,,Independent,Combined,278.0,-38.067137,144.330286
@@ -1682,7 +1770,7 @@ Geelong Baptist College,46370.0,2019,LOVELY BANKS,27.0,3.3,86.4,100.0,1018.0,Ind
 Geelong Baptist College,46370.0,2020,LOVELY BANKS,25.0,1.9,72.2,100.0,1018.0,Independent,Combined,338.0,-38.068112,144.328265
 Geelong Baptist College,46370.0,2021,LOVELY BANKS,24.0,3.0,58.3,100.0,1032.0,Independent,Combined,352.0,-38.068112,144.328265
 Geelong Baptist College,46370.0,2022,LOVELY BANKS,26.0,0.9,68.4,100.0,1029.0,Independent,Combined,349.0,-38.068112,144.328265
-Geelong Baptist College,,2023,LOVELY BANKS,25.0,3.3,78.3,96.0,,,,,,
+Geelong Baptist College,46370.0,2023,LOVELY BANKS,25.0,3.3,78.3,96.0,,,,,,
 Geelong Grammar School,50402.0,2014,CORIO,33.0,13.9,83.0,100.0,1150.0,Independent,Combined,1431.0,-38.06692309,144.39852571
 Geelong Grammar School,50402.0,2015,CORIO,33.0,11.8,88.0,100.0,1154.0,Independent,Combined,1462.0,-38.06692309,144.39852571
 Geelong Grammar School,50402.0,2016,CORIO,32.0,7.3,87.0,100.0,1149.0,Independent,Combined,1457.0,-38.06692309,144.39852571
@@ -1692,7 +1780,7 @@ Geelong Grammar School,50402.0,2019,CORIO,30.0,5.8,83.5,100.0,1152.0,Independent
 Geelong Grammar School,50402.0,2020,CORIO,31.0,8.7,85.4,100.0,1152.0,Independent,Combined,1421.0,-38.06692309,144.39852571
 Geelong Grammar School,50402.0,2021,CORIO,32.0,10.6,80.2,100.0,1150.0,Independent,Combined,1335.0,-38.06692309,144.39852571
 Geelong Grammar School,50402.0,2022,CORIO,32.0,8.4,83.7,99.0,1153.0,Independent,Combined,1346.0,-38.06692309,144.39852571
-Geelong Grammar School,,2023,CORIO,32.0,10.1,77.5,100.0,,,,,,
+Geelong Grammar School,50402.0,2023,CORIO,32.0,10.1,77.5,100.0,,,,,,
 Geelong High School,45391.0,2014,EAST GEELONG,26.0,1.2,60.0,98.0,982.0,Government,Secondary,938.0,-38.153026,144.373726
 Geelong High School,45391.0,2015,EAST GEELONG,26.0,0.8,72.0,96.0,985.0,Government,Secondary,949.0,-38.153026,144.373726
 Geelong High School,45391.0,2016,EAST GEELONG,24.0,1.3,57.0,96.0,978.0,Government,Secondary,936.0,-38.153026,144.373726
@@ -1702,7 +1790,7 @@ Geelong High School,45391.0,2019,EAST GEELONG,26.0,1.5,51.9,97.0,995.0,Governmen
 Geelong High School,45391.0,2020,EAST GEELONG,27.0,3.1,55.2,93.0,998.0,Government,Secondary,934.0,-38.153026,144.373726
 Geelong High School,45391.0,2021,EAST GEELONG,26.0,1.5,47.1,97.0,999.0,Government,Secondary,938.0,-38.153026,144.373726
 Geelong High School,45391.0,2022,EAST GEELONG,27.0,5.9,51.3,96.0,998.0,Government,Secondary,931.0,-38.153026,144.373726
-Geelong High School,,2023,EAST GEELONG,26.0,1.4,40.0,94.0,,,,,,
+Geelong High School,45391.0,2023,EAST GEELONG,26.0,1.4,40.0,94.0,,,,,,
 Geelong Lutheran College,46388.0,2014,ARMSTRONG CREEK,31.0,7.1,56.0,89.0,1079.0,Independent,Combined,373.0,-38.23097342,144.3386112
 Geelong Lutheran College,46388.0,2015,ARMSTRONG CREEK,29.0,1.9,89.0,100.0,1090.0,Independent,Combined,435.0,-38.23097342,144.3386112
 Geelong Lutheran College,46388.0,2016,ARMSTRONG CREEK,30.0,3.8,89.0,100.0,1077.0,Independent,Combined,499.0,-38.23097342,144.3386112
@@ -1712,7 +1800,7 @@ Geelong Lutheran College,46388.0,2019,ARMSTRONG CREEK,28.0,2.5,93.9,100.0,1087.0
 Geelong Lutheran College,46388.0,2020,ARMSTRONG CREEK,28.0,4.2,81.5,100.0,1087.0,Independent,Combined,687.0,-38.23097342,144.3386112
 Geelong Lutheran College,46388.0,2021,ARMSTRONG CREEK,30.0,6.2,80.4,100.0,1088.0,Independent,Combined,746.0,-38.23097342,144.3386112
 Geelong Lutheran College,46388.0,2022,ARMSTRONG CREEK,30.0,3.9,88.9,100.0,1094.0,Independent,Combined,818.0,-38.23097342,144.3386112
-Geelong Lutheran College,,2023,ARMSTRONG CREEK,28.0,5.5,55.6,100.0,,,,,,
+Geelong Lutheran College,46388.0,2023,ARMSTRONG CREEK,28.0,5.5,55.6,100.0,,,,,,
 Genazzano F.C.J. College,45752.0,2014,KEW,35.0,21.6,99.0,100.0,1160.0,Catholic,Combined,1095.0,-37.808973,145.055783
 Genazzano F.C.J. College,45752.0,2015,KEW,35.0,20.5,100.0,100.0,1146.0,Catholic,Combined,1088.0,-37.808973,145.055783
 Genazzano F.C.J. College,45752.0,2016,KEW,35.0,22.6,99.0,100.0,1143.0,Catholic,Combined,1079.0,-37.808973,145.055783
@@ -1722,13 +1810,13 @@ Genazzano F.C.J. College,45752.0,2019,KEW,35.0,23.3,100.0,100.0,1131.0,Catholic,
 Genazzano F.C.J. College,45752.0,2020,KEW,34.0,19.0,100.0,100.0,1138.0,Catholic,Combined,935.0,-37.808973,145.055783
 Genazzano F.C.J. College,45752.0,2021,KEW,34.0,18.2,99.2,98.0,1137.0,Catholic,Combined,834.0,-37.808973,145.055783
 Genazzano F.C.J. College,45752.0,2022,KEW,33.0,18.1,99.1,99.0,1137.0,Catholic,Combined,768.0,-37.808973,145.055783
-Genazzano F.C.J. College,,2023,KEW,34.0,18.0,95.5,99.0,,,,,,
-Gilmore College For Girls,46239.0,2014,FOOTSCRAY,24.0,1.6,98.0,100.0,1055.0,Independent,Combined,1016.0,-37.724488,144.762878
-Gilmore College For Girls,46239.0,2015,FOOTSCRAY,24.0,0.0,94.0,93.0,1066.0,Independent,Combined,1058.0,-37.724488,144.762878
-Gilmore College For Girls,46239.0,2016,FOOTSCRAY,26.0,2.3,94.0,97.0,1053.0,Independent,Combined,1124.0,-37.724488,144.762878
-Gilmore College For Girls,46239.0,2017,FOOTSCRAY,29.0,7.4,100.0,100.0,1057.0,Independent,Combined,1197.0,-37.724488,144.762878
-Gilmore College For Girls,46239.0,2018,FOOTSCRAY,27.0,1.2,93.9,100.0,1049.0,Independent,Combined,1242.0,-37.724488,144.762878
-Gilmore College For Girls,46239.0,2019,FOOTSCRAY,25.0,0.0,96.2,96.0,1069.0,Independent,Combined,1298.0,-37.724488,144.762878
+Genazzano F.C.J. College,45752.0,2023,KEW,34.0,18.0,95.5,99.0,,,,,,
+Gilmore College For Girls,52813.0,2014,FOOTSCRAY,24.0,1.6,98.0,100.0,,,,,,
+Gilmore College For Girls,52813.0,2015,FOOTSCRAY,24.0,0.0,94.0,93.0,,,,,,
+Gilmore College For Girls,52813.0,2016,FOOTSCRAY,26.0,2.3,94.0,97.0,,,,,,
+Gilmore College For Girls,52813.0,2017,FOOTSCRAY,29.0,7.4,100.0,100.0,,,,,,
+Gilmore College For Girls,52813.0,2018,FOOTSCRAY,27.0,1.2,93.9,100.0,,,,,,
+Gilmore College For Girls,52813.0,2019,FOOTSCRAY,25.0,0.0,96.2,96.0,,,,,,
 Gilson College,46239.0,2014,TAYLORS HILL,28.0,4.7,94.0,99.0,1055.0,Independent,Combined,1016.0,-37.724488,144.762878
 Gilson College,46239.0,2015,TAYLORS HILL,29.0,6.6,97.0,100.0,1066.0,Independent,Combined,1058.0,-37.724488,144.762878
 Gilson College,46239.0,2016,TAYLORS HILL,29.0,6.8,81.0,99.0,1053.0,Independent,Combined,1124.0,-37.724488,144.762878
@@ -1742,8 +1830,8 @@ Gilson College,46239.0,2021,TAYLORS HILL,29.0,5.0,91.2,100.0,1074.0,Independent,
 Gilson College,46239.0,2021,MERNDA,29.0,2.9,100.0,100.0,1074.0,Independent,Combined,1290.0,-37.724488,144.762878
 Gilson College,46239.0,2022,TAYLORS HILL,28.0,1.9,92.2,100.0,1083.0,Independent,Combined,1276.0,-37.724488,144.762878
 Gilson College,46239.0,2022,MERNDA,28.0,0.0,80.0,100.0,1083.0,Independent,Combined,1276.0,-37.724488,144.762878
-Gilson College,,2023,TAYLORS HILL,27.0,2.3,81.4,100.0,,,,,,
-Gilson College,,2023,MERNDA,26.0,4.2,100.0,100.0,,,,,,
+Gilson College,46239.0,2023,TAYLORS HILL,27.0,2.3,81.4,100.0,,,,,,
+Gilson College,46239.0,2023,MERNDA,26.0,4.2,100.0,100.0,,,,,,
 Gippsland Grammar,46196.0,2014,SALE,32.0,9.9,94.0,100.0,1106.0,Independent,Combined,907.0,-38.093651,147.064627
 Gippsland Grammar,46196.0,2015,SALE,33.0,11.1,95.0,100.0,1104.0,Independent,Combined,924.0,-38.093651,147.064627
 Gippsland Grammar,46196.0,2016,SALE,31.0,8.3,92.0,100.0,1108.0,Independent,Combined,921.0,-38.093651,147.064627
@@ -1753,7 +1841,7 @@ Gippsland Grammar,46196.0,2019,SALE,32.0,11.8,83.1,98.0,1094.0,Independent,Combi
 Gippsland Grammar,46196.0,2020,SALE,32.0,9.8,91.9,99.0,1094.0,Independent,Combined,1005.0,-38.093651,147.064627
 Gippsland Grammar,46196.0,2021,SALE,31.0,7.6,83.9,99.0,1100.0,Independent,Combined,1007.0,-38.093651,147.064627
 Gippsland Grammar,46196.0,2022,SALE,30.0,6.7,86.4,99.0,1109.0,Independent,Combined,1014.0,-38.093651,147.064627
-Gippsland Grammar,,2023,SALE,31.0,8.1,80.0,97.0,,,,,,
+Gippsland Grammar,46196.0,2023,SALE,31.0,8.1,80.0,97.0,,,,,,
 Girton Grammar School,46325.0,2014,BENDIGO,33.0,18.0,95.0,100.0,1106.0,Independent,Combined,1182.0,-36.761969,144.270883
 Girton Grammar School,46325.0,2015,BENDIGO,34.0,18.5,97.0,100.0,1115.0,Independent,Combined,1167.0,-36.761969,144.270883
 Girton Grammar School,46325.0,2016,BENDIGO,34.0,20.1,98.0,100.0,1120.0,Independent,Combined,1159.0,-36.761969,144.270883
@@ -1763,7 +1851,7 @@ Girton Grammar School,46325.0,2019,BENDIGO,32.0,11.8,94.7,100.0,1123.0,Independe
 Girton Grammar School,46325.0,2020,BENDIGO,32.0,12.7,94.7,100.0,1131.0,Independent,Combined,1064.0,-36.761969,144.270883
 Girton Grammar School,46325.0,2021,BENDIGO,33.0,18.2,95.3,100.0,1129.0,Independent,Combined,1026.0,-36.761969,144.270883
 Girton Grammar School,46325.0,2022,BENDIGO,32.0,13.2,91.6,99.0,1135.0,Independent,Combined,1014.0,-36.761969,144.270883
-Girton Grammar School,,2023,BENDIGO,33.0,15.9,86.6,100.0,,,,,,
+Girton Grammar School,46325.0,2023,BENDIGO,33.0,15.9,86.6,100.0,,,,,,
 Gisborne Secondary College,45393.0,2014,GISBORNE,27.0,2.8,66.0,92.0,1010.0,Government,Secondary,998.0,-37.49811364,144.58477412
 Gisborne Secondary College,45393.0,2015,GISBORNE,28.0,4.2,76.0,92.0,1010.0,Government,Secondary,1032.0,-37.49811364,144.58477412
 Gisborne Secondary College,45393.0,2016,GISBORNE,25.0,3.2,66.0,97.0,1011.0,Government,Secondary,1040.0,-37.49811364,144.58477412
@@ -1773,7 +1861,7 @@ Gisborne Secondary College,45393.0,2019,GISBORNE,24.0,1.8,75.9,96.0,1008.0,Gover
 Gisborne Secondary College,45393.0,2020,GISBORNE,26.0,2.1,63.4,97.0,1008.0,Government,Secondary,1214.0,-37.49811364,144.58477412
 Gisborne Secondary College,45393.0,2021,GISBORNE,28.0,4.8,66.1,98.0,1010.0,Government,Secondary,1156.0,-37.49811364,144.58477412
 Gisborne Secondary College,45393.0,2022,GISBORNE,27.0,4.8,65.8,98.0,1013.0,Government,Secondary,1115.0,-37.49811364,144.58477412
-Gisborne Secondary College,,2023,GISBORNE,26.0,2.6,56.1,97.0,,,,,,
+Gisborne Secondary College,45393.0,2023,GISBORNE,26.0,2.6,56.1,97.0,,,,,,
 Gladstone Park Sec College,45394.0,2014,GLADSTONE PARK,29.0,3.6,98.0,99.0,987.0,Government,Secondary,1594.0,-37.68921,144.890816
 Gladstone Park Sec College,45394.0,2015,GLADSTONE PARK,29.0,4.8,100.0,100.0,991.0,Government,Secondary,1548.0,-37.68921,144.890816
 Gladstone Park Sec College,45394.0,2016,GLADSTONE PARK,29.0,5.0,95.0,99.0,989.0,Government,Secondary,1589.0,-37.68921,144.890816
@@ -1783,7 +1871,7 @@ Gladstone Park Sec College,45394.0,2019,GLADSTONE PARK,28.0,2.8,87.3,99.0,995.0,
 Gladstone Park Sec College,45394.0,2020,GLADSTONE PARK,29.0,5.1,85.4,98.0,996.0,Government,Secondary,1640.0,-37.68921,144.890816
 Gladstone Park Sec College,45394.0,2021,GLADSTONE PARK,28.0,4.4,81.7,100.0,997.0,Government,Secondary,1610.0,-37.68921,144.890816
 Gladstone Park Sec College,45394.0,2022,GLADSTONE PARK,27.0,3.4,77.6,99.0,993.0,Government,Secondary,1498.0,-37.68921,144.890816
-Gladstone Park Sec College,,2023,GLADSTONE PARK,27.0,3.2,82.7,98.0,,,,,,
+Gladstone Park Sec College,45394.0,2023,GLADSTONE PARK,27.0,3.2,82.7,98.0,,,,,,
 Glen Eira College,45495.0,2014,CAULFIELD EAST,28.0,5.0,94.0,100.0,1054.0,Government,Secondary,638.0,-37.8857,145.038006
 Glen Eira College,45495.0,2015,CAULFIELD EAST,28.0,6.8,98.0,100.0,1065.0,Government,Secondary,680.0,-37.8857,145.038006
 Glen Eira College,45495.0,2016,CAULFIELD EAST,29.0,3.2,88.0,100.0,1073.0,Government,Secondary,718.0,-37.8857,145.038006
@@ -1793,7 +1881,7 @@ Glen Eira College,45495.0,2019,CAULFIELD EAST,30.0,5.7,87.8,100.0,1095.0,Governm
 Glen Eira College,45495.0,2020,CAULFIELD EAST,31.0,5.9,79.4,99.0,1101.0,Government,Secondary,832.0,-37.8857,145.038006
 Glen Eira College,45495.0,2021,CAULFIELD EAST,31.0,5.2,85.9,98.0,1106.0,Government,Secondary,863.0,-37.8857,145.038006
 Glen Eira College,45495.0,2022,CAULFIELD EAST,31.0,10.1,81.5,98.0,1115.0,Government,Secondary,855.0,-37.8857,145.038006
-Glen Eira College,,2023,CAULFIELD EAST,32.0,9.1,91.9,99.0,,,,,,
+Glen Eira College,45495.0,2023,CAULFIELD EAST,32.0,9.1,91.9,99.0,,,,,,
 Glen Waverley Sec College,45546.0,2014,GLEN WAVERLEY,34.0,20.3,97.0,100.0,1098.0,Government,Secondary,2011.0,-37.87811,145.162714
 Glen Waverley Sec College,45546.0,2015,GLEN WAVERLEY,33.0,16.5,97.0,100.0,1097.0,Government,Secondary,2001.0,-37.87811,145.162714
 Glen Waverley Sec College,45546.0,2016,GLEN WAVERLEY,33.0,15.2,95.0,100.0,1093.0,Government,Secondary,1964.0,-37.87811,145.162714
@@ -1803,7 +1891,7 @@ Glen Waverley Sec College,45546.0,2019,GLEN WAVERLEY,33.0,13.9,95.3,100.0,1115.0
 Glen Waverley Sec College,45546.0,2020,GLEN WAVERLEY,32.0,12.9,96.2,100.0,1116.0,Government,Secondary,1962.0,-37.87811,145.162714
 Glen Waverley Sec College,45546.0,2021,GLEN WAVERLEY,32.0,12.5,96.8,100.0,1118.0,Government,Secondary,1987.0,-37.87811,145.162714
 Glen Waverley Sec College,45546.0,2022,GLEN WAVERLEY,33.0,13.4,93.2,100.0,1121.0,Government,Secondary,2018.0,-37.87811,145.162714
-Glen Waverley Sec College,,2023,GLEN WAVERLEY,33.0,13.5,94.2,99.0,,,,,,
+Glen Waverley Sec College,45546.0,2023,GLEN WAVERLEY,33.0,13.5,94.2,99.0,,,,,,
 Gleneagles Secondary College,45599.0,2014,ENDEAVOUR HILLS,28.0,4.2,97.0,98.0,982.0,Government,Secondary,1363.0,-37.97435311,145.27628069
 Gleneagles Secondary College,45599.0,2015,ENDEAVOUR HILLS,29.0,4.4,93.0,97.0,984.0,Government,Secondary,1356.0,-37.97435311,145.27628069
 Gleneagles Secondary College,45599.0,2016,ENDEAVOUR HILLS,29.0,4.4,91.0,98.0,973.0,Government,Secondary,1378.0,-37.97435311,145.27628069
@@ -1813,9 +1901,17 @@ Gleneagles Secondary College,45599.0,2019,ENDEAVOUR HILLS,27.0,5.3,84.4,97.0,978
 Gleneagles Secondary College,45599.0,2020,ENDEAVOUR HILLS,28.0,5.2,82.6,99.0,978.0,Government,Secondary,1515.0,-37.97435311,145.27628069
 Gleneagles Secondary College,45599.0,2021,ENDEAVOUR HILLS,28.0,2.8,67.0,99.0,978.0,Government,Secondary,1533.0,-37.97435311,145.27628069
 Gleneagles Secondary College,45599.0,2022,ENDEAVOUR HILLS,27.0,2.8,68.8,96.0,972.0,Government,Secondary,1472.0,-37.97435311,145.27628069
-Gleneagles Secondary College,,2023,ENDEAVOUR HILLS,29.0,4.3,75.3,100.0,,,,,,
+Gleneagles Secondary College,45599.0,2023,ENDEAVOUR HILLS,29.0,4.3,75.3,100.0,,,,,,
+Glenroy Neighbourhood Centre,44907.0,2014,GLENROY,,,,,,Government,Special,128.0,-37.69931796,144.91941199
+Glenroy Neighbourhood Centre,44907.0,2015,GLENROY,,,,,,Government,Special,129.0,-37.69931796,144.91941199
+Glenroy Neighbourhood Centre,44907.0,2016,GLENROY,,,,,,Government,Special,133.0,-37.69931796,144.91941199
+Glenroy Neighbourhood Centre,44907.0,2017,GLENROY,,,,,,Government,Special,143.0,-37.69931796,144.91941199
+Glenroy Neighbourhood Centre,44907.0,2018,GLENROY,,,,,980.0,Government,Special,139.0,-37.69931796,144.91941199
+Glenroy Neighbourhood Centre,44907.0,2019,GLENROY,,,,,989.0,Government,Special,133.0,-37.69931796,144.91941199
+Glenroy Neighbourhood Centre,44907.0,2020,GLENROY,,,,,994.0,Government,Special,135.0,-37.69931796,144.91941199
+Glenroy Neighbourhood Centre,44907.0,2021,GLENROY,,,,,1001.0,Government,Special,137.0,-37.69931796,144.91941199
 Glenroy Private,50503.0,2022,GLENROY,20.0,0.0,100.0,75.0,973.0,Independent,Combined,435.0,-37.697077,144.928185
-Glenroy Private,,2023,GLENROY,22.0,,84.6,85.0,,,,,,
+Glenroy Private,50503.0,2023,GLENROY,22.0,,84.6,85.0,,,,,,
 Glenroy Secondary College,45625.0,2014,GLENROY,26.0,2.3,54.0,85.0,921.0,Government,Secondary,485.0,-37.705324,144.927565
 Glenroy Secondary College,45625.0,2015,GLENROY,25.0,0.8,67.0,85.0,930.0,Government,Secondary,490.0,-37.705324,144.927565
 Glenroy Secondary College,45625.0,2016,GLENROY,26.0,0.0,67.0,83.0,920.0,Government,Secondary,459.0,-37.705324,144.927565
@@ -1825,13 +1921,17 @@ Glenroy Secondary College,45625.0,2019,GLENROY,24.0,0.9,93.9,98.0,919.0,Governme
 Glenroy Secondary College,45625.0,2020,GLENROY,20.0,0.7,83.8,86.0,917.0,Government,Secondary,426.0,-37.705324,144.927565
 Glenroy Secondary College,45625.0,2021,GLENROY,23.0,0.0,69.0,83.0,911.0,Government,Secondary,435.0,-37.705324,144.927565
 Glenroy Secondary College,45625.0,2022,GLENROY,21.0,0.0,83.8,97.0,913.0,Government,Secondary,436.0,-37.705324,144.927565
-Glenroy Secondary College,,2023,GLENROY,22.0,,47.4,82.0,,,,,,
-Glenvale School,44939.0,2014,YARRAMBAT,31.0,14.9,0.0,98.0,,Government,Special,138.0,-37.8883595,145.16174647
-Glenvale School,44939.0,2015,BROADMEADOWS,31.0,12.6,0.0,100.0,,Government,Special,146.0,-37.8883595,145.16174647
-Glenvale School,44939.0,2016,BROADMEADOWS,33.0,12.3,0.0,96.0,,Government,Special,145.0,-37.8883595,145.16174647
-Glenvale School,44939.0,2017,BROADMEADOWS,32.0,13.0,0.0,98.0,,Government,Special,157.0,-37.8883595,145.16174647
-Glenvale School,44939.0,2018,EPPING,32.0,10.3,0.0,100.0,1050.0,Government,Special,166.0,-37.8883595,145.16174647
-Glenvale School,44939.0,2019,EPPING,30.0,9.4,0.0,100.0,1049.0,Government,Special,173.0,-37.8883595,145.16174647
+Glenroy Secondary College,45625.0,2023,GLENROY,22.0,,47.4,82.0,,,,,,
+Glenvale School,46360.0,2014,YARRAMBAT,31.0,14.9,0.0,98.0,1028.0,Independent,Combined,574.0,-37.64322649,145.13881141
+Glenvale School,46360.0,2015,BROADMEADOWS,31.0,12.6,0.0,100.0,1055.0,Independent,Combined,575.0,-37.64322649,145.13881141
+Glenvale School,46360.0,2016,BROADMEADOWS,33.0,12.3,0.0,96.0,,Independent,Combined,576.0,-37.64322649,145.13881141
+Glenvale School,46360.0,2017,BROADMEADOWS,32.0,13.0,0.0,98.0,,Independent,Combined,579.0,-37.64322649,145.13881141
+Glenvale School,46360.0,2018,EPPING,32.0,10.3,0.0,100.0,1008.0,Independent,Combined,555.0,-37.64322649,145.13881141
+Glenvale School,46360.0,2019,EPPING,30.0,9.4,0.0,100.0,1001.0,Independent,Combined,562.0,-37.64322649,145.13881141
+Goldfields Employment & Learn,,2014,MARYBOROUGH,,,,,,,,,,
+Goldfields Employment & Learn,,2015,MARYBOROUGH,,,,,,,,,,
+Goldfields Employment & Learn,,2016,MARYBOROUGH,,,,,,,,,,
+Goldfields Employment & Learn,,2017,MARYBOROUGH,,,,,,,,,,
 Good News Lutheran College,46334.0,2015,TARNEIT,25.0,0.0,,,1071.0,Independent,Combined,676.0,-37.855204,144.665994
 Good News Lutheran College,46334.0,2016,TARNEIT,25.0,0.0,85.0,100.0,1076.0,Independent,Combined,786.0,-37.855204,144.665994
 Good News Lutheran College,46334.0,2017,TARNEIT,25.0,0.6,90.0,100.0,1073.0,Independent,Combined,879.0,-37.855204,144.665994
@@ -1840,7 +1940,7 @@ Good News Lutheran College,46334.0,2019,TARNEIT,24.0,0.0,79.3,97.0,1086.0,Indepe
 Good News Lutheran College,46334.0,2020,TARNEIT,26.0,0.8,78.4,100.0,1086.0,Independent,Combined,1110.0,-37.855204,144.665994
 Good News Lutheran College,46334.0,2021,TARNEIT,28.0,3.9,83.3,98.0,1096.0,Independent,Combined,1192.0,-37.855204,144.665994
 Good News Lutheran College,46334.0,2022,TARNEIT,29.0,0.8,84.7,100.0,1101.0,Independent,Combined,1261.0,-37.855204,144.665994
-Good News Lutheran College,,2023,TARNEIT,29.0,6.1,94.5,100.0,,,,,,
+Good News Lutheran College,46334.0,2023,TARNEIT,29.0,6.1,94.5,100.0,,,,,,
 Good Shepherd College,46267.0,2014,HAMILTON,27.0,0.0,50.0,100.0,1005.0,Independent,Combined,119.0,-37.768839,142.040519
 Good Shepherd College,46267.0,2015,HAMILTON,30.0,9.1,57.0,100.0,1014.0,Independent,Combined,129.0,-37.768839,142.040519
 Good Shepherd College,46267.0,2016,HAMILTON,32.0,7.1,67.0,100.0,998.0,Independent,Combined,129.0,-37.768839,142.040519
@@ -1850,7 +1950,17 @@ Good Shepherd College,46267.0,2019,HAMILTON,30.0,3.8,75.0,100.0,1015.0,Independe
 Good Shepherd College,46267.0,2020,HAMILTON,26.0,8.5,70.0,90.0,1015.0,Independent,Combined,198.0,-37.768839,142.040519
 Good Shepherd College,46267.0,2021,HAMILTON,27.0,0.0,66.7,83.0,1017.0,Independent,Combined,221.0,-37.768839,142.040519
 Good Shepherd College,46267.0,2022,HAMILTON,27.0,0.0,83.3,100.0,1029.0,Independent,Combined,220.0,-37.768839,142.040519
-Good Shepherd College,,2023,HAMILTON,25.0,,14.3,43.0,,,,,,
+Good Shepherd College,46267.0,2023,HAMILTON,25.0,,14.3,43.0,,,,,,
+Gordon Institute,,2014,GEELONG,21.0,0.0,44.0,97.0,,,,,,
+Gordon Institute,,2015,GEELONG,23.0,1.7,52.0,88.0,,,,,,
+Gordon Institute,,2016,GEELONG,21.0,0.0,48.0,85.0,,,,,,
+Gordon Institute,,2017,GEELONG,24.0,0.0,42.0,94.0,,,,,,
+Gordon Institute of TAFE,,2018,GEELONG,22.0,0.0,48.3,93.0,,,,,,
+Gordon Institute of TAFE,,2019,GEELONG,21.0,5.6,32.1,93.0,,,,,,
+Gordon Institute of TAFE,,2020,GEELONG,27.0,0.0,41.4,97.0,,,,,,
+Gordon Institute of TAFE,,2021,GEELONG,27.0,2.0,33.3,100.0,,,,,,
+Gordon Institute of TAFE,,2022,GEELONG,28.0,0.0,42.1,89.0,,,,,,
+Gordon Institute of TAFE,,2023,GEELONG,22.0,,20.7,90.0,,,,,,
 Goroke P-12 College,45301.0,2014,GOROKE,27.0,0.0,71.0,100.0,986.0,Government,Combined,96.0,-36.71571458,141.48337571
 Goroke P-12 College,45301.0,2015,GOROKE,28.0,0.0,75.0,100.0,968.0,Government,Combined,96.0,-36.71571458,141.48337571
 Goroke P-12 College,45301.0,2016,GOROKE,30.0,4.8,100.0,100.0,988.0,Government,Combined,80.0,-36.71571458,141.48337571
@@ -1860,7 +1970,17 @@ Goroke P-12 College,45301.0,2019,GOROKE,34.0,25.0,100.0,100.0,920.0,Government,C
 Goroke P-12 College,45301.0,2020,GOROKE,,,100.0,100.0,944.0,Government,Combined,63.0,-36.71571458,141.48337571
 Goroke P-12 College,45301.0,2021,GOROKE,,,,,925.0,Government,Combined,68.0,-36.71571458,141.48337571
 Goroke P-12 College,45301.0,2022,GOROKE,32.0,5.9,100.0,100.0,937.0,Government,Combined,77.0,-36.71571458,141.48337571
-Goroke P-12 College,,2023,GOROKE,,,,,,,,,,
+Goroke P-12 College,45301.0,2023,GOROKE,,,,,,,,,,
+Goulburn Ovens Inst of TAFE,,2014,SHEPPARTON,,,,,,,,,,
+Goulburn Ovens Inst of TAFE,,2015,SHEPPARTON,,,,,,,,,,
+Goulburn Ovens Inst of TAFE,,2016,SHEPPARTON,,,,,,,,,,
+Goulburn Ovens Inst of TAFE,,2017,SHEPPARTON,,,,,,,,,,
+Goulburn Ovens Inst of TAFE,,2018,SHEPPARTON,,,,,,,,,,
+Goulburn Ovens Inst of TAFE,,2019,SHEPPARTON,,,,,,,,,,
+Goulburn Ovens Inst of TAFE,,2020,SHEPPARTON,,,,,,,,,,
+Goulburn Ovens Inst of TAFE,,2021,SHEPPARTON,,,,,,,,,,
+Goulburn Ovens Inst of TAFE,,2022,SHEPPARTON,,,,,,,,,,
+Goulburn Ovens Inst of TAFE,,2023,SHEPPARTON,,,5.9,86.0,,,,,,
 Goulburn Valley Grammar Schl,46273.0,2014,SHEPPARTON,33.0,16.5,97.0,99.0,1122.0,Independent,Combined,680.0,-36.327476,145.415577
 Goulburn Valley Grammar Schl,46273.0,2015,SHEPPARTON,35.0,21.4,98.0,99.0,1127.0,Independent,Combined,690.0,-36.327476,145.415577
 Goulburn Valley Grammar Schl,46273.0,2016,SHEPPARTON,35.0,22.8,99.0,100.0,1127.0,Independent,Combined,696.0,-36.327476,145.415577
@@ -1869,16 +1989,16 @@ Goulburn Valley Grammar Schl,46273.0,2019,SHEPPARTON,33.0,17.5,95.5,100.0,1123.0
 Goulburn Valley Grammar Schl,46273.0,2020,SHEPPARTON,35.0,21.6,94.7,100.0,1123.0,Independent,Combined,687.0,-36.327476,145.415577
 Goulburn Valley Grammar Schl,46273.0,2021,SHEPPARTON,34.0,17.4,97.7,100.0,1122.0,Independent,Combined,688.0,-36.327476,145.415577
 Goulburn Valley Grammar Schl,46273.0,2022,SHEPPARTON,34.0,19.5,92.4,100.0,1127.0,Independent,Combined,690.0,-36.327476,145.415577
-Goulburn Valley Grammar Schl,,2023,SHEPPARTON,35.0,19.2,95.8,100.0,,,,,,
+Goulburn Valley Grammar Schl,46273.0,2023,SHEPPARTON,35.0,19.2,95.8,100.0,,,,,,
 Goulburn Valley Grammar School,46273.0,2017,SHEPPARTON,34.0,17.2,97.0,100.0,1127.0,Independent,Combined,693.0,-36.327476,145.415577
 Grace Christian College Wodonga,46302.0,2022,LENEVA,,,25.0,,1036.0,Independent,Combined,135.0,-36.157173,146.887345
-Grace Christian College Wodonga,,2023,LENEVA,,,50.0,100.0,,,,,,
-Greater Shepparton SC - McGuire,,2020,SHEPPARTON,22.0,0.0,60.0,84.0,,,,,,
-Greater Shepparton SC - Wanganui,,2020,SHEPPARTON,24.0,2.0,79.2,98.0,,,,,,
-Greater Shepparton SC McGuire,,2021,SHEPPARTON,24.0,0.0,57.1,93.0,,,,,,
-Greater Shepparton SC Wanganui,,2021,SHEPPARTON,24.0,0.4,57.0,97.0,,,,,,
+Grace Christian College Wodonga,46302.0,2023,LENEVA,,,50.0,100.0,,,,,,
+Greater Shepparton SC - McGuire,53105.0,2020,SHEPPARTON,22.0,0.0,60.0,84.0,,,,,,
+Greater Shepparton SC - Wanganui,53105.0,2020,SHEPPARTON,24.0,2.0,79.2,98.0,,,,,,
+Greater Shepparton SC McGuire,53105.0,2021,SHEPPARTON,24.0,0.0,57.1,93.0,,,,,,
+Greater Shepparton SC Wanganui,53105.0,2021,SHEPPARTON,24.0,0.4,57.0,97.0,,,,,,
 Greater Shepparton Sec College,53105.0,2022,SHEPPARTON,25.0,0.8,68.9,97.0,918.0,Government,Secondary,2083.0,-36.3727899419763,145.415246069628
-Greater Shepparton Sec College,,2023,SHEPPARTON,22.0,0.3,65.1,96.0,,,,,,
+Greater Shepparton Sec College,53105.0,2023,SHEPPARTON,22.0,0.3,65.1,96.0,,,,,,
 Greensborough Sec College,45522.0,2014,GREENSBOROUGH,27.0,4.8,81.0,95.0,998.0,Government,Secondary,881.0,-37.70865867,145.09012899
 Greensborough Sec College,45522.0,2015,GREENSBOROUGH,27.0,3.7,76.0,95.0,999.0,Government,Secondary,805.0,-37.70865867,145.09012899
 Greensborough Sec College,45522.0,2016,GREENSBOROUGH,27.0,5.4,83.0,95.0,1005.0,Government,Secondary,741.0,-37.70865867,145.09012899
@@ -1888,7 +2008,7 @@ Greensborough Sec College,45522.0,2019,GREENSBOROUGH,26.0,3.0,78.3,98.0,996.0,Go
 Greensborough Sec College,45522.0,2020,GREENSBOROUGH,27.0,1.8,83.3,94.0,1004.0,Government,Secondary,441.0,-37.70865867,145.09012899
 Greensborough Sec College,45522.0,2021,GREENSBOROUGH,26.0,1.0,90.9,100.0,998.0,Government,Secondary,447.0,-37.70865867,145.09012899
 Greensborough Sec College,45522.0,2022,GREENSBOROUGH,28.0,1.5,74.3,91.0,1005.0,Government,Secondary,447.0,-37.70865867,145.09012899
-Greensborough Sec College,,2023,GREENSBOROUGH,22.0,,55.9,94.0,,,,,,
+Greensborough Sec College,45522.0,2023,GREENSBOROUGH,22.0,,55.9,94.0,,,,,,
 Grovedale College,45331.0,2014,GROVEDALE,27.0,1.3,72.0,99.0,980.0,Government,Secondary,874.0,-38.2110078,144.32715137
 Grovedale College,45331.0,2015,GROVEDALE,26.0,2.6,58.0,95.0,977.0,Government,Secondary,823.0,-38.2110078,144.32715137
 Grovedale College,45331.0,2016,GROVEDALE,27.0,1.9,53.0,99.0,982.0,Government,Secondary,846.0,-38.2110078,144.32715137
@@ -1898,7 +2018,7 @@ Grovedale College,45331.0,2019,GROVEDALE,25.0,1.2,64.5,99.0,988.0,Government,Sec
 Grovedale College,45331.0,2020,GROVEDALE,25.0,2.0,54.3,100.0,992.0,Government,Secondary,851.0,-38.2110078,144.32715137
 Grovedale College,45331.0,2021,GROVEDALE,24.0,0.8,52.6,95.0,995.0,Government,Secondary,801.0,-38.2110078,144.32715137
 Grovedale College,45331.0,2022,GROVEDALE,26.0,0.9,56.3,96.0,991.0,Government,Secondary,724.0,-38.2110078,144.32715137
-Grovedale College,,2023,GROVEDALE,25.0,1.3,39.0,98.0,,,,,,
+Grovedale College,45331.0,2023,GROVEDALE,25.0,1.3,39.0,98.0,,,,,,
 Haileybury College,46189.0,2014,KEYSBOROUGH,35.0,25.0,90.0,100.0,1156.0,Independent,Combined,3366.0,-37.995979,145.14643
 Haileybury College,46189.0,2015,KEYSBOROUGH,35.0,26.4,94.0,100.0,1169.0,Independent,Combined,3426.0,-37.995979,145.14643
 Haileybury College,46189.0,2016,KEYSBOROUGH,35.0,24.0,93.0,100.0,1167.0,Independent,Combined,3435.0,-37.995979,145.14643
@@ -1908,7 +2028,7 @@ Haileybury College,46189.0,2019,KEYSBOROUGH,36.0,29.2,92.2,100.0,1179.0,Independ
 Haileybury College,46189.0,2020,KEYSBOROUGH,35.0,26.8,93.5,100.0,1179.0,Independent,Combined,4206.0,-37.995979,145.14643
 Haileybury College,46189.0,2021,KEYSBOROUGH,35.0,29.2,94.4,100.0,1181.0,Independent,Combined,4304.0,-37.995979,145.14643
 Haileybury College,46189.0,2022,KEYSBOROUGH,36.0,29.5,93.5,100.0,1181.0,Independent,Combined,4432.0,-37.995979,145.14643
-Haileybury College,,2023,KEYSBOROUGH,35.0,26.3,95.3,100.0,,,,,,
+Haileybury College,46189.0,2023,KEYSBOROUGH,35.0,26.3,95.3,100.0,,,,,,
 Haileybury Girls College,46189.0,2014,KEYSBOROUGH,36.0,25.8,94.0,100.0,1156.0,Independent,Combined,3366.0,-37.995979,145.14643
 Haileybury Girls College,46189.0,2015,KEYSBOROUGH,36.0,28.8,99.0,100.0,1169.0,Independent,Combined,3426.0,-37.995979,145.14643
 Haileybury Girls College,46189.0,2016,KEYSBOROUGH,36.0,30.0,97.0,100.0,1167.0,Independent,Combined,3435.0,-37.995979,145.14643
@@ -1918,23 +2038,23 @@ Haileybury Girls College,46189.0,2019,KEYSBOROUGH,36.0,30.6,97.1,100.0,1179.0,In
 Haileybury Girls College,46189.0,2020,KEYSBOROUGH,36.0,29.2,97.1,100.0,1179.0,Independent,Combined,4206.0,-37.995979,145.14643
 Haileybury Girls College,46189.0,2021,KEYSBOROUGH,37.0,37.2,98.8,100.0,1181.0,Independent,Combined,4304.0,-37.995979,145.14643
 Haileybury Girls College,46189.0,2022,KEYSBOROUGH,36.0,33.5,98.3,99.0,1181.0,Independent,Combined,4432.0,-37.995979,145.14643
-Haileybury Girls College,,2023,KEYSBOROUGH,36.0,28.6,97.3,100.0,,,,,,
-Haileybury Rendall School,44917.0,2018,BERRIMAH,33.0,18.2,,,1017.0,Government,Special,114.0,-37.938959,145.031808
-Haileybury Rendall School,44917.0,2019,BERRIMAH,28.0,1.8,31.6,100.0,1023.0,Government,Special,115.0,-37.938959,145.031808
-Haileybury Rendall School,44917.0,2020,BERRIMAH,32.0,17.2,68.2,95.0,1032.0,Government,Special,106.0,-37.938959,145.031808
-Haileybury Rendall School,44917.0,2021,BERRIMAH,31.0,12.0,34.4,100.0,1037.0,Government,Special,108.0,-37.938959,145.031808
-Haileybury Rendall School,44917.0,2022,BERRIMAH,29.0,5.4,24.1,100.0,1021.0,Government,Special,106.0,-37.938959,145.031808
-Haileybury Rendall School,,2023,BERRIMAH,32.0,13.1,47.2,97.0,,,,,,
-Hallam Senior Sec College,45326.0,2014,HALLAM,22.0,0.1,58.0,94.0,1050.0,Government,Combined,706.0,-37.809243,145.111907
-Hallam Senior Sec College,45326.0,2015,HALLAM,21.0,0.0,47.0,94.0,1050.0,Government,Combined,634.0,-37.809243,145.111907
-Hallam Senior Sec College,45326.0,2016,HALLAM,21.0,0.1,71.0,94.0,1056.0,Government,Combined,545.0,-37.809243,145.111907
-Hallam Senior Sec College,45326.0,2017,HALLAM,21.0,0.2,62.0,90.0,1047.0,Government,Combined,481.0,-37.809243,145.111907
-Hallam Senior Sec College,45326.0,2018,HALLAM,22.0,0.4,68.8,93.0,1045.0,Government,Secondary,485.0,-37.809243,145.111907
-Hallam Senior Sec College,45326.0,2019,HALLAM,22.0,0.3,49.2,89.0,1048.0,Government,Secondary,406.0,-37.809243,145.111907
-Hallam Senior Sec College,45326.0,2020,HALLAM,23.0,0.6,60.5,95.0,1051.0,Government,Secondary,338.0,-37.809243,145.111907
-Hallam Senior Sec College,45326.0,2021,HALLAM,23.0,1.6,42.0,88.0,1052.0,Government,Secondary,334.0,-37.809243,145.111907
-Hallam Senior Sec College,45326.0,2022,HALLAM,25.0,0.0,42.3,85.0,1055.0,Government,Secondary,361.0,-37.809243,145.111907
-Hallam Senior Sec College,,2023,HALLAM,23.0,1.3,24.3,95.0,,,,,,
+Haileybury Girls College,46189.0,2023,KEYSBOROUGH,36.0,28.6,97.3,100.0,,,,,,
+Haileybury Rendall School,46189.0,2018,BERRIMAH,33.0,18.2,,,1175.0,Independent,Combined,3927.0,-37.995979,145.14643
+Haileybury Rendall School,46189.0,2019,BERRIMAH,28.0,1.8,31.6,100.0,1179.0,Independent,Combined,4054.0,-37.995979,145.14643
+Haileybury Rendall School,46189.0,2020,BERRIMAH,32.0,17.2,68.2,95.0,1179.0,Independent,Combined,4206.0,-37.995979,145.14643
+Haileybury Rendall School,46189.0,2021,BERRIMAH,31.0,12.0,34.4,100.0,1181.0,Independent,Combined,4304.0,-37.995979,145.14643
+Haileybury Rendall School,46189.0,2022,BERRIMAH,29.0,5.4,24.1,100.0,1181.0,Independent,Combined,4432.0,-37.995979,145.14643
+Haileybury Rendall School,46189.0,2023,BERRIMAH,32.0,13.1,47.2,97.0,,,,,,
+Hallam Senior Sec College,40623.0,2014,HALLAM,22.0,0.1,58.0,94.0,,Government,Secondary,963.0,-38.00020053,145.26091674
+Hallam Senior Sec College,40623.0,2015,HALLAM,21.0,0.0,47.0,94.0,,Government,Secondary,966.0,-38.00020053,145.26091674
+Hallam Senior Sec College,40623.0,2016,HALLAM,21.0,0.1,71.0,94.0,,Government,Secondary,906.0,-38.00020053,145.26091674
+Hallam Senior Sec College,40623.0,2017,HALLAM,21.0,0.2,62.0,90.0,,Government,Secondary,909.0,-38.00020053,145.26091674
+Hallam Senior Sec College,40623.0,2018,HALLAM,22.0,0.4,68.8,93.0,965.0,Government,Secondary,902.0,-38.00020053,145.26091674
+Hallam Senior Sec College,40623.0,2019,HALLAM,22.0,0.3,49.2,89.0,970.0,Government,Secondary,771.0,-38.00020053,145.26091674
+Hallam Senior Sec College,40623.0,2020,HALLAM,23.0,0.6,60.5,95.0,966.0,Government,Secondary,693.0,-38.00020053,145.26091674
+Hallam Senior Sec College,40623.0,2021,HALLAM,23.0,1.6,42.0,88.0,964.0,Government,Secondary,623.0,-38.000383,145.262797
+Hallam Senior Sec College,40623.0,2022,HALLAM,25.0,0.0,42.3,85.0,955.0,Government,Secondary,478.0,-38.000383,145.262797
+Hallam Senior Sec College,40623.0,2023,HALLAM,23.0,1.3,24.3,95.0,,,,,,
 Hampton Park Sec College,45499.0,2014,HAMPTON PARK,24.0,1.5,87.0,94.0,929.0,Government,Secondary,1207.0,-38.034925,145.259148
 Hampton Park Sec College,45499.0,2015,HAMPTON PARK,24.0,1.0,83.0,94.0,930.0,Government,Secondary,1185.0,-38.034925,145.259148
 Hampton Park Sec College,45499.0,2016,HAMPTON PARK,25.0,1.9,74.0,95.0,917.0,Government,Secondary,1134.0,-38.034925,145.259148
@@ -1944,7 +2064,7 @@ Hampton Park Sec College,45499.0,2019,HAMPTON PARK,27.0,0.4,71.0,94.0,917.0,Gove
 Hampton Park Sec College,45499.0,2020,HAMPTON PARK,27.0,0.8,82.1,99.0,914.0,Government,Secondary,1147.0,-38.034925,145.259148
 Hampton Park Sec College,45499.0,2021,HAMPTON PARK,27.0,2.8,80.0,95.0,912.0,Government,Secondary,1131.0,-38.034925,145.259148
 Hampton Park Sec College,45499.0,2022,HAMPTON PARK,27.0,0.6,65.0,95.0,897.0,Government,Secondary,1138.0,-38.034925,145.259148
-Hampton Park Sec College,,2023,HAMPTON PARK,29.0,2.1,69.1,97.0,,,,,,
+Hampton Park Sec College,45499.0,2023,HAMPTON PARK,29.0,2.1,69.1,97.0,,,,,,
 Hawkesdale College,45224.0,2014,HAWKESDALE,29.0,2.1,60.0,85.0,983.0,Government,Combined,227.0,-38.106976,142.319173
 Hawkesdale College,45224.0,2015,HAWKESDALE,30.0,1.5,64.0,93.0,970.0,Government,Combined,214.0,-38.106976,142.319173
 Hawkesdale College,45224.0,2016,HAWKESDALE,28.0,4.5,86.0,100.0,979.0,Government,Combined,214.0,-38.106976,142.319173
@@ -1954,12 +2074,12 @@ Hawkesdale College,45224.0,2019,HAWKESDALE,25.0,3.0,33.3,100.0,975.0,Government,
 Hawkesdale College,45224.0,2020,HAWKESDALE,30.0,0.0,60.0,100.0,979.0,Government,Combined,172.0,-38.106976,142.319173
 Hawkesdale College,45224.0,2021,HAWKESDALE,28.0,2.6,60.0,100.0,971.0,Government,Combined,179.0,-38.106976,142.319173
 Hawkesdale College,45224.0,2022,HAWKESDALE,21.0,0.0,66.7,100.0,964.0,Government,Combined,171.0,-38.106976,142.319173
-Hawkesdale College,,2023,HAWKESDALE,20.0,,75.0,100.0,,,,,,
+Hawkesdale College,45224.0,2023,HAWKESDALE,20.0,,75.0,100.0,,,,,,
 Hazel Glen College,50683.0,2019,DOREEN,29.0,0.0,,,1020.0,Government,Combined,2803.0,-37.59822111,145.12339968
 Hazel Glen College,50683.0,2020,DOREEN,26.0,1.2,71.9,100.0,1020.0,Government,Combined,2956.0,-37.59822111,145.12339968
 Hazel Glen College,50683.0,2021,DOREEN,27.0,2.2,66.9,98.0,1021.0,Government,Combined,2906.0,-37.59822111,145.12339968
 Hazel Glen College,50683.0,2022,DOREEN,27.0,1.6,73.2,98.0,1020.0,Government,Combined,2782.0,-37.59822111,145.12339968
-Hazel Glen College,,2023,DOREEN,26.0,2.5,54.0,98.0,,,,,,
+Hazel Glen College,50683.0,2023,DOREEN,26.0,2.5,54.0,98.0,,,,,,
 Healesville High School,45397.0,2014,HEALESVILLE,25.0,1.0,80.0,100.0,949.0,Government,Secondary,400.0,-37.64356325,145.53197325
 Healesville High School,45397.0,2015,HEALESVILLE,27.0,0.0,50.0,93.0,953.0,Government,Secondary,418.0,-37.64356325,145.53197325
 Healesville High School,45397.0,2016,HEALESVILLE,27.0,5.4,63.0,97.0,955.0,Government,Secondary,423.0,-37.64356325,145.53197325
@@ -1969,7 +2089,7 @@ Healesville High School,45397.0,2019,HEALESVILLE,28.0,3.1,84.6,100.0,958.0,Gover
 Healesville High School,45397.0,2020,HEALESVILLE,27.0,1.3,92.3,100.0,959.0,Government,Secondary,342.0,-37.64356325,145.53197325
 Healesville High School,45397.0,2021,HEALESVILLE,27.0,5.2,90.0,97.0,962.0,Government,Secondary,332.0,-37.64356325,145.53197325
 Healesville High School,45397.0,2022,HEALESVILLE,25.0,0.0,84.6,85.0,951.0,Government,Secondary,319.0,-37.64356325,145.53197325
-Healesville High School,,2023,HEALESVILLE,25.0,,72.4,97.0,,,,,,
+Healesville High School,45397.0,2023,HEALESVILLE,25.0,,72.4,97.0,,,,,,
 Heathdale Christian College,46275.0,2014,WERRIBEE,28.0,4.4,95.0,100.0,,Independent,Combined,1198.0,-37.881318,144.681332
 Heathdale Christian College,46275.0,2015,WERRIBEE,29.0,5.6,98.0,100.0,1127.0,Independent,Combined,1195.0,-37.881318,144.681332
 Heathdale Christian College,46275.0,2016,WERRIBEE,29.0,9.9,93.0,100.0,1131.0,Independent,Combined,1216.0,-37.881318,144.681332
@@ -1979,7 +2099,7 @@ Heathdale Christian College,46275.0,2019,WERRIBEE,30.0,8.7,100.0,100.0,1140.0,In
 Heathdale Christian College,46275.0,2020,WERRIBEE,29.0,4.3,96.6,100.0,1148.0,Independent,Combined,1684.0,-37.881318,144.681332
 Heathdale Christian College,46275.0,2021,WERRIBEE,29.0,4.0,95.5,99.0,1146.0,Independent,Combined,1864.0,-37.881318,144.681332
 Heathdale Christian College,46275.0,2022,WERRIBEE,30.0,8.5,96.9,100.0,966.0,Independent,Combined,1995.0,-37.881318,144.681332
-Heathdale Christian College,,2023,WERRIBEE,31.0,8.4,91.8,100.0,,,,,,
+Heathdale Christian College,46275.0,2023,WERRIBEE,31.0,8.4,91.8,100.0,,,,,,
 Heatherton Christian College,46350.0,2014,CLARINDA,30.0,13.0,72.0,100.0,1125.0,Independent,Combined,391.0,-37.957836,145.11125874
 Heatherton Christian College,46350.0,2015,CLARINDA,30.0,5.8,76.0,100.0,1105.0,Independent,Combined,356.0,-37.957836,145.11125874
 Heatherton Christian College,46350.0,2016,CLARINDA,30.0,6.4,93.0,100.0,1101.0,Independent,Combined,360.0,-37.957836,145.11125874
@@ -1989,7 +2109,7 @@ Heatherton Christian College,46350.0,2019,CLARINDA,30.0,13.8,86.7,100.0,1115.0,I
 Heatherton Christian College,46350.0,2020,CLARINDA,28.0,5.0,75.0,100.0,1118.0,Independent,Combined,579.0,-37.957836,145.11125874
 Heatherton Christian College,46350.0,2021,CLARINDA,29.0,4.6,85.2,100.0,1124.0,Independent,Combined,665.0,-37.957836,145.11125874
 Heatherton Christian College,46350.0,2022,CLARINDA,28.0,0.0,78.9,100.0,1125.0,Independent,Combined,715.0,-37.957836,145.11125874
-Heatherton Christian College,,2023,CLARINDA,30.0,6.6,67.9,100.0,,,,,,
+Heatherton Christian College,46350.0,2023,CLARINDA,30.0,6.6,67.9,100.0,,,,,,
 Heathmont College,45555.0,2014,HEATHMONT,29.0,2.9,61.0,93.0,971.0,Government,Secondary,492.0,-37.83842619,145.23210355
 Heathmont College,45555.0,2015,HEATHMONT,27.0,2.8,76.0,96.0,987.0,Government,Secondary,459.0,-37.83842619,145.23210355
 Heathmont College,45555.0,2016,HEATHMONT,27.0,3.1,82.0,92.0,982.0,Government,Secondary,479.0,-37.83842619,145.23210355
@@ -1999,7 +2119,7 @@ Heathmont College,45555.0,2019,HEATHMONT,26.0,0.8,69.4,94.0,1013.0,Government,Se
 Heathmont College,45555.0,2020,HEATHMONT,26.0,2.0,58.3,95.0,1012.0,Government,Secondary,688.0,-37.83842619,145.23210355
 Heathmont College,45555.0,2021,HEATHMONT,26.0,1.1,72.1,100.0,1013.0,Government,Secondary,691.0,-37.83842619,145.23210355
 Heathmont College,45555.0,2022,HEATHMONT,26.0,0.4,63.6,100.0,1009.0,Government,Secondary,709.0,-37.83842619,145.23210355
-Heathmont College,,2023,HEATHMONT,24.0,1.1,57.5,97.0,,,,,,
+Heathmont College,45555.0,2023,HEATHMONT,24.0,1.1,57.5,97.0,,,,,,
 Heritage College,46212.0,2014,OFFICER,26.0,1.7,91.0,95.0,1025.0,Independent,Combined,405.0,-38.050215,145.316519
 Heritage College,46212.0,2015,OFFICER,25.0,0.7,83.0,100.0,1027.0,Independent,Combined,394.0,-38.050215,145.316519
 Heritage College,46212.0,2016,OFFICER,23.0,0.0,67.0,100.0,1010.0,Independent,Combined,371.0,-38.050215,145.316519
@@ -2009,14 +2129,14 @@ Heritage College,46212.0,2019,OFFICER,28.0,3.0,66.7,100.0,1031.0,Independent,Com
 Heritage College,46212.0,2020,OFFICER,21.0,0.0,66.7,100.0,1031.0,Independent,Combined,413.0,-38.050215,145.316519
 Heritage College,46212.0,2021,OFFICER,30.0,8.3,75.0,88.0,1028.0,Independent,Combined,427.0,-38.050215,145.316519
 Heritage College,46212.0,2022,OFFICER,26.0,0.0,33.3,100.0,1037.0,Independent,Combined,465.0,-38.050215,145.316519
-Heritage College,,2023,OFFICER,25.0,,33.3,92.0,,,,,,
+Heritage College,46212.0,2023,OFFICER,25.0,,33.3,92.0,,,,,,
 Hester Hornbrook Academy,52517.0,2017,SOUTH MELBOURNE,,,,,,Independent,Special,169.0,-37.82918,144.96312
 Hester Hornbrook Academy,52517.0,2018,SOUTH MELBOURNE,,,,,,Independent,Special,170.0,-37.82918,144.96312
 Hester Hornbrook Academy,52517.0,2019,SOUTH MELBOURNE,,,,,,Independent,Special,199.0,-37.82918,144.96312
 Hester Hornbrook Academy,52517.0,2020,SOUTH MELBOURNE,,,,,,Independent,Special,217.0,-37.82918,144.96312
 Hester Hornbrook Academy,52517.0,2021,SOUTH MELBOURNE,,,,,911.0,Independent,Special,298.0,-37.82918,144.96312
 Hester Hornbrook Academy,52517.0,2022,MELBOURNE,,,,,911.0,Independent,Special,383.0,-37.82918,144.96312
-Hester Hornbrook Academy,,2023,SOUTH MELBOURNE,,,5.0,25.0,,,,,,
+Hester Hornbrook Academy,52517.0,2023,SOUTH MELBOURNE,,,5.0,25.0,,,,,,
 Heywood & District Sec College,45398.0,2014,HEYWOOD,27.0,1.4,86.0,93.0,923.0,Government,Secondary,162.0,-38.12926753,141.62049994
 Heywood & District Sec College,45398.0,2015,HEYWOOD,27.0,2.5,62.0,92.0,930.0,Government,Secondary,153.0,-38.12926753,141.62049994
 Heywood & District Sec College,45398.0,2016,HEYWOOD,26.0,1.4,69.0,100.0,928.0,Government,Secondary,156.0,-38.12926753,141.62049994
@@ -2026,7 +2146,7 @@ Heywood & District Sec College,45398.0,2019,HEYWOOD,26.0,0.0,40.0,100.0,905.0,Go
 Heywood & District Sec College,45398.0,2020,HEYWOOD,24.0,0.0,40.0,100.0,897.0,Government,Secondary,96.0,-38.12926753,141.62049994
 Heywood & District Sec College,45398.0,2021,HEYWOOD,26.0,0.0,33.3,100.0,889.0,Government,Secondary,82.0,-38.12926753,141.62049994
 Heywood & District Sec College,45398.0,2022,HEYWOOD,,,50.0,100.0,883.0,Government,Secondary,69.0,-38.12926753,141.62049994
-Heywood & District Sec College,,2023,HEYWOOD,27.0,,40.0,100.0,,,,,,
+Heywood & District Sec College,45398.0,2023,HEYWOOD,27.0,,40.0,100.0,,,,,,
 Highvale Secondary College,45399.0,2014,GLEN WAVERLEY,30.0,4.1,83.0,97.0,1074.0,Government,Secondary,971.0,-37.86624,145.176723
 Highvale Secondary College,45399.0,2015,GLEN WAVERLEY,29.0,5.9,85.0,98.0,1076.0,Government,Secondary,1002.0,-37.86624,145.176723
 Highvale Secondary College,45399.0,2016,GLEN WAVERLEY,31.0,7.0,89.0,99.0,1074.0,Government,Secondary,1061.0,-37.86624,145.176723
@@ -2036,17 +2156,17 @@ Highvale Secondary College,45399.0,2019,GLEN WAVERLEY,31.0,9.3,86.1,97.0,1083.0,
 Highvale Secondary College,45399.0,2020,GLEN WAVERLEY,30.0,9.3,93.9,100.0,1086.0,Government,Secondary,1009.0,-37.86624,145.176723
 Highvale Secondary College,45399.0,2021,GLEN WAVERLEY,30.0,6.3,86.9,96.0,1087.0,Government,Secondary,1055.0,-37.86624,145.176723
 Highvale Secondary College,45399.0,2022,GLEN WAVERLEY,31.0,7.5,93.8,100.0,1099.0,Government,Secondary,1102.0,-37.86624,145.176723
-Highvale Secondary College,,2023,GLEN WAVERLEY,29.0,6.1,86.7,98.0,,,,,,
-Highview Christian Comm College,46256.0,2014,MARYBOROUGH,29.0,2.9,77.0,96.0,1000.0,Independent,Combined,90.0,-37.088492,144.205424
-Highview Christian Comm College,46256.0,2015,MARYBOROUGH,28.0,4.8,75.0,97.0,985.0,Independent,Combined,75.0,-37.088492,144.205424
-Highview Christian Comm College,46256.0,2016,MARYBOROUGH,27.0,5.1,83.0,100.0,989.0,Independent,Combined,74.0,-37.088492,144.205424
-Highview Christian Comm College,46256.0,2017,MARYBOROUGH,27.0,4.8,75.0,98.0,977.0,Independent,Combined,75.0,-37.088492,144.205424
-Highview Christian Comm College,46256.0,2018,MARYBOROUGH,30.0,3.8,81.4,100.0,994.0,Independent,Combined,57.0,-37.088492,144.205424
-Highview Christian Comm College,46256.0,2019,MARYBOROUGH,26.0,0.9,76.0,92.0,995.0,Independent,Combined,63.0,-37.088492,144.205424
-Highview Christian Comm College,46256.0,2020,MARYBOROUGH,27.0,1.6,86.3,98.0,1021.0,Independent,Combined,62.0,-37.088492,144.205424
-Highview Christian Comm College,46256.0,2021,MARYBOROUGH,28.0,5.9,78.0,100.0,1007.0,Independent,Combined,38.0,-37.088492,144.205424
-Highview Christian Comm College,46256.0,2022,MARYBOROUGH,27.0,1.1,76.6,98.0,1014.0,Independent,Combined,30.0,-37.088492,144.205424
-Highview Christian Comm College,,2023,MARYBOROUGH,27.0,2.8,66.7,95.0,,,,,,
+Highvale Secondary College,45399.0,2023,GLEN WAVERLEY,29.0,6.1,86.7,98.0,,,,,,
+Highview Christian Comm College,46142.0,2014,MARYBOROUGH,29.0,2.9,77.0,96.0,1023.0,Independent,Secondary,444.0,-37.0534,143.737
+Highview Christian Comm College,46142.0,2015,MARYBOROUGH,28.0,4.8,75.0,97.0,,Independent,Secondary,440.0,-37.0534,143.737
+Highview Christian Comm College,46142.0,2016,MARYBOROUGH,27.0,5.1,83.0,100.0,,Independent,Secondary,409.0,-37.0534,143.737
+Highview Christian Comm College,46142.0,2017,MARYBOROUGH,27.0,4.8,75.0,98.0,1011.0,Independent,Secondary,405.0,-37.0534,143.737
+Highview Christian Comm College,46142.0,2018,MARYBOROUGH,30.0,3.8,81.4,100.0,1017.0,Independent,Secondary,409.0,-37.0534,143.737
+Highview Christian Comm College,46142.0,2019,MARYBOROUGH,26.0,0.9,76.0,92.0,1007.0,Independent,Secondary,410.0,-37.0534,143.737
+Highview Christian Comm College,46142.0,2020,MARYBOROUGH,27.0,1.6,86.3,98.0,1007.0,Independent,Secondary,413.0,-37.0534,143.737
+Highview Christian Comm College,46142.0,2021,MARYBOROUGH,28.0,5.9,78.0,100.0,1012.0,Independent,Secondary,440.0,-37.0534,143.737
+Highview Christian Comm College,46142.0,2022,MARYBOROUGH,27.0,1.1,76.6,98.0,1014.0,Independent,Secondary,416.0,-37.0534,143.737
+Highview Christian Comm College,46142.0,2023,MARYBOROUGH,27.0,2.8,66.7,95.0,,,,,,
 Hillcrest Christian College,46276.0,2014,CLYDE NORTH,30.0,6.7,94.0,100.0,1073.0,Independent,Combined,1229.0,-38.084681,145.363801
 Hillcrest Christian College,46276.0,2015,CLYDE NORTH,29.0,3.9,98.0,99.0,1077.0,Independent,Combined,1372.0,-38.084681,145.363801
 Hillcrest Christian College,46276.0,2016,CLYDE NORTH,28.0,3.7,93.0,100.0,1081.0,Independent,Combined,1425.0,-38.084681,145.363801
@@ -2056,26 +2176,43 @@ Hillcrest Christian College,46276.0,2019,CLYDE NORTH,29.0,4.7,83.7,97.0,1090.0,I
 Hillcrest Christian College,46276.0,2020,CLYDE NORTH,30.0,4.3,93.5,99.0,1090.0,Independent,Combined,1728.0,-38.084681,145.363801
 Hillcrest Christian College,46276.0,2021,CLYDE NORTH,31.0,5.8,85.4,100.0,1096.0,Independent,Combined,1811.0,-38.084681,145.363801
 Hillcrest Christian College,46276.0,2022,CLYDE NORTH,30.0,3.1,81.1,100.0,1100.0,Independent,Combined,1911.0,-38.084681,145.363801
-Hillcrest Christian College,,2023,CLYDE NORTH,30.0,3.7,74.0,99.0,,,,,,
+Hillcrest Christian College,46276.0,2023,CLYDE NORTH,30.0,3.7,74.0,99.0,,,,,,
 Holmes Grammar School,40736.0,2021,MELBOURNE,30.0,4.4,88.9,100.0,,Independent,Secondary,,-37.810302,144.972271
 Holmes Grammar School,40736.0,2022,MELBOURNE,26.0,0.0,100.0,100.0,,Independent,Secondary,,-37.810302,144.972271
-Holmes Grammar School,,2023,MELBOURNE,29.0,5.7,53.8,100.0,,,,,,
-Holmes Secondary College,40623.0,2014,MELBOURNE,23.0,0.0,88.0,100.0,,Government,Secondary,963.0,-38.00020053,145.26091674
-Holmes Secondary College,40623.0,2015,MELBOURNE,31.0,3.3,83.0,83.0,,Government,Secondary,966.0,-38.00020053,145.26091674
-Holmes Secondary College,40623.0,2016,MELBOURNE,25.0,3.1,100.0,100.0,,Government,Secondary,906.0,-38.00020053,145.26091674
-Holmes Secondary College,40623.0,2017,MELBOURNE,26.0,0.0,83.0,92.0,,Government,Secondary,909.0,-38.00020053,145.26091674
-Holmes Secondary College,40623.0,2018,MELBOURNE,28.0,6.5,92.9,86.0,965.0,Government,Secondary,902.0,-38.00020053,145.26091674
-Holmes Secondary College,40623.0,2019,MELBOURNE,23.0,0.0,100.0,100.0,970.0,Government,Secondary,771.0,-38.00020053,145.26091674
-Holmes Secondary College,40623.0,2020,MELBOURNE,28.0,1.9,91.7,92.0,966.0,Government,Secondary,693.0,-38.00020053,145.26091674
+Holmes Grammar School,40736.0,2023,MELBOURNE,29.0,5.7,53.8,100.0,,,,,,
+Holmes Secondary College,40736.0,2014,MELBOURNE,23.0,0.0,88.0,100.0,,Independent,Secondary,,-37.810302,144.972271
+Holmes Secondary College,40736.0,2015,MELBOURNE,31.0,3.3,83.0,83.0,,Independent,Secondary,,-37.810302,144.972271
+Holmes Secondary College,40736.0,2016,MELBOURNE,25.0,3.1,100.0,100.0,,Independent,Secondary,,-37.810302,144.972271
+Holmes Secondary College,40736.0,2017,MELBOURNE,26.0,0.0,83.0,92.0,,Independent,Secondary,,-37.810302,144.972271
+Holmes Secondary College,40736.0,2018,MELBOURNE,28.0,6.5,92.9,86.0,,Independent,Secondary,,-37.810302,144.972271
+Holmes Secondary College,40736.0,2019,MELBOURNE,23.0,0.0,100.0,100.0,,Independent,Secondary,,-37.810302,144.972271
+Holmes Secondary College,40736.0,2020,MELBOURNE,28.0,1.9,91.7,92.0,,Independent,Secondary,,-37.810302,144.972271
+Holmesglen Institute,,2019,HOLMESGLEN,,,,,,,,,,
+Holmesglen Institute,,2020,HOLMESGLEN,,,,,,,,,,
+Holmesglen Institute,,2022,MOORABBIN,,,0.0,100.0,,,,,,
+Holmesglen Institute,,2023,MOORABBIN,,,3.0,78.0,,,,,,
+Holmesglen Institute of TAFE,,2014,HOLMESGLEN,22.0,0.0,44.0,85.0,,,,,,
+Holmesglen Institute of TAFE,,2014,MOORABBIN,,,,,,,,,,
+Holmesglen Institute of TAFE,,2015,HOLMESGLEN,,,,,,,,,,
+Holmesglen Institute of TAFE,,2015,MOORABBIN,,,,,,,,,,
+Holmesglen Institute of TAFE,,2016,HOLMESGLEN,,,,,,,,,,
+Holmesglen Institute of TAFE,,2016,MOORABBIN,18.0,0.0,,,,,,,,
+Holmesglen Institute of TAFE,,2017,HOLMESGLEN,,,,,,,,,,
+Holmesglen Institute of TAFE,,2017,MOORABBIN,,,,,,,,,,
+Holmesglen Institute of TAFE,,2018,HOLMESGLEN,,,,,,,,,,
+Holmesglen Institute of TAFE,,2018,MOORABBIN,,,,,,,,,,
+Holmesglen Institute of TAFE,,2019,MOORABBIN,,,,,,,,,,
+Holmesglen Institute of TAFE,,2020,MOORABBIN,,,,,,,,,,
+Holmesglen Institute of TAFE,,2021,MOORABBIN,,,,,,,,,,
 Holy Trinity Lutheran College,46242.0,2018,HORSHAM,33.0,0.0,,,1057.0,Independent,Combined,526.0,-36.708181,142.217749
 Holy Trinity Lutheran College,46242.0,2019,HORSHAM,26.0,0.0,100.0,100.0,1046.0,Independent,Combined,569.0,-36.708181,142.217749
 Holy Trinity Lutheran College,46242.0,2020,HORSHAM,29.0,10.0,81.8,100.0,1046.0,Independent,Combined,607.0,-36.708181,142.217749
 Holy Trinity Lutheran College,46242.0,2021,HORSHAM,30.0,19.3,100.0,100.0,1067.0,Independent,Combined,613.0,-36.708181,142.217749
 Holy Trinity Lutheran College,46242.0,2022,HORSHAM,31.0,5.5,77.8,96.0,1067.0,Independent,Combined,601.0,-36.708181,142.217749
-Holy Trinity Lutheran College,,2023,HORSHAM,29.0,3.0,45.5,100.0,,,,,,
+Holy Trinity Lutheran College,46242.0,2023,HORSHAM,29.0,3.0,45.5,100.0,,,,,,
 Homestead Senior Sec College,52780.0,2021,POINT COOK,29.0,3.3,,,1041.0,Government,Secondary,234.0,-37.915419,144.767561
 Homestead Senior Sec College,52780.0,2022,POINT COOK,28.0,2.6,83.3,96.0,1046.0,Government,Secondary,342.0,-37.915419,144.767561
-Homestead Senior Sec College,,2023,POINT COOK,29.0,2.3,62.5,99.0,,,,,,
+Homestead Senior Sec College,52780.0,2023,POINT COOK,29.0,2.3,62.5,99.0,,,,,,
 Hopetoun P-12 College,45400.0,2014,HOPETOUN,30.0,0.0,58.0,89.0,968.0,Government,Combined,122.0,-35.73486974,142.36602962
 Hopetoun P-12 College,45400.0,2015,HOPETOUN,32.0,13.8,100.0,100.0,957.0,Government,Combined,102.0,-35.73486974,142.36602962
 Hopetoun P-12 College,45400.0,2016,HOPETOUN,27.0,0.0,89.0,100.0,957.0,Government,Combined,103.0,-35.73486974,142.36602962
@@ -2085,7 +2222,7 @@ Hopetoun P-12 College,45400.0,2019,HOPETOUN,18.0,0.0,75.0,100.0,958.0,Government
 Hopetoun P-12 College,45400.0,2020,HOPETOUN,31.0,0.0,50.0,100.0,968.0,Government,Combined,78.0,-35.73486974,142.36602962
 Hopetoun P-12 College,45400.0,2021,HOPETOUN,30.0,13.3,33.3,100.0,966.0,Government,Combined,77.0,-35.73486974,142.36602962
 Hopetoun P-12 College,45400.0,2022,HOPETOUN,28.0,10.3,100.0,100.0,927.0,Government,Combined,89.0,-35.73486974,142.36602962
-Hopetoun P-12 College,,2023,HOPETOUN,24.0,,16.7,100.0,,,,,,
+Hopetoun P-12 College,45400.0,2023,HOPETOUN,24.0,,16.7,100.0,,,,,,
 Hoppers Crossing Sec College,45500.0,2014,HOPPERS CROSSING,27.0,1.8,71.0,96.0,936.0,Government,Secondary,1386.0,-37.871223,144.695358
 Hoppers Crossing Sec College,45500.0,2015,HOPPERS CROSSING,28.0,1.3,74.0,97.0,945.0,Government,Secondary,1379.0,-37.871223,144.695358
 Hoppers Crossing Sec College,45500.0,2016,HOPPERS CROSSING,29.0,2.8,75.0,96.0,945.0,Government,Secondary,1428.0,-37.871223,144.695358
@@ -2095,7 +2232,7 @@ Hoppers Crossing Sec College,45500.0,2019,HOPPERS CROSSING,28.0,4.9,65.4,99.0,96
 Hoppers Crossing Sec College,45500.0,2020,HOPPERS CROSSING,29.0,4.1,80.0,98.0,972.0,Government,Secondary,1522.0,-37.871223,144.695358
 Hoppers Crossing Sec College,45500.0,2021,HOPPERS CROSSING,28.0,3.3,71.9,99.0,972.0,Government,Secondary,1512.0,-37.871223,144.695358
 Hoppers Crossing Sec College,45500.0,2022,HOPPERS CROSSING,28.0,4.7,70.4,92.0,971.0,Government,Secondary,1469.0,-37.871223,144.695358
-Hoppers Crossing Sec College,,2023,HOPPERS CROSSING,27.0,2.5,57.6,98.0,,,,,,
+Hoppers Crossing Sec College,45500.0,2023,HOPPERS CROSSING,27.0,2.5,57.6,98.0,,,,,,
 Horsham College,45556.0,2014,HORSHAM,28.0,4.6,76.0,93.0,955.0,Government,Secondary,890.0,-36.707706,142.187075
 Horsham College,45556.0,2015,HORSHAM,29.0,3.7,67.0,93.0,952.0,Government,Secondary,878.0,-36.707706,142.187075
 Horsham College,45556.0,2016,HORSHAM,30.0,4.8,73.0,93.0,961.0,Government,Secondary,874.0,-36.707706,142.187075
@@ -2105,7 +2242,7 @@ Horsham College,45556.0,2019,HORSHAM,28.0,4.3,70.6,97.0,978.0,Government,Seconda
 Horsham College,45556.0,2020,HORSHAM,29.0,1.8,59.5,99.0,980.0,Government,Secondary,958.0,-36.707706,142.187075
 Horsham College,45556.0,2021,HORSHAM,30.0,4.1,67.4,99.0,983.0,Government,Secondary,1000.0,-36.707706,142.187075
 Horsham College,45556.0,2022,HORSHAM,32.0,10.1,65.2,100.0,976.0,Government,Secondary,1016.0,-36.707706,142.187075
-Horsham College,,2023,HORSHAM,31.0,5.3,49.0,94.0,,,,,,
+Horsham College,45556.0,2023,HORSHAM,31.0,5.3,49.0,94.0,,,,,,
 Hume Anglican Grammar,46385.0,2014,MICKLEHAM,28.0,1.4,95.0,100.0,1031.0,Independent,Combined,776.0,-37.568405,144.931491
 Hume Anglican Grammar,46385.0,2015,MICKLEHAM,28.0,2.5,92.0,100.0,1043.0,Independent,Combined,844.0,-37.568405,144.931491
 Hume Anglican Grammar,46385.0,2016,MICKLEHAM,27.0,0.7,86.0,97.0,1056.0,Independent,Combined,902.0,-37.568405,144.931491
@@ -2115,7 +2252,7 @@ Hume Anglican Grammar,46385.0,2019,MICKLEHAM,30.0,5.5,92.0,100.0,1083.0,Independ
 Hume Anglican Grammar,46385.0,2020,MICKLEHAM,31.0,9.1,93.7,98.0,1083.0,Independent,Combined,1445.0,-37.568405,144.931491
 Hume Anglican Grammar,46385.0,2021,MICKLEHAM,30.0,5.3,95.3,100.0,1084.0,Independent,Combined,1671.0,-37.568405,144.931491
 Hume Anglican Grammar,46385.0,2022,MICKLEHAM,31.0,7.3,96.7,100.0,1089.0,Independent,Combined,2002.0,-37.568405,144.931491
-Hume Anglican Grammar,,2023,MICKLEHAM,30.0,8.4,91.4,99.0,,,,,,
+Hume Anglican Grammar,46385.0,2023,MICKLEHAM,30.0,8.4,91.4,99.0,,,,,,
 Hume Central Sec College,50190.0,2014,BROADMEADOWS,25.0,2.9,96.0,97.0,887.0,Government,Secondary,1119.0,-37.680677,144.915239
 Hume Central Sec College,50190.0,2015,BROADMEADOWS,24.0,1.8,96.0,100.0,882.0,Government,Secondary,1125.0,-37.680677,144.915239
 Hume Central Sec College,50190.0,2016,BROADMEADOWS,24.0,1.5,99.0,100.0,886.0,Government,Secondary,1112.0,-37.680677,144.915239
@@ -2125,7 +2262,7 @@ Hume Central Sec College,50190.0,2019,BROADMEADOWS,26.0,3.1,82.8,94.0,894.0,Gove
 Hume Central Sec College,50190.0,2020,BROADMEADOWS,26.0,0.5,89.9,93.0,893.0,Government,Secondary,1186.0,-37.680677,144.915239
 Hume Central Sec College,50190.0,2021,BROADMEADOWS,27.0,3.3,86.7,97.0,894.0,Government,Secondary,1181.0,-37.680677,144.915239
 Hume Central Sec College,50190.0,2022,BROADMEADOWS,27.0,1.8,86.7,89.0,881.0,Government,Secondary,1176.0,-37.680677,144.915239
-Hume Central Sec College,,2023,BROADMEADOWS,26.0,0.6,78.9,99.0,,,,,,
+Hume Central Sec College,50190.0,2023,BROADMEADOWS,26.0,0.6,78.9,99.0,,,,,,
 Huntingtower School,46201.0,2014,MOUNT WAVERLEY,36.0,27.0,99.0,100.0,1172.0,Independent,Combined,636.0,-37.876741,145.136288
 Huntingtower School,46201.0,2015,MOUNT WAVERLEY,35.0,23.2,100.0,100.0,1171.0,Independent,Combined,657.0,-37.876741,145.136288
 Huntingtower School,46201.0,2016,MOUNT WAVERLEY,36.0,28.9,100.0,100.0,1175.0,Independent,Combined,675.0,-37.876741,145.136288
@@ -2135,14 +2272,14 @@ Huntingtower School,46201.0,2019,MOUNT WAVERLEY,37.0,33.2,98.9,100.0,1175.0,Inde
 Huntingtower School,46201.0,2020,MOUNT WAVERLEY,36.0,24.7,100.0,100.0,1175.0,Independent,Combined,720.0,-37.876741,145.136288
 Huntingtower School,46201.0,2021,MOUNT WAVERLEY,37.0,31.6,98.9,99.0,1176.0,Independent,Combined,721.0,-37.876741,145.136288
 Huntingtower School,46201.0,2022,MOUNT WAVERLEY,36.0,28.9,95.7,100.0,1190.0,Independent,Combined,736.0,-37.876741,145.136288
-Huntingtower School,,2023,MOUNT WAVERLEY,37.0,33.8,98.9,100.0,,,,,,
+Huntingtower School,46201.0,2023,MOUNT WAVERLEY,37.0,33.8,98.9,100.0,,,,,,
 Ilim College,46328.0,2017,BROADMEADOWS,29.0,7.8,94.0,98.0,1009.0,Independent,Combined,2164.0,-37.668621,144.930072
 Ilim College,46328.0,2018,BROADMEADOWS,28.0,3.2,91.0,99.0,1009.0,Independent,Combined,2340.0,-37.668621,144.930072
 Ilim College,46328.0,2019,BROADMEADOWS,30.0,5.3,95.8,100.0,1010.0,Independent,Combined,2444.0,-37.668621,144.930072
 Ilim College,46328.0,2020,BROADMEADOWS,30.0,6.8,93.2,100.0,1010.0,Independent,Combined,2491.0,-37.668621,144.930072
 Ilim College,46328.0,2021,BROADMEADOWS,28.0,3.5,94.4,100.0,1014.0,Independent,Combined,2551.0,-37.668621,144.930072
 Ilim College,46328.0,2022,BROADMEADOWS,28.0,4.5,100.0,100.0,1025.0,Independent,Combined,2582.0,-37.668621,144.930072
-Ilim College,,2023,BROADMEADOWS,29.0,7.5,95.3,100.0,,,,,,
+Ilim College,46328.0,2023,BROADMEADOWS,29.0,7.5,95.3,100.0,,,,,,
 Ilim College Boys Campus,46328.0,2016,DALLAS,33.0,9.1,,,1001.0,Independent,Combined,1947.0,-37.668621,144.930072
 Ilim College Boys Campus,46328.0,2017,DALLAS,28.0,3.8,91.0,100.0,1009.0,Independent,Combined,2164.0,-37.668621,144.930072
 Ilim College Boys Campus,46328.0,2018,DALLAS,27.0,0.6,78.9,92.0,1009.0,Independent,Combined,2340.0,-37.668621,144.930072
@@ -2150,20 +2287,20 @@ Ilim College Kiewa Campus,46328.0,2019,DALLAS,25.0,2.7,80.4,94.0,1010.0,Independ
 Ilim College Kiewa Campus,46328.0,2020,DALLAS,29.0,3.4,83.6,100.0,1010.0,Independent,Combined,2491.0,-37.668621,144.930072
 Ilim College Kiewa Campus,46328.0,2021,DALLAS,27.0,4.3,81.4,100.0,1014.0,Independent,Combined,2551.0,-37.668621,144.930072
 Ilim College Kiewa Campus,46328.0,2022,DALLAS,25.0,2.6,90.3,100.0,1025.0,Independent,Combined,2582.0,-37.668621,144.930072
-Ilim College Kiewa Campus,,2023,DALLAS,24.0,2.1,84.5,100.0,,,,,,
-Ilim College of Australia,46345.0,2014,BROADMEADOWS,29.0,4.9,98.0,100.0,,Independent,Combined,950.0,-37.705621,144.971191
-Ilim College of Australia,46345.0,2015,BROADMEADOWS,28.0,6.8,93.0,100.0,,Independent,Combined,943.0,-37.705621,144.971191
-Ilim College of Australia,46345.0,2016,BROADMEADOWS,29.0,7.3,93.0,100.0,,Independent,Combined,1010.0,-37.705621,144.971191
+Ilim College Kiewa Campus,46328.0,2023,DALLAS,24.0,2.1,84.5,100.0,,,,,,
+Ilim College of Australia,46328.0,2014,BROADMEADOWS,29.0,4.9,98.0,100.0,992.0,Independent,Combined,1514.0,-37.668621,144.930072
+Ilim College of Australia,46328.0,2015,BROADMEADOWS,28.0,6.8,93.0,100.0,1006.0,Independent,Combined,1729.0,-37.668621,144.930072
+Ilim College of Australia,46328.0,2016,BROADMEADOWS,29.0,7.3,93.0,100.0,1001.0,Independent,Combined,1947.0,-37.668621,144.930072
 Indie School Wodonga,43720.0,2022,WODONGA,,,,,951.0,Independent,Special,797.0,-36.118028,146.889403
-Indie School Wodonga,,2023,WODONGA,,,2.7,86.0,,,,,,
-Iona College Geelong,,2023,CHARLEMONT,,,,,,,,,,
-Irymple Secondary College,,2023,IRYMPLE,,,,,,,,,,
+Indie School Wodonga,43720.0,2023,WODONGA,,,2.7,86.0,,,,,,
+Iona College Geelong,52858.0,2023,CHARLEMONT,,,,,,,,,,
+Irymple Secondary College,45332.0,2023,IRYMPLE,,,,,,,,,,
 Islamic College of Melbourne,50312.0,2018,TARNEIT,26.0,2.2,95.2,100.0,1041.0,Independent,Combined,1115.0,-37.85474629,144.66015383
 Islamic College of Melbourne,50312.0,2019,TARNEIT,28.0,4.5,100.0,100.0,,Independent,Combined,1218.0,-37.85474629,144.66015383
 Islamic College of Melbourne,50312.0,2020,TARNEIT,30.0,5.8,100.0,100.0,,Independent,Combined,1309.0,-37.85474629,144.66015383
 Islamic College of Melbourne,50312.0,2021,TARNEIT,31.0,5.9,100.0,100.0,1060.0,Independent,Combined,1403.0,-37.85474629,144.66015383
 Islamic College of Melbourne,50312.0,2022,TARNEIT,30.0,8.3,100.0,100.0,1070.0,Independent,Combined,1581.0,-37.85474629,144.66015383
-Islamic College of Melbourne,,2023,TARNEIT,31.0,8.2,97.2,100.0,,,,,,
+Islamic College of Melbourne,50312.0,2023,TARNEIT,31.0,8.2,97.2,100.0,,,,,,
 Ivanhoe Girls' Grammar School,46185.0,2014,IVANHOE,34.0,19.7,98.0,100.0,1165.0,Independent,Combined,970.0,-37.766522068351,145.047477413679
 Ivanhoe Girls' Grammar School,46185.0,2015,IVANHOE,34.0,20.2,99.0,100.0,1169.0,Independent,Combined,944.0,-37.766522068351,145.047477413679
 Ivanhoe Girls' Grammar School,46185.0,2016,IVANHOE,34.0,18.4,100.0,100.0,1159.0,Independent,Combined,929.0,-37.766522068351,145.047477413679
@@ -2173,7 +2310,7 @@ Ivanhoe Girls' Grammar School,46185.0,2019,IVANHOE,34.0,18.7,99.1,100.0,1161.0,I
 Ivanhoe Girls' Grammar School,46185.0,2020,IVANHOE,35.0,25.7,100.0,100.0,1161.0,Independent,Combined,817.0,-37.766522068351,145.047477413679
 Ivanhoe Girls' Grammar School,46185.0,2021,IVANHOE,35.0,25.5,96.5,100.0,1162.0,Independent,Combined,813.0,-37.766522068351,145.047477413679
 Ivanhoe Girls' Grammar School,46185.0,2022,IVANHOE,34.0,15.0,99.0,100.0,1181.0,Independent,Combined,835.0,-37.766522068351,145.047477413679
-Ivanhoe Girls' Grammar School,,2023,IVANHOE,34.0,18.6,100.0,100.0,,,,,,
+Ivanhoe Girls' Grammar School,46185.0,2023,IVANHOE,34.0,18.6,100.0,100.0,,,,,,
 Ivanhoe Grammar School,46170.0,2014,IVANHOE,34.0,17.5,93.0,100.0,1142.0,Independent,Combined,1961.0,-37.772515,145.044477
 Ivanhoe Grammar School,46170.0,2014,MERNDA,34.0,12.9,96.0,100.0,1142.0,Independent,Combined,1961.0,-37.772515,145.044477
 Ivanhoe Grammar School,46170.0,2015,IVANHOE,34.0,17.0,93.0,99.0,1150.0,Independent,Combined,1991.0,-37.772515,145.044477
@@ -2192,8 +2329,8 @@ Ivanhoe Grammar School,46170.0,2021,IVANHOE,32.0,10.3,89.4,100.0,1148.0,Independ
 Ivanhoe Grammar School,46170.0,2021,MERNDA,33.0,12.0,97.2,100.0,1148.0,Independent,Combined,2195.0,-37.772515,145.044477
 Ivanhoe Grammar School,46170.0,2022,IVANHOE,32.0,12.6,91.3,99.0,1154.0,Independent,Combined,2288.0,-37.772515,145.044477
 Ivanhoe Grammar School,46170.0,2022,MERNDA,34.0,13.8,91.7,100.0,1154.0,Independent,Combined,2288.0,-37.772515,145.044477
-Ivanhoe Grammar School,,2023,IVANHOE,33.0,13.4,93.6,99.0,,,,,,
-Ivanhoe Grammar School,,2023,MERNDA,33.0,15.6,90.3,100.0,,,,,,
+Ivanhoe Grammar School,46170.0,2023,IVANHOE,33.0,13.4,93.6,99.0,,,,,,
+Ivanhoe Grammar School,46170.0,2023,MERNDA,33.0,15.6,90.3,100.0,,,,,,
 John Fawkner College,45626.0,2014,FAWKNER,26.0,1.4,88.0,88.0,913.0,Government,Secondary,354.0,-37.70271075,144.97185868
 John Fawkner College,45626.0,2015,FAWKNER,29.0,2.8,85.0,88.0,936.0,Government,Secondary,354.0,-37.70271075,144.97185868
 John Fawkner College,45626.0,2016,FAWKNER,26.0,0.8,86.0,100.0,935.0,Government,Secondary,348.0,-37.70271075,144.97185868
@@ -2203,7 +2340,7 @@ John Fawkner College,45626.0,2019,FAWKNER,23.0,0.9,44.8,86.0,939.0,Government,Se
 John Fawkner College,45626.0,2020,FAWKNER,20.0,1.1,69.2,97.0,939.0,Government,Secondary,341.0,-37.70271075,144.97185868
 John Fawkner College,45626.0,2021,FAWKNER,20.0,0.0,57.6,100.0,943.0,Government,Secondary,314.0,-37.70271075,144.97185868
 John Fawkner College,45626.0,2022,FAWKNER,18.0,1.9,80.8,92.0,948.0,Government,Secondary,304.0,-37.70271075,144.97185868
-John Fawkner College,,2023,FAWKNER,21.0,,87.0,100.0,,,,,,
+John Fawkner College,45626.0,2023,FAWKNER,21.0,,87.0,100.0,,,,,,
 John Monash Science School,40828.0,2014,CLAYTON,35.0,19.9,100.0,100.0,,Government,Secondary,632.0,-37.91419502,145.12878264
 John Monash Science School,40828.0,2015,CLAYTON,35.0,21.5,99.0,100.0,,Government,Secondary,632.0,-37.91419502,145.12878264
 John Monash Science School,40828.0,2016,CLAYTON,34.0,15.6,99.0,100.0,,Government,Secondary,641.0,-37.91419502,145.12878264
@@ -2213,7 +2350,7 @@ John Monash Science School,40828.0,2019,CLAYTON,34.0,16.3,99.1,100.0,1096.0,Gove
 John Monash Science School,40828.0,2020,CLAYTON,34.0,17.1,98.6,100.0,1101.0,Government,Secondary,661.0,-37.91419502,145.12878264
 John Monash Science School,40828.0,2021,CLAYTON,35.0,18.7,99.1,100.0,1104.0,Government,Secondary,678.0,-37.91419502,145.12878264
 John Monash Science School,40828.0,2022,CLAYTON,35.0,21.2,98.6,100.0,1116.0,Government,Secondary,656.0,-37.91419502,145.12878264
-John Monash Science School,,2023,CLAYTON,35.0,21.5,97.4,99.0,,,,,,
+John Monash Science School,40828.0,2023,CLAYTON,35.0,21.5,97.4,99.0,,,,,,
 John Paul College,45994.0,2014,FRANKSTON,29.0,5.6,96.0,100.0,1025.0,Catholic,Secondary,941.0,-38.13608554,145.13953025
 John Paul College,45994.0,2015,FRANKSTON,28.0,3.7,85.0,98.0,1027.0,Catholic,Secondary,909.0,-38.13608554,145.13953025
 John Paul College,45994.0,2016,FRANKSTON,27.0,2.0,86.0,100.0,1028.0,Catholic,Secondary,819.0,-38.13608554,145.13953025
@@ -2223,7 +2360,7 @@ John Paul College,45994.0,2019,FRANKSTON,29.0,4.1,88.8,100.0,1036.0,Catholic,Sec
 John Paul College,45994.0,2020,FRANKSTON,29.0,5.3,78.3,99.0,1041.0,Catholic,Secondary,930.0,-38.134567,145.139395
 John Paul College,45994.0,2021,FRANKSTON,29.0,4.0,81.7,100.0,1042.0,Catholic,Secondary,1003.0,-38.134567,145.139395
 John Paul College,45994.0,2022,FRANKSTON,28.0,5.7,64.4,100.0,1045.0,Catholic,Secondary,1072.0,-38.134567,145.139395
-John Paul College,,2023,FRANKSTON,29.0,5.1,55.9,98.0,,,,,,
+John Paul College,45994.0,2023,FRANKSTON,29.0,5.1,55.9,98.0,,,,,,
 Kambrya College,45480.0,2014,BERWICK,30.0,2.6,82.0,100.0,990.0,Government,Secondary,1019.0,-38.05368819,145.34740996
 Kambrya College,45480.0,2015,BERWICK,29.0,2.3,65.0,98.0,988.0,Government,Secondary,1028.0,-38.05368819,145.34740996
 Kambrya College,45480.0,2016,BERWICK,29.0,2.2,75.0,100.0,1000.0,Government,Secondary,1190.0,-38.05368819,145.34740996
@@ -2233,7 +2370,15 @@ Kambrya College,45480.0,2019,BERWICK,30.0,4.9,85.4,98.0,1024.0,Government,Second
 Kambrya College,45480.0,2020,BERWICK,31.0,6.4,93.8,98.0,1024.0,Government,Secondary,1609.0,-38.05368819,145.34740996
 Kambrya College,45480.0,2021,BERWICK,31.0,6.4,93.8,98.0,1027.0,Government,Secondary,1692.0,-38.05368819,145.34740996
 Kambrya College,45480.0,2022,BERWICK,30.0,8.3,87.2,96.0,1029.0,Government,Secondary,1766.0,-38.05368819,145.34740996
-Kambrya College,,2023,BERWICK,31.0,6.0,64.0,95.0,,,,,,
+Kambrya College,45480.0,2023,BERWICK,31.0,6.0,64.0,95.0,,,,,,
+Kangan Institute,,2020,BROADMEADOWS,,,,,,,,,,
+Kangan Institute,,2021,BROADMEADOWS,,,,,,,,,,
+Kangan Institute of TAFE,,2014,BROADMEADOWS,20.0,0.6,29.0,57.0,,,,,,
+Kangan Institute of TAFE,,2015,BROADMEADOWS,19.0,0.0,33.0,54.0,,,,,,
+Kangan Institute of TAFE,,2016,BROADMEADOWS,20.0,0.0,33.0,69.0,,,,,,
+Kangan Institute of TAFE,,2017,BROADMEADOWS,19.0,0.0,33.0,81.0,,,,,,
+Kangan Institute of TAFE,,2018,BROADMEADOWS,19.0,0.0,17.2,48.0,,,,,,
+Kangan Institute of TAFE,,2019,BROADMEADOWS,17.0,0.0,12.5,75.0,,,,,,
 Kaniva P-12 College,45575.0,2014,KANIVA,28.0,4.3,25.0,100.0,991.0,Government,Combined,206.0,-36.38271876,141.24484506
 Kaniva P-12 College,45575.0,2015,KANIVA,27.0,1.6,18.0,100.0,983.0,Government,Combined,213.0,-36.38271876,141.24484506
 Kaniva P-12 College,45575.0,2016,KANIVA,31.0,9.8,50.0,100.0,981.0,Government,Combined,211.0,-36.38271876,141.24484506
@@ -2243,7 +2388,7 @@ Kaniva P-12 College,45575.0,2019,KANIVA,29.0,5.0,14.3,100.0,982.0,Government,Com
 Kaniva P-12 College,45575.0,2020,KANIVA,31.0,3.3,12.5,88.0,984.0,Government,Combined,173.0,-36.38271876,141.24484506
 Kaniva P-12 College,45575.0,2021,KANIVA,29.0,12.9,14.3,100.0,985.0,Government,Combined,166.0,-36.38271876,141.24484506
 Kaniva P-12 College,45575.0,2022,KANIVA,28.0,5.6,20.0,100.0,981.0,Government,Combined,159.0,-36.38271876,141.24484506
-Kaniva P-12 College,,2023,KANIVA,25.0,,,100.0,,,,,,
+Kaniva P-12 College,45575.0,2023,KANIVA,25.0,,,100.0,,,,,,
 Kardinia Internatl College,46332.0,2014,BELL POST HILL,33.0,12.2,90.0,100.0,1119.0,Independent,Combined,1713.0,-38.112649,144.328729
 Kardinia Internatl College,46332.0,2015,BELL POST HILL,33.0,14.6,89.0,99.0,1122.0,Independent,Combined,1749.0,-38.112649,144.328729
 Kardinia Internatl College,46332.0,2016,BELL POST HILL,32.0,10.5,94.0,100.0,1116.0,Independent,Combined,1758.0,-38.112649,144.328729
@@ -2253,7 +2398,9 @@ Kardinia Internatl College,46332.0,2019,BELL POST HILL,32.0,13.0,88.7,100.0,1124
 Kardinia Internatl College,46332.0,2020,BELL POST HILL,31.0,8.9,89.0,100.0,1124.0,Independent,Combined,1830.0,-38.112649,144.328729
 Kardinia Internatl College,46332.0,2021,BELL POST HILL,32.0,11.9,87.6,100.0,1134.0,Independent,Combined,1839.0,-38.112649,144.328729
 Kardinia Internatl College,46332.0,2022,BELL POST HILL,32.0,12.5,89.9,100.0,1140.0,Independent,Combined,1844.0,-38.112649,144.328729
-Kardinia Internatl College,,2023,BELL POST HILL,32.0,12.4,91.0,100.0,,,,,,
+Kardinia Internatl College,46332.0,2023,BELL POST HILL,32.0,12.4,91.0,100.0,,,,,,
+Karingal,45571.0,2015,BELMONT,,,,,968.0,Government,Secondary,903.0,-38.14667462,145.15836583
+Karingal,45571.0,2016,BELMONT,,,,,961.0,Government,Secondary,946.0,-38.14667462,145.15836583
 Keilor Downs College,45501.0,2014,KEILOR DOWNS,29.0,6.1,88.0,98.0,983.0,Government,Secondary,1200.0,-37.716234,144.81158
 Keilor Downs College,45501.0,2015,KEILOR DOWNS,29.0,9.1,96.0,98.0,988.0,Government,Secondary,1179.0,-37.716234,144.81158
 Keilor Downs College,45501.0,2016,KEILOR DOWNS,29.0,3.8,91.0,98.0,988.0,Government,Secondary,1283.0,-37.716234,144.81158
@@ -2263,7 +2410,7 @@ Keilor Downs College,45501.0,2019,KEILOR DOWNS,29.0,4.1,92.7,98.0,1003.0,Governm
 Keilor Downs College,45501.0,2020,KEILOR DOWNS,30.0,4.3,90.0,99.0,1003.0,Government,Secondary,1387.0,-37.716234,144.81158
 Keilor Downs College,45501.0,2021,KEILOR DOWNS,28.0,3.9,87.6,98.0,1006.0,Government,Secondary,1370.0,-37.716234,144.81158
 Keilor Downs College,45501.0,2022,KEILOR DOWNS,29.0,6.0,89.5,99.0,1004.0,Government,Secondary,1281.0,-37.716234,144.81158
-Keilor Downs College,,2023,KEILOR DOWNS,30.0,4.7,81.2,98.0,,,,,,
+Keilor Downs College,45501.0,2023,KEILOR DOWNS,30.0,4.7,81.2,98.0,,,,,,
 Kensington Comm High School,45404.0,2014,KENSINGTON,,,,,940.0,Government,Secondary,176.0,-37.787909,144.925577
 Kensington Comm High School,45404.0,2015,KENSINGTON,,,,,935.0,Government,Secondary,115.0,-37.787909,144.925577
 Kensington Comm High School,45404.0,2016,KENSINGTON,,,,,943.0,Government,Secondary,104.0,-37.787909,144.925577
@@ -2273,7 +2420,7 @@ Kensington Comm High School,45404.0,2019,KENSINGTON,,,,,950.0,Government,Seconda
 Kensington Comm High School,45404.0,2020,KENSINGTON,,,,,958.0,Government,Secondary,106.0,-37.787909,144.925577
 Kensington Comm High School,45404.0,2021,KENSINGTON,,,,,963.0,Government,Secondary,103.0,-37.787909,144.925577
 Kensington Comm High School,45404.0,2022,KENSINGTON,,,,,944.0,Government,Secondary,90.0,-37.787909,144.925577
-Kensington Comm High School,,2023,KENSINGTON,,,,75.0,,,,,,
+Kensington Comm High School,45404.0,2023,KENSINGTON,,,,75.0,,,,,,
 Kerang Christian College,46289.0,2016,KERANG,27.0,0.0,58.0,100.0,1008.0,Independent,Combined,115.0,-35.730422,143.913416
 Kerang Christian College,46289.0,2017,KERANG,27.0,0.0,92.0,100.0,1013.0,Independent,Combined,113.0,-35.730422,143.913416
 Kerang Christian College,46289.0,2018,KERANG,24.0,0.0,54.5,100.0,1013.0,Independent,Combined,128.0,-35.730422,143.913416
@@ -2281,7 +2428,7 @@ Kerang Christian College,46289.0,2019,KERANG,25.0,0.0,100.0,100.0,1002.0,Indepen
 Kerang Christian College,46289.0,2020,KERANG,25.0,0.0,62.5,100.0,1002.0,Independent,Combined,125.0,-35.730422,143.913416
 Kerang Christian College,46289.0,2021,KERANG,27.0,4.2,50.0,100.0,999.0,Independent,Combined,135.0,-35.730422,143.913416
 Kerang Christian College,46289.0,2022,KERANG,33.0,16.7,55.6,100.0,1008.0,Independent,Combined,139.0,-35.730422,143.913416
-Kerang Christian College,,2023,KERANG,28.0,1.9,90.0,100.0,,,,,,
+Kerang Christian College,46289.0,2023,KERANG,28.0,1.9,90.0,100.0,,,,,,
 Kerang Technical High School,45403.0,2014,KERANG,25.0,4.8,59.0,93.0,957.0,Government,Secondary,348.0,-35.725651,143.913802
 Kerang Technical High School,45403.0,2015,KERANG,25.0,3.3,53.0,86.0,951.0,Government,Secondary,327.0,-35.725651,143.913802
 Kerang Technical High School,45403.0,2016,KERANG,27.0,1.4,48.0,97.0,956.0,Government,Secondary,306.0,-35.725651,143.913802
@@ -2291,7 +2438,7 @@ Kerang Technical High School,45403.0,2019,KERANG,27.0,1.7,58.6,100.0,946.0,Gover
 Kerang Technical High School,45403.0,2020,KERANG,28.0,6.5,76.7,97.0,959.0,Government,Secondary,235.0,-35.725651,143.913802
 Kerang Technical High School,45403.0,2021,KERANG,30.0,9.3,40.9,95.0,952.0,Government,Secondary,255.0,-35.725651,143.913802
 Kerang Technical High School,45403.0,2022,KERANG,28.0,0.0,50.0,89.0,943.0,Government,Secondary,243.0,-35.725651,143.913802
-Kerang Technical High School,,2023,KERANG,23.0,4.7,21.1,95.0,,,,,,
+Kerang Technical High School,45403.0,2023,KERANG,23.0,4.7,21.1,95.0,,,,,,
 Kew High School,45405.0,2014,KEW EAST,32.0,9.7,87.0,99.0,1057.0,Government,Secondary,1041.0,-37.794722,145.061556
 Kew High School,45405.0,2015,KEW EAST,31.0,10.0,90.0,100.0,1061.0,Government,Secondary,1117.0,-37.794722,145.061556
 Kew High School,45405.0,2016,KEW EAST,32.0,10.9,95.0,100.0,1055.0,Government,Secondary,1118.0,-37.794722,145.061556
@@ -2301,7 +2448,7 @@ Kew High School,45405.0,2019,KEW EAST,32.0,12.3,89.8,98.0,1090.0,Government,Seco
 Kew High School,45405.0,2020,KEW EAST,31.0,10.8,95.6,98.0,1096.0,Government,Secondary,1134.0,-37.794722,145.061556
 Kew High School,45405.0,2021,KEW EAST,30.0,8.3,89.3,99.0,1103.0,Government,Secondary,1118.0,-37.794722,145.061556
 Kew High School,45405.0,2022,KEW EAST,30.0,8.1,93.8,98.0,1112.0,Government,Secondary,1080.0,-37.794722,145.061556
-Kew High School,,2023,KEW EAST,31.0,7.2,96.8,99.0,,,,,,
+Kew High School,45405.0,2023,KEW EAST,31.0,7.2,96.8,99.0,,,,,,
 Keysborough SC - Acacia,45595.0,2014,KEYSBOROUGH,25.0,2.7,77.0,95.0,922.0,Government,Secondary,1471.0,-37.96700048,145.1593617
 Keysborough SC - Acacia,45595.0,2015,KEYSBOROUGH,25.0,1.8,93.0,93.0,922.0,Government,Secondary,1589.0,-37.96700048,145.1593617
 Keysborough SC - Acacia,45595.0,2016,KEYSBOROUGH,27.0,2.1,100.0,97.0,915.0,Government,Secondary,1707.0,-37.96700048,145.1593617
@@ -2311,7 +2458,7 @@ Keysborough SC - Acacia,45595.0,2019,KEYSBOROUGH,26.0,1.9,91.5,98.0,931.0,Govern
 Keysborough SC - Acacia,45595.0,2020,KEYSBOROUGH,28.0,2.2,91.3,99.0,937.0,Government,Secondary,1859.0,-37.96700048,145.1593617
 Keysborough SC - Acacia,45595.0,2021,KEYSBOROUGH,28.0,2.0,87.4,95.0,943.0,Government,Secondary,1844.0,-37.96700048,145.1593617
 Keysborough SC - Acacia,45595.0,2022,KEYSBOROUGH,28.0,3.1,90.5,94.0,933.0,Government,Secondary,1874.0,-37.96700048,145.1593617
-Keysborough SC - Acacia,,2023,KEYSBOROUGH,27.0,2.4,80.9,97.0,,,,,,
+Keysborough SC - Acacia,45595.0,2023,KEYSBOROUGH,27.0,2.4,80.9,97.0,,,,,,
 Keysborough SC - Banksia,45595.0,2014,SPRINGVALE SOUTH,27.0,2.2,85.0,95.0,922.0,Government,Secondary,1471.0,-37.96700048,145.1593617
 Keysborough SC - Banksia,45595.0,2015,SPRINGVALE SOUTH,28.0,3.8,97.0,99.0,922.0,Government,Secondary,1589.0,-37.96700048,145.1593617
 Keysborough SC - Banksia,45595.0,2016,SPRINGVALE SOUTH,27.0,3.7,99.0,98.0,915.0,Government,Secondary,1707.0,-37.96700048,145.1593617
@@ -2321,7 +2468,7 @@ Keysborough SC - Banksia,45595.0,2019,SPRINGVALE SOUTH,27.0,1.5,87.1,96.0,931.0,
 Keysborough SC - Banksia,45595.0,2020,SPRINGVALE SOUTH,28.0,2.3,83.5,100.0,937.0,Government,Secondary,1859.0,-37.96700048,145.1593617
 Keysborough SC - Banksia,45595.0,2021,SPRINGVALE SOUTH,27.0,0.9,83.5,97.0,943.0,Government,Secondary,1844.0,-37.96700048,145.1593617
 Keysborough SC - Banksia,45595.0,2022,SPRINGVALE SOUTH,26.0,1.7,84.8,97.0,933.0,Government,Secondary,1874.0,-37.96700048,145.1593617
-Keysborough SC - Banksia,,2023,SPRINGVALE SOUTH,26.0,1.3,68.0,96.0,,,,,,
+Keysborough SC - Banksia,45595.0,2023,SPRINGVALE SOUTH,26.0,1.3,68.0,96.0,,,,,,
 Kilbreda College,45712.0,2014,MENTONE,31.0,7.0,92.0,100.0,1050.0,Catholic,Secondary,966.0,-37.984153,145.065712
 Kilbreda College,45712.0,2015,MENTONE,29.0,5.0,96.0,100.0,1055.0,Catholic,Secondary,976.0,-37.984153,145.065712
 Kilbreda College,45712.0,2016,MENTONE,31.0,5.9,93.0,100.0,1052.0,Catholic,Secondary,974.0,-37.984153,145.065712
@@ -2331,7 +2478,7 @@ Kilbreda College,45712.0,2019,MENTONE,31.0,7.8,88.8,100.0,1060.0,Catholic,Second
 Kilbreda College,45712.0,2020,MENTONE,33.0,13.1,93.0,100.0,1065.0,Catholic,Secondary,894.0,-37.984153,145.065712
 Kilbreda College,45712.0,2021,MENTONE,31.0,9.9,89.4,99.0,1068.0,Catholic,Secondary,886.0,-37.984153,145.065712
 Kilbreda College,45712.0,2022,MENTONE,31.0,7.7,84.0,100.0,1068.0,Catholic,Secondary,877.0,-37.984153,145.065712
-Kilbreda College,,2023,MENTONE,31.0,8.1,65.9,100.0,,,,,,
+Kilbreda College,45712.0,2023,MENTONE,31.0,8.1,65.9,100.0,,,,,,
 Killester College,45906.0,2014,SPRINGVALE,29.0,5.3,98.0,100.0,951.0,Catholic,Secondary,891.0,-37.959071,145.152017
 Killester College,45906.0,2015,SPRINGVALE,30.0,4.9,97.0,99.0,990.0,Catholic,Secondary,900.0,-37.959071,145.152017
 Killester College,45906.0,2016,SPRINGVALE,30.0,5.3,93.0,98.0,982.0,Catholic,Secondary,891.0,-37.959071,145.152017
@@ -2341,7 +2488,7 @@ Killester College,45906.0,2019,SPRINGVALE,31.0,6.2,99.2,100.0,1000.0,Catholic,Se
 Killester College,45906.0,2020,SPRINGVALE,31.0,3.7,98.4,100.0,1002.0,Catholic,Secondary,943.0,-37.959071,145.152017
 Killester College,45906.0,2021,SPRINGVALE,30.0,6.0,96.9,100.0,1005.0,Catholic,Secondary,965.0,-37.959071,145.152017
 Killester College,45906.0,2022,SPRINGVALE,29.0,7.1,93.5,99.0,1005.0,Catholic,Secondary,971.0,-37.959071,145.152017
-Killester College,,2023,SPRINGVALE,30.0,6.0,87.5,99.0,,,,,,
+Killester College,45906.0,2023,SPRINGVALE,30.0,6.0,87.5,99.0,,,,,,
 Kilvington Grammar School,46188.0,2014,ORMOND,33.0,12.2,100.0,100.0,1169.0,Independent,Combined,576.0,-37.899519,145.041216
 Kilvington Grammar School,46188.0,2015,ORMOND,34.0,15.6,98.0,100.0,1179.0,Independent,Combined,605.0,-37.899519,145.041216
 Kilvington Grammar School,46188.0,2016,ORMOND,35.0,25.6,100.0,100.0,1186.0,Independent,Combined,672.0,-37.899519,145.041216
@@ -2351,7 +2498,7 @@ Kilvington Grammar School,46188.0,2019,ORMOND,36.0,23.8,98.7,100.0,1171.0,Indepe
 Kilvington Grammar School,46188.0,2020,ORMOND,35.0,20.2,100.0,100.0,1171.0,Independent,Combined,742.0,-37.899519,145.041216
 Kilvington Grammar School,46188.0,2021,ORMOND,34.0,14.5,97.1,99.0,1169.0,Independent,Combined,754.0,-37.899519,145.041216
 Kilvington Grammar School,46188.0,2022,ORMOND,34.0,15.6,98.8,100.0,1174.0,Independent,Combined,760.0,-37.899519,145.041216
-Kilvington Grammar School,,2023,ORMOND,33.0,15.2,97.4,100.0,,,,,,
+Kilvington Grammar School,46188.0,2023,ORMOND,33.0,15.2,97.4,100.0,,,,,,
 Kings College,46306.0,2014,WARRNAMBOOL,29.0,2.6,77.0,100.0,1067.0,Independent,Combined,284.0,-38.362113,142.506174
 Kings College,46306.0,2015,WARRNAMBOOL,31.0,3.9,74.0,95.0,1060.0,Independent,Combined,255.0,-38.362113,142.506174
 Kings College,46306.0,2016,WARRNAMBOOL,30.0,5.1,71.0,100.0,1037.0,Independent,Combined,241.0,-38.362113,142.506174
@@ -2361,7 +2508,7 @@ Kings College,46306.0,2019,WARRNAMBOOL,32.0,4.3,57.1,100.0,1040.0,Independent,Co
 Kings College,46306.0,2020,WARRNAMBOOL,27.0,0.0,85.7,100.0,1040.0,Independent,Combined,198.0,-38.362113,142.506174
 Kings College,46306.0,2021,WARRNAMBOOL,30.0,2.9,14.3,86.0,901.0,Independent,Combined,210.0,-38.362113,142.506174
 Kings College,46306.0,2022,WARRNAMBOOL,29.0,0.0,63.6,100.0,1065.0,Independent,Combined,229.0,-38.362113,142.506174
-Kings College,,2023,WARRNAMBOOL,30.0,,60.0,100.0,,,,,,
+Kings College,46306.0,2023,WARRNAMBOOL,30.0,,60.0,100.0,,,,,,
 Kingswood College,46202.0,2014,BOX HILL,32.0,8.9,90.0,100.0,1151.0,Independent,Combined,569.0,-37.832777,145.118628
 Kingswood College,46202.0,2015,BOX HILL,31.0,7.6,98.0,98.0,1168.0,Independent,Combined,540.0,-37.832777,145.118628
 Kingswood College,46202.0,2016,BOX HILL,32.0,18.0,89.0,100.0,1161.0,Independent,Combined,534.0,-37.832777,145.118628
@@ -2371,7 +2518,7 @@ Kingswood College,46202.0,2019,BOX HILL,32.0,12.6,100.0,100.0,1157.0,Independent
 Kingswood College,46202.0,2020,BOX HILL,33.0,14.9,95.3,100.0,1157.0,Independent,Combined,570.0,-37.832777,145.118628
 Kingswood College,46202.0,2021,BOX HILL,32.0,11.5,89.4,100.0,1147.0,Independent,Combined,540.0,-37.832777,145.118628
 Kingswood College,46202.0,2022,BOX HILL,32.0,6.6,90.1,99.0,1147.0,Independent,Combined,574.0,-37.832777,145.118628
-Kingswood College,,2023,BOX HILL,31.0,9.6,85.0,100.0,,,,,,
+Kingswood College,46202.0,2023,BOX HILL,31.0,9.6,85.0,100.0,,,,,,
 Kolbe Catholic College,46123.0,2014,GREENVALE,25.0,0.7,98.0,98.0,930.0,Catholic,Secondary,906.0,-37.61565904,144.90988638
 Kolbe Catholic College,46123.0,2015,GREENVALE,26.0,3.7,98.0,98.0,972.0,Catholic,Secondary,898.0,-37.61565904,144.90988638
 Kolbe Catholic College,46123.0,2016,GREENVALE,26.0,0.7,100.0,100.0,968.0,Catholic,Secondary,900.0,-37.61565904,144.90988638
@@ -2381,7 +2528,7 @@ Kolbe Catholic College,46123.0,2019,GREENVALE,26.0,1.0,96.0,100.0,973.0,Catholic
 Kolbe Catholic College,46123.0,2020,GREENVALE,26.0,2.0,84.0,98.0,975.0,Catholic,Secondary,1010.0,-37.61565904,144.90988638
 Kolbe Catholic College,46123.0,2021,GREENVALE,26.0,1.4,92.5,99.0,975.0,Catholic,Secondary,1068.0,-37.61565904,144.90988638
 Kolbe Catholic College,46123.0,2022,GREENVALE,25.0,1.4,93.3,97.0,976.0,Catholic,Secondary,1116.0,-37.61565904,144.90988638
-Kolbe Catholic College,,2023,GREENVALE,25.0,1.3,82.5,92.0,,,,,,
+Kolbe Catholic College,46123.0,2023,GREENVALE,25.0,1.3,82.5,92.0,,,,,,
 Koo Wee Rup Sec College,45407.0,2014,KOO WEE RUP,30.0,9.6,69.0,97.0,962.0,Government,Secondary,991.0,-38.19701512,145.49578417
 Koo Wee Rup Sec College,45407.0,2015,KOO WEE RUP,29.0,3.7,65.0,95.0,964.0,Government,Secondary,986.0,-38.19701512,145.49578417
 Koo Wee Rup Sec College,45407.0,2016,KOO WEE RUP,29.0,3.1,74.0,95.0,961.0,Government,Secondary,944.0,-38.19701512,145.49578417
@@ -2391,7 +2538,7 @@ Koo Wee Rup Sec College,45407.0,2019,KOO WEE RUP,28.0,4.4,93.0,99.0,966.0,Govern
 Koo Wee Rup Sec College,45407.0,2020,KOO WEE RUP,28.0,2.0,83.3,98.0,970.0,Government,Secondary,1078.0,-38.19701512,145.49578417
 Koo Wee Rup Sec College,45407.0,2021,KOO WEE RUP,26.0,1.5,76.2,98.0,972.0,Government,Secondary,1104.0,-38.19701512,145.49578417
 Koo Wee Rup Sec College,45407.0,2022,KOO WEE RUP,28.0,5.0,86.9,97.0,967.0,Government,Secondary,1087.0,-38.19701512,145.49578417
-Koo Wee Rup Sec College,,2023,KOO WEE RUP,28.0,2.4,63.6,100.0,,,,,,
+Koo Wee Rup Sec College,45407.0,2023,KOO WEE RUP,28.0,2.4,63.6,100.0,,,,,,
 Koonung Secondary College,45406.0,2014,MONT ALBERT NORTH,32.0,8.3,92.0,98.0,1087.0,Government,Secondary,1084.0,-37.803729,145.116155
 Koonung Secondary College,45406.0,2015,MONT ALBERT NORTH,31.0,7.2,94.0,99.0,1086.0,Government,Secondary,1013.0,-37.803729,145.116155
 Koonung Secondary College,45406.0,2016,MONT ALBERT NORTH,31.0,7.5,90.0,98.0,1090.0,Government,Secondary,991.0,-37.803729,145.116155
@@ -2401,7 +2548,7 @@ Koonung Secondary College,45406.0,2019,MONT ALBERT NORTH,33.0,9.4,93.4,99.0,1089
 Koonung Secondary College,45406.0,2020,MONT ALBERT NORTH,32.0,9.0,93.2,100.0,1091.0,Government,Secondary,1047.0,-37.803729,145.116155
 Koonung Secondary College,45406.0,2021,MONT ALBERT NORTH,32.0,9.1,92.9,98.0,1093.0,Government,Secondary,1104.0,-37.803729,145.116155
 Koonung Secondary College,45406.0,2022,MONT ALBERT NORTH,31.0,9.5,84.0,99.0,1100.0,Government,Secondary,1130.0,-37.803729,145.116155
-Koonung Secondary College,,2023,MONT ALBERT NORTH,32.0,9.9,86.0,99.0,,,,,,
+Koonung Secondary College,45406.0,2023,MONT ALBERT NORTH,32.0,9.9,86.0,99.0,,,,,,
 Korowa Anglican Girls' School,46136.0,2014,GLEN IRIS,35.0,24.1,100.0,100.0,1200.0,Independent,Combined,619.0,-37.861454,145.054637
 Korowa Anglican Girls' School,46136.0,2015,GLEN IRIS,36.0,25.3,97.0,100.0,1211.0,Independent,Combined,597.0,-37.861454,145.054637
 Korowa Anglican Girls' School,46136.0,2016,GLEN IRIS,36.0,27.1,100.0,100.0,1204.0,Independent,Combined,559.0,-37.861454,145.054637
@@ -2411,7 +2558,7 @@ Korowa Anglican Girls' School,46136.0,2019,GLEN IRIS,37.0,29.7,100.0,100.0,1191.
 Korowa Anglican Girls' School,46136.0,2020,GLEN IRIS,36.0,20.8,97.4,100.0,1191.0,Independent,Combined,708.0,-37.861454,145.054637
 Korowa Anglican Girls' School,46136.0,2021,GLEN IRIS,36.0,27.2,100.0,100.0,1189.0,Independent,Combined,701.0,-37.861454,145.054637
 Korowa Anglican Girls' School,46136.0,2022,GLEN IRIS,36.0,31.8,100.0,100.0,1194.0,Independent,Combined,704.0,-37.861454,145.054637
-Korowa Anglican Girls' School,,2023,GLEN IRIS,36.0,29.0,98.8,100.0,,,,,,
+Korowa Anglican Girls' School,46136.0,2023,GLEN IRIS,36.0,29.0,98.8,100.0,,,,,,
 Korumburra Sec College,45408.0,2014,KORUMBURRA,29.0,4.3,88.0,100.0,965.0,Government,Secondary,411.0,-38.44387,145.8039
 Korumburra Sec College,45408.0,2015,KORUMBURRA,26.0,2.5,61.0,89.0,960.0,Government,Secondary,389.0,-38.44387,145.8039
 Korumburra Sec College,45408.0,2016,KORUMBURRA,26.0,1.5,66.0,100.0,963.0,Government,Secondary,372.0,-38.44387,145.8039
@@ -2421,7 +2568,7 @@ Korumburra Sec College,45408.0,2019,KORUMBURRA,29.0,5.3,92.3,100.0,974.0,Governm
 Korumburra Sec College,45408.0,2020,KORUMBURRA,27.0,5.2,66.7,100.0,973.0,Government,Secondary,340.0,-38.44387,145.8039
 Korumburra Sec College,45408.0,2021,KORUMBURRA,26.0,0.8,84.6,100.0,973.0,Government,Secondary,348.0,-38.44387,145.8039
 Korumburra Sec College,45408.0,2022,KORUMBURRA,25.0,0.0,69.6,100.0,970.0,Government,Secondary,375.0,-38.44387,145.8039
-Korumburra Sec College,,2023,KORUMBURRA,25.0,,34.4,100.0,,,,,,
+Korumburra Sec College,45408.0,2023,KORUMBURRA,25.0,,34.4,100.0,,,,,,
 Kurnai College,45503.0,2014,CHURCHILL,28.0,2.0,59.0,98.0,955.0,Government,Secondary,1174.0,-38.228791,146.432788
 Kurnai College,45503.0,2015,CHURCHILL,26.0,2.3,64.0,98.0,936.0,Government,Secondary,1148.0,-38.228791,146.432788
 Kurnai College,45503.0,2016,CHURCHILL,26.0,2.3,44.0,89.0,937.0,Government,Secondary,1148.0,-38.228791,146.432788
@@ -2431,7 +2578,7 @@ Kurnai College,45503.0,2019,CHURCHILL,27.0,1.9,61.6,95.0,937.0,Government,Second
 Kurnai College,45503.0,2020,CHURCHILL,27.0,0.7,57.1,100.0,934.0,Government,Secondary,1087.0,-38.228791,146.432788
 Kurnai College,45503.0,2021,CHURCHILL,28.0,8.7,57.1,96.0,928.0,Government,Secondary,1112.0,-38.228791,146.432788
 Kurnai College,45503.0,2022,CHURCHILL,27.0,6.1,52.6,99.0,905.0,Government,Secondary,1104.0,-38.228791,146.432788
-Kurnai College,,2023,CHURCHILL,26.0,2.7,49.2,95.0,,,,,,
+Kurnai College,45503.0,2023,CHURCHILL,26.0,2.7,49.2,95.0,,,,,,
 Kurunjang Secondary College,45504.0,2014,MELTON,24.0,0.5,68.0,86.0,945.0,Government,Secondary,708.0,-37.67318002,144.58582721
 Kurunjang Secondary College,45504.0,2015,MELTON,24.0,0.4,66.0,85.0,936.0,Government,Secondary,725.0,-37.67318002,144.58582721
 Kurunjang Secondary College,45504.0,2016,MELTON,24.0,0.0,66.0,90.0,934.0,Government,Secondary,758.0,-37.67318002,144.58582721
@@ -2441,7 +2588,7 @@ Kurunjang Secondary College,45504.0,2019,MELTON,25.0,0.4,79.6,98.0,940.0,Governm
 Kurunjang Secondary College,45504.0,2020,MELTON,25.0,1.7,71.4,95.0,939.0,Government,Secondary,915.0,-37.67318002,144.58582721
 Kurunjang Secondary College,45504.0,2021,MELTON,26.0,2.6,78.4,98.0,943.0,Government,Secondary,903.0,-37.67318002,144.58582721
 Kurunjang Secondary College,45504.0,2022,MELTON,24.0,1.9,74.5,87.0,939.0,Government,Secondary,902.0,-37.67318002,144.58582721
-Kurunjang Secondary College,,2023,MELTON,25.0,1.7,61.4,98.0,,,,,,
+Kurunjang Secondary College,45504.0,2023,MELTON,25.0,1.7,61.4,98.0,,,,,,
 Kyabram P-12 College,45409.0,2014,KYABRAM,27.0,3.3,70.0,98.0,961.0,Government,Combined,1025.0,-36.317476,145.056207
 Kyabram P-12 College,45409.0,2015,KYABRAM,26.0,2.4,63.0,92.0,952.0,Government,Combined,1020.0,-36.317476,145.056207
 Kyabram P-12 College,45409.0,2016,KYABRAM,26.0,1.1,57.0,94.0,952.0,Government,Combined,990.0,-36.317476,145.056207
@@ -2451,17 +2598,17 @@ Kyabram P-12 College,45409.0,2019,KYABRAM,27.0,0.9,39.0,98.0,957.0,Government,Co
 Kyabram P-12 College,45409.0,2020,KYABRAM,27.0,0.4,70.6,98.0,960.0,Government,Combined,932.0,-36.317476,145.056207
 Kyabram P-12 College,45409.0,2021,KYABRAM,29.0,0.0,63.3,96.0,959.0,Government,Combined,931.0,-36.317476,145.056207
 Kyabram P-12 College,45409.0,2022,KYABRAM,28.0,0.7,50.0,97.0,953.0,Government,Combined,948.0,-36.317476,145.056207
-Kyabram P-12 College,,2023,KYABRAM,24.0,0.6,23.1,90.0,,,,,,
-Kyneton Secondary College,45424.0,2014,KYNETON,27.0,2.8,71.0,95.0,939.0,Government,Secondary,755.0,-37.68244498,144.56688187
-Kyneton Secondary College,45424.0,2015,KYNETON,27.0,2.5,81.0,100.0,938.0,Government,Secondary,871.0,-37.68244498,144.56688187
-Kyneton Secondary College,45424.0,2016,KYNETON,27.0,2.0,81.0,100.0,930.0,Government,Secondary,955.0,-37.68244498,144.56688187
-Kyneton Secondary College,45424.0,2017,KYNETON,27.0,2.4,79.0,100.0,932.0,Government,Secondary,1067.0,-37.68244498,144.56688187
-Kyneton Secondary College,45424.0,2018,KYNETON,26.0,1.3,65.6,100.0,935.0,Government,Secondary,1061.0,-37.68244498,144.56688187
-Kyneton Secondary College,45424.0,2019,KYNETON,27.0,1.5,74.4,97.0,946.0,Government,Secondary,1138.0,-37.68244498,144.56688187
-Kyneton Secondary College,45424.0,2020,KYNETON,27.0,1.9,83.9,100.0,952.0,Government,Secondary,1213.0,-37.68244498,144.56688187
-Kyneton Secondary College,45424.0,2021,KYNETON,26.0,1.5,72.0,100.0,951.0,Government,Secondary,1329.0,-37.68244498,144.56688187
-Kyneton Secondary College,45424.0,2022,KYNETON,26.0,1.2,57.9,100.0,940.0,Government,Secondary,1383.0,-37.68244498,144.56688187
-Kyneton Secondary College,,2023,KYNETON,28.0,2.0,38.9,100.0,,,,,,
+Kyabram P-12 College,45409.0,2023,KYABRAM,24.0,0.6,23.1,90.0,,,,,,
+Kyneton Secondary College,45412.0,2014,KYNETON,27.0,2.8,71.0,95.0,972.0,Government,Secondary,532.0,-37.25132966,144.45817072
+Kyneton Secondary College,45412.0,2015,KYNETON,27.0,2.5,81.0,100.0,972.0,Government,Secondary,526.0,-37.25132966,144.45817072
+Kyneton Secondary College,45412.0,2016,KYNETON,27.0,2.0,81.0,100.0,981.0,Government,Secondary,508.0,-37.25132966,144.45817072
+Kyneton Secondary College,45412.0,2017,KYNETON,27.0,2.4,79.0,100.0,962.0,Government,Secondary,470.0,-37.25132966,144.45817072
+Kyneton Secondary College,45412.0,2018,KYNETON,26.0,1.3,65.6,100.0,983.0,Government,Secondary,439.0,-37.25132966,144.45817072
+Kyneton Secondary College,45412.0,2019,KYNETON,27.0,1.5,74.4,97.0,995.0,Government,Secondary,479.0,-37.25132966,144.45817072
+Kyneton Secondary College,45412.0,2020,KYNETON,27.0,1.9,83.9,100.0,996.0,Government,Secondary,500.0,-37.25132966,144.45817072
+Kyneton Secondary College,45412.0,2021,KYNETON,26.0,1.5,72.0,100.0,1004.0,Government,Secondary,520.0,-37.25132966,144.45817072
+Kyneton Secondary College,45412.0,2022,KYNETON,26.0,1.2,57.9,100.0,1006.0,Government,Secondary,574.0,-37.25132966,144.45817072
+Kyneton Secondary College,45412.0,2023,KYNETON,28.0,2.0,38.9,100.0,,,,,,
 Lake Bolac College,44149.0,2014,LAKE BOLAC,33.0,0.0,,,976.0,Government,Combined,78.0,-37.720241,142.837903
 Lake Bolac College,44149.0,2015,LAKE BOLAC,27.0,0.0,100.0,100.0,955.0,Government,Combined,89.0,-37.720241,142.837903
 Lake Bolac College,44149.0,2017,LAKE BOLAC,,,100.0,,970.0,Government,Combined,93.0,-37.720241,142.837903
@@ -2478,7 +2625,7 @@ Lakes Entrance Sec College,45505.0,2019,LAKES ENTRANCE,30.0,10.9,81.8,91.0,920.0
 Lakes Entrance Sec College,45505.0,2020,LAKES ENTRANCE,25.0,2.7,37.5,100.0,913.0,Government,Secondary,280.0,-37.871343,147.998412
 Lakes Entrance Sec College,45505.0,2021,LAKES ENTRANCE,26.0,5.2,46.7,87.0,915.0,Government,Secondary,270.0,-37.871343,147.998412
 Lakes Entrance Sec College,45505.0,2022,LAKES ENTRANCE,28.0,7.9,50.0,100.0,901.0,Government,Secondary,264.0,-37.871343,147.998412
-Lakes Entrance Sec College,,2023,LAKES ENTRANCE,24.0,,50.0,83.0,,,,,,
+Lakes Entrance Sec College,45505.0,2023,LAKES ENTRANCE,24.0,,50.0,83.0,,,,,,
 Lakeside Lutheran College,46380.0,2014,PAKENHAM,27.0,0.0,100.0,100.0,1045.0,Independent,Combined,294.0,-38.06492414,145.45592791
 Lakeside Lutheran College,46380.0,2015,PAKENHAM,29.0,2.1,100.0,100.0,1045.0,Independent,Combined,325.0,-38.06492414,145.45592791
 Lakeside Lutheran College,46380.0,2016,PAKENHAM,25.0,2.7,90.0,100.0,1044.0,Independent,Combined,355.0,-38.06492414,145.45592791
@@ -2488,7 +2635,7 @@ Lakeside Lutheran College,46380.0,2019,PAKENHAM,26.0,0.0,100.0,100.0,1033.0,Inde
 Lakeside Lutheran College,46380.0,2020,PAKENHAM,26.0,5.3,100.0,100.0,1033.0,Independent,Combined,407.0,-38.06492414,145.45592791
 Lakeside Lutheran College,46380.0,2021,PAKENHAM,27.0,0.8,71.4,100.0,1033.0,Independent,Combined,464.0,-38.06492414,145.45592791
 Lakeside Lutheran College,46380.0,2022,PAKENHAM,25.0,3.6,81.0,100.0,1029.0,Independent,Combined,503.0,-38.06492414,145.45592791
-Lakeside Lutheran College,,2023,PAKENHAM,25.0,6.8,76.9,96.0,,,,,,
+Lakeside Lutheran College,46380.0,2023,PAKENHAM,25.0,6.8,76.9,96.0,,,,,,
 Lakeview Senior College,50199.0,2014,CAROLINE SPRINGS,27.0,2.7,96.0,99.0,,Government,Secondary,999.0,-37.73116305,144.74013589
 Lakeview Senior College,50199.0,2015,CAROLINE SPRINGS,29.0,4.1,94.0,98.0,,Government,Secondary,998.0,-37.73116305,144.74013589
 Lakeview Senior College,50199.0,2016,CAROLINE SPRINGS,29.0,5.3,93.0,100.0,,Government,Secondary,1013.0,-37.73116305,144.74013589
@@ -2498,7 +2645,7 @@ Lakeview Senior College,50199.0,2019,CAROLINE SPRINGS,29.0,2.9,87.9,97.0,1007.0,
 Lakeview Senior College,50199.0,2020,CAROLINE SPRINGS,28.0,5.1,92.6,96.0,1013.0,Government,Secondary,1011.0,-37.73116305,144.74013589
 Lakeview Senior College,50199.0,2021,CAROLINE SPRINGS,27.0,3.1,88.2,97.0,1011.0,Government,Secondary,990.0,-37.73116305,144.74013589
 Lakeview Senior College,50199.0,2022,CAROLINE SPRINGS,26.0,4.2,86.9,92.0,1009.0,Government,Secondary,968.0,-37.73116305,144.74013589
-Lakeview Senior College,,2023,CAROLINE SPRINGS,28.0,3.2,71.9,92.0,,,,,,
+Lakeview Senior College,50199.0,2023,CAROLINE SPRINGS,28.0,3.2,71.9,92.0,,,,,,
 Lalor North Sec College,45414.0,2014,EPPING,23.0,1.0,83.0,95.0,942.0,Government,Secondary,448.0,-37.66098319,145.03495798
 Lalor North Sec College,45414.0,2015,EPPING,24.0,1.8,93.0,93.0,947.0,Government,Secondary,429.0,-37.66098319,145.03495798
 Lalor North Sec College,45414.0,2016,EPPING,25.0,0.8,76.0,98.0,951.0,Government,Secondary,427.0,-37.66098319,145.03495798
@@ -2508,7 +2655,7 @@ Lalor North Sec College,45414.0,2019,EPPING,26.0,1.6,96.2,94.0,948.0,Government,
 Lalor North Sec College,45414.0,2020,EPPING,24.0,1.1,92.1,100.0,948.0,Government,Secondary,359.0,-37.66098319,145.03495798
 Lalor North Sec College,45414.0,2021,EPPING,25.0,0.5,83.3,95.0,946.0,Government,Secondary,325.0,-37.66098319,145.03495798
 Lalor North Sec College,45414.0,2022,EPPING,23.0,4.3,80.0,95.0,945.0,Government,Secondary,298.0,-37.66098319,145.03495798
-Lalor North Sec College,,2023,EPPING,21.0,0.6,85.7,97.0,,,,,,
+Lalor North Sec College,45414.0,2023,EPPING,21.0,0.6,85.7,97.0,,,,,,
 Lalor Secondary College,45413.0,2014,LALOR,27.0,2.2,88.0,99.0,948.0,Government,Secondary,1090.0,-37.67265939,145.03062279
 Lalor Secondary College,45413.0,2015,LALOR,29.0,4.7,82.0,99.0,948.0,Government,Secondary,1047.0,-37.67265939,145.03062279
 Lalor Secondary College,45413.0,2016,LALOR,30.0,4.8,86.0,95.0,941.0,Government,Secondary,993.0,-37.67265939,145.03062279
@@ -2518,7 +2665,7 @@ Lalor Secondary College,45413.0,2019,LALOR,25.0,2.2,86.4,97.0,952.0,Government,S
 Lalor Secondary College,45413.0,2020,LALOR,27.0,0.7,92.7,99.0,955.0,Government,Secondary,1112.0,-37.67265939,145.03062279
 Lalor Secondary College,45413.0,2021,LALOR,28.0,3.1,69.2,97.0,957.0,Government,Secondary,1108.0,-37.671732,145.030585
 Lalor Secondary College,45413.0,2022,LALOR,27.0,3.4,85.4,99.0,948.0,Government,Secondary,1128.0,-37.671732,145.030585
-Lalor Secondary College,,2023,LALOR,25.0,1.5,73.6,95.0,,,,,,
+Lalor Secondary College,45413.0,2023,LALOR,25.0,1.5,73.6,95.0,,,,,,
 Lara Secondary College,45574.0,2014,LARA,27.0,0.5,88.0,93.0,982.0,Government,Secondary,761.0,-38.01839851,144.41233424
 Lara Secondary College,45574.0,2015,LARA,26.0,0.3,65.0,94.0,975.0,Government,Secondary,773.0,-38.01839851,144.41233424
 Lara Secondary College,45574.0,2016,LARA,26.0,0.6,75.0,99.0,969.0,Government,Secondary,768.0,-38.01839851,144.41233424
@@ -2528,7 +2675,7 @@ Lara Secondary College,45574.0,2019,LARA,24.0,0.0,46.6,100.0,981.0,Government,Se
 Lara Secondary College,45574.0,2020,LARA,25.0,0.0,53.2,85.0,977.0,Government,Secondary,635.0,-38.01839851,144.41233424
 Lara Secondary College,45574.0,2021,LARA,24.0,2.4,46.0,86.0,980.0,Government,Secondary,646.0,-38.01839851,144.41233424
 Lara Secondary College,45574.0,2022,LARA,25.0,0.0,42.9,93.0,971.0,Government,Secondary,690.0,-38.01839851,144.41233424
-Lara Secondary College,,2023,LARA,25.0,2.1,39.0,92.0,,,,,,
+Lara Secondary College,45574.0,2023,LARA,25.0,2.1,39.0,92.0,,,,,,
 Lauriston Girls School,46150.0,2014,ARMADALE,37.0,29.8,98.0,100.0,1193.0,Independent,Combined,766.0,-37.852317,145.025089
 Lauriston Girls School,46150.0,2015,ARMADALE,36.0,30.9,98.0,100.0,1197.0,Independent,Combined,819.0,-37.852317,145.025089
 Lauriston Girls School,46150.0,2016,ARMADALE,36.0,24.7,98.0,100.0,1188.0,Independent,Combined,880.0,-37.852317,145.025089
@@ -2538,7 +2685,7 @@ Lauriston Girls School,46150.0,2019,ARMADALE,35.0,21.1,98.8,98.0,1194.0,Independ
 Lauriston Girls School,46150.0,2020,ARMADALE,35.0,24.3,96.9,100.0,1194.0,Independent,Combined,894.0,-37.852317,145.025089
 Lauriston Girls School,46150.0,2021,ARMADALE,36.0,33.7,100.0,100.0,1188.0,Independent,Combined,885.0,-37.852317,145.025089
 Lauriston Girls School,46150.0,2022,ARMADALE,36.0,28.6,100.0,100.0,1201.0,Independent,Combined,893.0,-37.852317,145.025089
-Lauriston Girls School,,2023,ARMADALE,34.0,19.8,96.7,100.0,,,,,,
+Lauriston Girls School,46150.0,2023,ARMADALE,34.0,19.8,96.7,100.0,,,,,,
 Lavalla Catholic College,40708.0,2014,TRARALGON,29.0,4.0,82.0,100.0,1009.0,Catholic,Secondary,1131.0,-38.200886266954285,146.51419568451692
 Lavalla Catholic College,40708.0,2015,TRARALGON,29.0,4.1,75.0,97.0,1016.0,Catholic,Secondary,1169.0,-38.200886266954285,146.51419568451692
 Lavalla Catholic College,40708.0,2016,TRARALGON,28.0,3.0,75.0,100.0,1013.0,Catholic,Secondary,1180.0,-38.200886266954285,146.51419568451692
@@ -2548,13 +2695,13 @@ Lavalla Catholic College,40708.0,2019,TRARALGON,28.0,4.9,74.4,99.0,1023.0,Cathol
 Lavalla Catholic College,40708.0,2020,TRARALGON,28.0,5.4,72.7,98.0,1026.0,Catholic,Secondary,1191.0,-38.200886266954285,146.51419568451692
 Lavalla Catholic College,40708.0,2021,TRARALGON,28.0,4.8,65.9,98.0,1027.0,Catholic,Secondary,1153.0,-38.200886266954285,146.51419568451692
 Lavalla Catholic College,40708.0,2022,TRARALGON,28.0,5.0,75.4,98.0,1029.0,Catholic,Secondary,1172.0,-38.200886266954285,146.51419568451692
-Lavalla Catholic College,,2023,TRARALGON,30.0,5.3,60.5,97.0,,,,,,
+Lavalla Catholic College,40708.0,2023,TRARALGON,30.0,5.3,60.5,97.0,,,,,,
 Lavers Hill K-12 College,45304.0,2017,LAVERS HILL,26.0,0.0,0.0,100.0,931.0,Government,Combined,107.0,-38.681844,143.383051
 Lavers Hill K-12 College,45304.0,2018,LAVERS HILL,29.0,0.0,75.0,88.0,906.0,Government,Combined,96.0,-38.681844,143.383051
 Lavers Hill K-12 College,45304.0,2020,LAVERS HILL,27.0,0.0,66.7,100.0,928.0,Government,Combined,79.0,-38.681844,143.383051
 Lavers Hill K-12 College,45304.0,2021,LAVERS HILL,,,100.0,100.0,924.0,Government,Combined,81.0,-38.681844,143.383051
 Lavers Hill K-12 College,45304.0,2022,LAVERS HILL,23.0,0.0,25.0,75.0,915.0,Government,Combined,63.0,-38.681844,143.383051
-Lavers Hill K-12 College,,2023,LAVERS HILL,,,50.0,100.0,,,,,,
+Lavers Hill K-12 College,45304.0,2023,LAVERS HILL,,,50.0,100.0,,,,,,
 Lavers Hill P12 College,45304.0,2014,LAVERS HILL,27.0,0.0,,,946.0,Government,Combined,77.0,-38.681844,143.383051
 Lavers Hill P12 College,45304.0,2015,LAVERS HILL,26.0,0.0,67.0,100.0,959.0,Government,Combined,89.0,-38.681844,143.383051
 Lavers Hill P12 College,45304.0,2016,LAVERS HILL,26.0,0.0,100.0,100.0,974.0,Government,Combined,98.0,-38.681844,143.383051
@@ -2567,7 +2714,7 @@ Laverton P-12 College,45590.0,2019,LAVERTON,23.0,1.2,100.0,100.0,925.0,Governmen
 Laverton P-12 College,45590.0,2020,LAVERTON,22.0,0.7,93.3,100.0,923.0,Government,Combined,653.0,-37.85617409,144.77263287
 Laverton P-12 College,45590.0,2021,LAVERTON,22.0,0.0,96.4,96.0,927.0,Government,Combined,670.0,-37.85617409,144.77263287
 Laverton P-12 College,45590.0,2022,LAVERTON,22.0,0.0,80.0,96.0,917.0,Government,Combined,712.0,-37.85617409,144.77263287
-Laverton P-12 College,,2023,LAVERTON,22.0,0.8,56.0,96.0,,,,,,
+Laverton P-12 College,45590.0,2023,LAVERTON,22.0,0.8,56.0,96.0,,,,,,
 Leibler Yavneh College,46218.0,2014,ELSTERNWICK,37.0,33.5,98.0,100.0,1163.0,Independent,Combined,596.0,-37.892871,145.006626
 Leibler Yavneh College,46218.0,2015,ELSTERNWICK,36.0,30.2,93.0,100.0,1159.0,Independent,Combined,583.0,-37.892871,145.006626
 Leibler Yavneh College,46218.0,2016,ELSTERNWICK,36.0,29.0,97.0,100.0,1146.0,Independent,Combined,572.0,-37.892871,145.006626
@@ -2577,7 +2724,7 @@ Leibler Yavneh College,46218.0,2019,ELSTERNWICK,35.0,26.0,97.4,100.0,1125.0,Inde
 Leibler Yavneh College,46218.0,2020,ELSTERNWICK,35.0,23.5,100.0,100.0,1125.0,Independent,Combined,570.0,-37.892871,145.006626
 Leibler Yavneh College,46218.0,2021,ELSTERNWICK,37.0,29.4,92.1,100.0,1128.0,Independent,Combined,565.0,-37.892871,145.006626
 Leibler Yavneh College,46218.0,2022,ELSTERNWICK,34.0,14.0,88.9,98.0,1132.0,Independent,Combined,570.0,-37.892871,145.006626
-Leibler Yavneh College,,2023,ELSTERNWICK,36.0,23.1,92.7,100.0,,,,,,
+Leibler Yavneh College,46218.0,2023,ELSTERNWICK,36.0,23.1,92.7,100.0,,,,,,
 Leongatha Secondary College,45520.0,2014,LEONGATHA,27.0,1.3,81.0,98.0,981.0,Government,Secondary,494.0,-38.47868659,145.96124111
 Leongatha Secondary College,45520.0,2015,LEONGATHA,27.0,2.3,84.0,94.0,979.0,Government,Secondary,483.0,-38.47868659,145.96124111
 Leongatha Secondary College,45520.0,2016,LEONGATHA,26.0,1.5,87.0,100.0,990.0,Government,Secondary,506.0,-38.47868659,145.96124111
@@ -2587,7 +2734,7 @@ Leongatha Secondary College,45520.0,2019,LEONGATHA,27.0,5.0,84.6,92.0,992.0,Gove
 Leongatha Secondary College,45520.0,2020,LEONGATHA,27.0,1.9,71.4,88.0,993.0,Government,Secondary,622.0,-38.47868659,145.96124111
 Leongatha Secondary College,45520.0,2021,LEONGATHA,27.0,1.3,84.7,97.0,992.0,Government,Secondary,616.0,-38.47868659,145.96124111
 Leongatha Secondary College,45520.0,2022,LEONGATHA,27.0,0.4,80.7,96.0,993.0,Government,Secondary,620.0,-38.47868659,145.96124111
-Leongatha Secondary College,,2023,LEONGATHA,28.0,5.1,50.0,97.0,,,,,,
+Leongatha Secondary College,45520.0,2023,LEONGATHA,28.0,5.1,50.0,97.0,,,,,,
 Lighthouse Christian College,46315.0,2014,KEYSBOROUGH,29.0,5.5,71.0,100.0,1060.0,Independent,Combined,514.0,-38.001083,145.142986
 Lighthouse Christian College,46315.0,2014,CRANBOURNE,27.0,1.8,96.0,100.0,1060.0,Independent,Combined,514.0,-38.001083,145.142986
 Lighthouse Christian College,46315.0,2015,KEYSBOROUGH,32.0,10.7,70.0,100.0,1069.0,Independent,Combined,540.0,-38.001083,145.142986
@@ -2606,8 +2753,8 @@ Lighthouse Christian College,46315.0,2021,KEYSBOROUGH,30.0,6.6,97.5,100.0,1079.0
 Lighthouse Christian College,46315.0,2021,CRANBOURNE,31.0,12.4,94.9,100.0,1079.0,Independent,Combined,845.0,-38.001083,145.142986
 Lighthouse Christian College,46315.0,2022,KEYSBOROUGH,32.0,8.7,100.0,100.0,1080.0,Independent,Combined,850.0,-38.001083,145.142986
 Lighthouse Christian College,46315.0,2022,CRANBOURNE,30.0,8.1,100.0,100.0,1080.0,Independent,Combined,850.0,-38.001083,145.142986
-Lighthouse Christian College,,2023,KEYSBOROUGH,29.0,2.8,96.6,100.0,,,,,,
-Lighthouse Christian College,,2023,CRANBOURNE,31.0,5.4,78.4,100.0,,,,,,
+Lighthouse Christian College,46315.0,2023,KEYSBOROUGH,29.0,2.8,96.6,100.0,,,,,,
+Lighthouse Christian College,46315.0,2023,CRANBOURNE,31.0,5.4,78.4,100.0,,,,,,
 Lilydale Heights College,45335.0,2014,LILYDALE,24.0,0.8,86.0,97.0,961.0,Government,Secondary,503.0,-37.7458221,145.34140676
 Lilydale Heights College,45335.0,2015,LILYDALE,25.0,0.9,86.0,98.0,970.0,Government,Secondary,462.0,-37.7458221,145.34140676
 Lilydale Heights College,45335.0,2016,LILYDALE,24.0,1.4,94.0,100.0,967.0,Government,Secondary,445.0,-37.7458221,145.34140676
@@ -2617,7 +2764,7 @@ Lilydale Heights College,45335.0,2019,LILYDALE,25.0,2.2,80.0,96.0,990.0,Governme
 Lilydale Heights College,45335.0,2020,LILYDALE,25.0,0.0,75.6,96.0,994.0,Government,Secondary,575.0,-37.7458221,145.34140676
 Lilydale Heights College,45335.0,2021,LILYDALE,23.0,0.5,73.7,100.0,995.0,Government,Secondary,652.0,-37.7458221,145.34140676
 Lilydale Heights College,45335.0,2022,LILYDALE,25.0,1.4,62.5,100.0,990.0,Government,Secondary,754.0,-37.7458221,145.34140676
-Lilydale Heights College,,2023,LILYDALE,26.0,1.7,56.9,100.0,,,,,,
+Lilydale Heights College,45335.0,2023,LILYDALE,26.0,1.7,56.9,100.0,,,,,,
 Lilydale High School,45415.0,2014,LILYDALE,28.0,3.5,58.0,94.0,1000.0,Government,Secondary,2063.0,-37.76073331,145.34521687
 Lilydale High School,45415.0,2015,LILYDALE,28.0,3.5,54.0,93.0,1004.0,Government,Secondary,2064.0,-37.76073331,145.34521687
 Lilydale High School,45415.0,2016,LILYDALE,27.0,2.4,62.0,98.0,1001.0,Government,Secondary,1994.0,-37.76073331,145.34521687
@@ -2627,7 +2774,7 @@ Lilydale High School,45415.0,2019,LILYDALE,29.0,2.5,60.8,99.0,1004.0,Government,
 Lilydale High School,45415.0,2020,LILYDALE,28.0,2.0,57.3,98.0,1004.0,Government,Secondary,1545.0,-37.76073331,145.34521687
 Lilydale High School,45415.0,2021,LILYDALE,27.0,2.4,51.3,96.0,1004.0,Government,Secondary,1488.0,-37.76073331,145.34521687
 Lilydale High School,45415.0,2022,LILYDALE,28.0,4.0,54.0,98.0,1004.0,Government,Secondary,1371.0,-37.76073331,145.34521687
-Lilydale High School,,2023,LILYDALE,28.0,2.4,39.4,96.0,,,,,,
+Lilydale High School,45415.0,2023,LILYDALE,28.0,2.4,39.4,96.0,,,,,,
 Little Yarra Steiner School,46313.0,2016,YARRA JUNCTION,,,29.0,100.0,,Independent,Combined,274.0,-37.79444291,145.631163
 Little Yarra Steiner School,46313.0,2017,YARRA JUNCTION,31.0,0.0,16.0,100.0,1048.0,Independent,Combined,277.0,-37.79444291,145.631163
 Little Yarra Steiner School,46313.0,2018,YARRA JUNCTION,33.0,4.8,41.2,100.0,1065.0,Independent,Combined,274.0,-37.79444291,145.631163
@@ -2635,7 +2782,7 @@ Little Yarra Steiner School,46313.0,2019,YARRA JUNCTION,,,30.8,100.0,1065.0,Inde
 Little Yarra Steiner School,46313.0,2020,YARRA JUNCTION,,,27.3,100.0,1065.0,Independent,Combined,261.0,-37.79444291,145.631163
 Little Yarra Steiner School,46313.0,2021,YARRA JUNCTION,32.0,5.6,57.1,100.0,1052.0,Independent,Combined,261.0,-37.79444291,145.631163
 Little Yarra Steiner School,46313.0,2022,YARRA JUNCTION,,,12.5,100.0,1060.0,Independent,Combined,228.0,-37.79444291,145.631163
-Little Yarra Steiner School,,2023,YARRA JUNCTION,31.0,7.1,33.3,100.0,,,,,,
+Little Yarra Steiner School,46313.0,2023,YARRA JUNCTION,31.0,7.1,33.3,100.0,,,,,,
 Loreto College,45638.0,2014,BALLARAT,31.0,6.1,94.0,100.0,1069.0,Catholic,Secondary,851.0,-37.55686069,143.8234695
 Loreto College,45638.0,2015,BALLARAT,30.0,4.4,92.0,98.0,1066.0,Catholic,Secondary,875.0,-37.55686069,143.8234695
 Loreto College,45638.0,2016,BALLARAT,32.0,11.2,97.0,100.0,1061.0,Catholic,Secondary,895.0,-37.55686069,143.8234695
@@ -2645,7 +2792,7 @@ Loreto College,45638.0,2019,BALLARAT,31.0,7.4,83.0,99.0,1073.0,Catholic,Secondar
 Loreto College,45638.0,2020,BALLARAT,31.0,6.3,88.1,99.0,1072.0,Catholic,Secondary,981.0,-37.55686069,143.8234695
 Loreto College,45638.0,2021,BALLARAT,31.0,10.9,82.4,100.0,1065.0,Catholic,Secondary,929.0,-37.55686069,143.8234695
 Loreto College,45638.0,2022,BALLARAT,31.0,7.9,79.4,99.0,1065.0,Catholic,Secondary,927.0,-37.55686069,143.8234695
-Loreto College,,2023,BALLARAT,31.0,6.1,74.1,100.0,,,,,,
+Loreto College,45638.0,2023,BALLARAT,31.0,6.1,74.1,100.0,,,,,,
 Loreto Mandeville Hall,45810.0,2014,TOORAK,35.0,28.9,99.0,100.0,1174.0,Catholic,Combined,1002.0,-37.848193,145.014892
 Loreto Mandeville Hall,45810.0,2015,TOORAK,36.0,26.9,100.0,100.0,1175.0,Catholic,Combined,1054.0,-37.848193,145.014892
 Loreto Mandeville Hall,45810.0,2016,TOORAK,36.0,31.1,100.0,100.0,1165.0,Catholic,Combined,1106.0,-37.848193,145.014892
@@ -2655,17 +2802,17 @@ Loreto Mandeville Hall,45810.0,2019,TOORAK,36.0,26.7,98.0,100.0,1166.0,Catholic,
 Loreto Mandeville Hall,45810.0,2020,TOORAK,36.0,29.3,100.0,100.0,1166.0,Catholic,Combined,1270.0,-37.848193,145.014892
 Loreto Mandeville Hall,45810.0,2021,TOORAK,35.0,24.7,98.0,100.0,1163.0,Catholic,Combined,1232.0,-37.848193,145.014892
 Loreto Mandeville Hall,45810.0,2022,TOORAK,35.0,23.0,98.6,100.0,1167.0,Catholic,Combined,1244.0,-37.848193,145.014892
-Loreto Mandeville Hall,,2023,TOORAK,36.0,29.6,99.4,99.0,,,,,,
+Loreto Mandeville Hall,45810.0,2023,TOORAK,36.0,29.6,99.4,99.0,,,,,,
 Lorne P-12 College,52491.0,2017,LORNE,27.0,0.0,95.0,100.0,1035.0,Government,Combined,183.0,-38.53917804,143.9738904
 Lorne P-12 College,52491.0,2018,LORNE,28.0,0.0,94.4,100.0,1030.0,Government,Combined,191.0,-38.53917804,143.9738904
 Lorne P-12 College,52491.0,2019,LORNE,25.0,1.1,89.5,100.0,1031.0,Government,Combined,174.0,-38.53917804,143.9738904
 Lorne P-12 College,52491.0,2020,LORNE,27.0,1.9,90.9,100.0,1023.0,Government,Combined,182.0,-38.53917804,143.9738904
 Lorne P-12 College,52491.0,2021,LORNE,27.0,4.3,69.2,100.0,1028.0,Government,Combined,181.0,-38.53917804,143.9738904
 Lorne P-12 College,52491.0,2022,LORNE,,,100.0,100.0,1038.0,Government,Combined,168.0,-38.53917804,143.9738904
-Lorne P-12 College,,2023,LORNE,26.0,8.7,83.3,100.0,,,,,,
-Lorne-Aireys Inlet P-12 Coll,,2014,LORNE,25.0,2.6,57.0,100.0,,,,,,
-Lorne-Aireys Inlet P-12 Coll,,2015,LORNE,28.0,2.2,100.0,100.0,,,,,,
-Lorne-Aireys Inlet P-12 Coll,,2016,LORNE,29.0,8.3,100.0,100.0,,,,,,
+Lorne P-12 College,52491.0,2023,LORNE,26.0,8.7,83.3,100.0,,,,,,
+Lorne-Aireys Inlet P-12 Coll,52491.0,2014,LORNE,25.0,2.6,57.0,100.0,,,,,,
+Lorne-Aireys Inlet P-12 Coll,52491.0,2015,LORNE,28.0,2.2,100.0,100.0,,,,,,
+Lorne-Aireys Inlet P-12 Coll,52491.0,2016,LORNE,29.0,8.3,100.0,100.0,,,,,,
 Lowanna College,45559.0,2014,NEWBOROUGH,25.0,1.4,65.0,94.0,945.0,Government,Secondary,1014.0,-38.17667934,146.28597982
 Lowanna College,45559.0,2015,NEWBOROUGH,26.0,2.1,56.0,87.0,951.0,Government,Secondary,967.0,-38.17667934,146.28597982
 Lowanna College,45559.0,2016,NEWBOROUGH,25.0,1.0,68.0,97.0,946.0,Government,Secondary,933.0,-38.17667934,146.28597982
@@ -2675,7 +2822,7 @@ Lowanna College,45559.0,2019,NEWBOROUGH,25.0,0.3,43.4,95.0,945.0,Government,Seco
 Lowanna College,45559.0,2020,NEWBOROUGH,27.0,2.5,55.4,95.0,942.0,Government,Secondary,866.0,-38.17667934,146.28597982
 Lowanna College,45559.0,2021,NEWBOROUGH,25.0,1.6,53.1,92.0,940.0,Government,Secondary,906.0,-38.17667934,146.28597982
 Lowanna College,45559.0,2022,NEWBOROUGH,26.0,1.9,57.6,95.0,936.0,Government,Secondary,911.0,-38.17667934,146.28597982
-Lowanna College,,2023,NEWBOROUGH,24.0,1.6,38.8,90.0,,,,,,
+Lowanna College,45559.0,2023,NEWBOROUGH,24.0,1.6,38.8,90.0,,,,,,
 Lowther Hall Anglican GS,46179.0,2014,ESSENDON,34.0,19.1,100.0,100.0,1150.0,Independent,Combined,802.0,-37.759908,144.914974
 Lowther Hall Anglican GS,46179.0,2015,ESSENDON,35.0,21.6,100.0,100.0,,Independent,Combined,788.0,-37.759908,144.914974
 Lowther Hall Anglican GS,46179.0,2016,ESSENDON,35.0,18.3,100.0,100.0,,Independent,Combined,787.0,-37.759908,144.914974
@@ -2685,7 +2832,7 @@ Lowther Hall Anglican GS,46179.0,2019,ESSENDON,34.0,18.8,100.0,100.0,,Independen
 Lowther Hall Anglican GS,46179.0,2020,ESSENDON,35.0,21.1,100.0,100.0,1155.0,Independent,Combined,820.0,-37.759908,144.914974
 Lowther Hall Anglican GS,46179.0,2021,ESSENDON,35.0,19.9,100.0,100.0,1155.0,Independent,Combined,798.0,-37.759908,144.914974
 Lowther Hall Anglican GS,46179.0,2022,ESSENDON,35.0,26.3,100.0,100.0,1160.0,Independent,Combined,809.0,-37.759908,144.914974
-Lowther Hall Anglican GS,,2023,ESSENDON,34.0,18.1,96.3,100.0,,,,,,
+Lowther Hall Anglican GS,46179.0,2023,ESSENDON,34.0,18.1,96.3,100.0,,,,,,
 Loyola College,46053.0,2014,WATSONIA,31.0,6.2,92.0,100.0,1067.0,Catholic,Secondary,1285.0,-37.703396,145.08073
 Loyola College,46053.0,2015,WATSONIA,31.0,8.6,89.0,99.0,1067.0,Catholic,Secondary,1329.0,-37.703396,145.08073
 Loyola College,46053.0,2016,WATSONIA,31.0,7.5,87.0,99.0,1063.0,Catholic,Secondary,1342.0,-37.703396,145.08073
@@ -2695,7 +2842,7 @@ Loyola College,46053.0,2019,WATSONIA,31.0,5.5,88.9,100.0,1068.0,Catholic,Seconda
 Loyola College,46053.0,2020,WATSONIA,30.0,4.9,90.6,100.0,1066.0,Catholic,Secondary,1360.0,-37.703396,145.08073
 Loyola College,46053.0,2021,WATSONIA,30.0,5.1,94.0,100.0,1056.0,Catholic,Secondary,1385.0,-37.703396,145.08073
 Loyola College,46053.0,2022,WATSONIA,30.0,5.5,89.9,99.0,1050.0,Catholic,Secondary,1405.0,-37.703396,145.08073
-Loyola College,,2023,WATSONIA,30.0,2.6,83.2,100.0,,,,,,
+Loyola College,46053.0,2023,WATSONIA,30.0,2.6,83.2,100.0,,,,,,
 Luther College,46223.0,2014,CROYDON HILLS,33.0,12.4,92.0,100.0,1118.0,Independent,Secondary,1180.0,-37.783056,145.272743
 Luther College,46223.0,2015,CROYDON HILLS,33.0,13.8,90.0,100.0,1115.0,Independent,Secondary,1172.0,-37.783056,145.272743
 Luther College,46223.0,2016,CROYDON HILLS,33.0,11.4,89.0,100.0,1110.0,Independent,Secondary,1178.0,-37.783056,145.272743
@@ -2705,7 +2852,7 @@ Luther College,46223.0,2019,CROYDON HILLS,32.0,8.1,87.1,100.0,1113.0,Independent
 Luther College,46223.0,2020,CROYDON HILLS,33.0,10.9,92.3,100.0,1113.0,Independent,Secondary,1192.0,-37.783056,145.272743
 Luther College,46223.0,2021,CROYDON HILLS,32.0,9.5,86.3,100.0,1117.0,Independent,Secondary,1171.0,-37.783056,145.272743
 Luther College,46223.0,2022,CROYDON HILLS,32.0,12.8,87.9,100.0,1130.0,Independent,Secondary,1169.0,-37.783056,145.272743
-Luther College,,2023,CROYDON HILLS,32.0,11.8,80.1,100.0,,,,,,
+Luther College,46223.0,2023,CROYDON HILLS,32.0,11.8,80.1,100.0,,,,,,
 Lynall Hall Community School,45417.0,2014,RICHMOND,18.0,0.0,89.0,78.0,906.0,Government,Secondary,117.0,-37.816477,145.002257
 Lynall Hall Community School,45417.0,2015,RICHMOND,21.0,0.0,40.0,70.0,937.0,Government,Secondary,118.0,-37.816477,145.002257
 Lynall Hall Community School,45417.0,2016,RICHMOND,19.0,0.0,56.0,89.0,909.0,Government,Secondary,97.0,-37.816477,145.002257
@@ -2715,7 +2862,7 @@ Lynall Hall Community School,45417.0,2019,RICHMOND,,,22.2,56.0,949.0,Government,
 Lynall Hall Community School,45417.0,2020,RICHMOND,,,0.0,100.0,957.0,Government,Secondary,65.0,-37.816477,145.002257
 Lynall Hall Community School,45417.0,2021,RICHMOND,,,100.0,100.0,989.0,Government,Secondary,72.0,-37.816477,145.002257
 Lynall Hall Community School,45417.0,2022,RICHMOND,,,0.0,,980.0,Government,Secondary,72.0,-37.816477,145.002257
-Lynall Hall Community School,,2023,RICHMOND,,,,67.0,,,,,,
+Lynall Hall Community School,45417.0,2023,RICHMOND,,,,67.0,,,,,,
 Lyndale Secondary College,45416.0,2014,DANDENONG NORTH,26.0,1.2,100.0,99.0,944.0,Government,Secondary,1057.0,-37.957779,145.206752
 Lyndale Secondary College,45416.0,2015,DANDENONG NORTH,26.0,2.9,94.0,90.0,947.0,Government,Secondary,991.0,-37.957779,145.206752
 Lyndale Secondary College,45416.0,2016,DANDENONG NORTH,26.0,1.6,94.0,99.0,944.0,Government,Secondary,948.0,-37.957779,145.206752
@@ -2725,7 +2872,7 @@ Lyndale Secondary College,45416.0,2019,DANDENONG NORTH,26.0,0.2,97.6,99.0,955.0,
 Lyndale Secondary College,45416.0,2020,DANDENONG NORTH,28.0,1.1,93.8,98.0,942.0,Government,Secondary,874.0,-37.957779,145.206752
 Lyndale Secondary College,45416.0,2021,DANDENONG NORTH,28.0,2.9,90.8,97.0,931.0,Government,Secondary,844.0,-37.957779,145.206752
 Lyndale Secondary College,45416.0,2022,DANDENONG NORTH,27.0,3.1,91.3,100.0,913.0,Government,Secondary,823.0,-37.957779,145.206752
-Lyndale Secondary College,,2023,DANDENONG NORTH,29.0,3.8,71.8,95.0,,,,,,
+Lyndale Secondary College,45416.0,2023,DANDENONG NORTH,29.0,3.8,71.8,95.0,,,,,,
 Lyndhurst Secondary College,45328.0,2014,CRANBOURNE,24.0,1.4,51.0,90.0,941.0,Government,Secondary,752.0,-38.075011,145.271218
 Lyndhurst Secondary College,45328.0,2015,CRANBOURNE,27.0,1.5,61.0,98.0,937.0,Government,Secondary,644.0,-38.075011,145.271218
 Lyndhurst Secondary College,45328.0,2016,CRANBOURNE,26.0,1.9,64.0,100.0,944.0,Government,Secondary,532.0,-38.075011,145.271218
@@ -2735,7 +2882,7 @@ Lyndhurst Secondary College,45328.0,2019,CRANBOURNE,27.0,2.4,53.6,96.0,948.0,Gov
 Lyndhurst Secondary College,45328.0,2020,CRANBOURNE,26.0,4.3,77.8,93.0,945.0,Government,Secondary,609.0,-38.075011,145.271218
 Lyndhurst Secondary College,45328.0,2021,CRANBOURNE,28.0,4.0,63.6,100.0,946.0,Government,Secondary,706.0,-38.075011,145.271218
 Lyndhurst Secondary College,45328.0,2022,CRANBOURNE,28.0,3.5,73.3,100.0,937.0,Government,Secondary,726.0,-38.075011,145.271218
-Lyndhurst Secondary College,,2023,CRANBOURNE,30.0,7.1,47.6,94.0,,,,,,
+Lyndhurst Secondary College,45328.0,2023,CRANBOURNE,30.0,7.1,47.6,94.0,,,,,,
 Mac.Robertson Girls' High Schl,45437.0,2014,MELBOURNE,38.0,36.6,100.0,100.0,1176.0,Government,Secondary,955.0,-37.836,144.972
 Mac.Robertson Girls' High Schl,45437.0,2015,MELBOURNE,38.0,38.2,100.0,100.0,1180.0,Government,Secondary,958.0,-37.836,144.972
 Mac.Robertson Girls' High Schl,45437.0,2016,MELBOURNE,38.0,36.1,99.0,100.0,1166.0,Government,Secondary,970.0,-37.836,144.972
@@ -2745,7 +2892,7 @@ Mac.Robertson Girls' High Schl,45437.0,2019,MELBOURNE,37.0,30.2,98.4,100.0,1165.
 Mac.Robertson Girls' High Schl,45437.0,2020,MELBOURNE,37.0,30.8,96.8,100.0,1165.0,Government,Secondary,1042.0,-37.836,144.972
 Mac.Robertson Girls' High Schl,45437.0,2021,MELBOURNE,37.0,31.4,98.8,100.0,1170.0,Government,Secondary,1083.0,-37.836,144.972
 Mac.Robertson Girls' High Schl,45437.0,2022,MELBOURNE,36.0,25.7,97.9,100.0,1174.0,Government,Secondary,1136.0,-37.836,144.972
-Mac.Robertson Girls' High Schl,,2023,MELBOURNE,36.0,29.3,98.3,100.0,,,,,,
+Mac.Robertson Girls' High Schl,45437.0,2023,MELBOURNE,36.0,29.3,98.3,100.0,,,,,,
 MacKillop Catholic Reg College,46002.0,2014,WERRIBEE,31.0,6.1,90.0,99.0,988.0,Catholic,Secondary,1559.0,-37.90901198,144.66445598
 MacKillop Catholic Reg College,46002.0,2015,WERRIBEE,31.0,4.7,94.0,95.0,1032.0,Catholic,Secondary,1602.0,-37.90901198,144.66445598
 MacKillop Catholic Reg College,46002.0,2016,WERRIBEE,30.0,4.6,83.0,97.0,1029.0,Catholic,Secondary,1600.0,-37.90901198,144.66445598
@@ -2755,7 +2902,7 @@ MacKillop Catholic Reg College,46002.0,2019,WERRIBEE,30.0,5.4,86.5,97.0,1041.0,C
 MacKillop Catholic Reg College,46002.0,2020,WERRIBEE,29.0,2.9,80.4,98.0,1044.0,Catholic,Secondary,1705.0,-37.90901198,144.66445598
 MacKillop Catholic Reg College,46002.0,2021,WERRIBEE,30.0,4.3,79.8,97.0,1046.0,Catholic,Secondary,1676.0,-37.90901198,144.66445598
 MacKillop Catholic Reg College,46002.0,2022,WERRIBEE,31.0,5.5,76.3,99.0,1052.0,Catholic,Secondary,1685.0,-37.90901198,144.66445598
-MacKillop Catholic Reg College,,2023,WERRIBEE,31.0,5.7,72.0,100.0,,,,,,
+MacKillop Catholic Reg College,46002.0,2023,WERRIBEE,31.0,5.7,72.0,100.0,,,,,,
 Macleod College,45311.0,2014,MACLEOD,28.0,6.0,86.0,96.0,1007.0,Government,Combined,582.0,-37.724746,145.072218
 Macleod College,45311.0,2015,MACLEOD,25.0,3.3,91.0,98.0,1014.0,Government,Combined,534.0,-37.724746,145.072218
 Macleod College,45311.0,2016,MACLEOD,26.0,0.7,96.0,100.0,1013.0,Government,Combined,547.0,-37.724746,145.072218
@@ -2765,7 +2912,7 @@ Macleod College,45311.0,2019,MACLEOD,26.0,3.0,94.8,97.0,1042.0,Government,Combin
 Macleod College,45311.0,2020,MACLEOD,25.0,2.8,87.8,100.0,1048.0,Government,Combined,506.0,-37.724746,145.072218
 Macleod College,45311.0,2021,MACLEOD,26.0,0.4,87.0,100.0,1051.0,Government,Combined,535.0,-37.724746,145.072218
 Macleod College,45311.0,2022,MACLEOD,27.0,0.4,91.8,100.0,1053.0,Government,Combined,517.0,-37.724746,145.072218
-Macleod College,,2023,MACLEOD,28.0,2.1,76.9,98.0,,,,,,
+Macleod College,45311.0,2023,MACLEOD,28.0,2.1,76.9,98.0,,,,,,
 Maffra Secondary College,45418.0,2014,MAFFRA,27.0,2.4,96.0,100.0,955.0,Government,Secondary,629.0,-37.964888,146.982424
 Maffra Secondary College,45418.0,2015,MAFFRA,26.0,1.8,87.0,98.0,950.0,Government,Secondary,611.0,-37.964888,146.982424
 Maffra Secondary College,45418.0,2016,MAFFRA,27.0,4.3,90.0,100.0,956.0,Government,Secondary,568.0,-37.964888,146.982424
@@ -2775,7 +2922,7 @@ Maffra Secondary College,45418.0,2019,MAFFRA,27.0,5.0,90.0,100.0,953.0,Governmen
 Maffra Secondary College,45418.0,2020,MAFFRA,26.0,2.6,83.9,100.0,955.0,Government,Secondary,545.0,-37.964888,146.982424
 Maffra Secondary College,45418.0,2021,MAFFRA,28.0,6.5,77.1,97.0,954.0,Government,Secondary,544.0,-37.964888,146.982424
 Maffra Secondary College,45418.0,2022,MAFFRA,27.0,2.8,59.4,100.0,949.0,Government,Secondary,505.0,-37.964888,146.982424
-Maffra Secondary College,,2023,MAFFRA,25.0,,40.0,96.0,,,,,,
+Maffra Secondary College,45418.0,2023,MAFFRA,25.0,,40.0,96.0,,,,,,
 Mallacoota P-12 College,44613.0,2014,MALLACOOTA,20.0,0.0,75.0,100.0,1029.0,Government,Combined,133.0,-37.559427,149.754296
 Mallacoota P-12 College,44613.0,2015,MALLACOOTA,27.0,0.0,57.0,71.0,1017.0,Government,Combined,132.0,-37.559427,149.754296
 Mallacoota P-12 College,44613.0,2016,MALLACOOTA,28.0,4.4,38.0,100.0,1023.0,Government,Combined,135.0,-37.559427,149.754296
@@ -2785,7 +2932,7 @@ Mallacoota P-12 College,44613.0,2019,MALLACOOTA,38.0,30.0,,,1030.0,Government,Co
 Mallacoota P-12 College,44613.0,2020,MALLACOOTA,30.0,9.3,70.0,100.0,1033.0,Government,Combined,139.0,-37.559427,149.754296
 Mallacoota P-12 College,44613.0,2021,MALLACOOTA,31.0,2.6,41.7,92.0,1040.0,Government,Combined,125.0,-37.559427,149.754296
 Mallacoota P-12 College,44613.0,2022,MALLACOOTA,31.0,22.7,50.0,100.0,1032.0,Government,Combined,112.0,-37.559427,149.754296
-Mallacoota P-12 College,,2023,MALLACOOTA,34.0,16.7,50.0,100.0,,,,,,
+Mallacoota P-12 College,44613.0,2023,MALLACOOTA,34.0,16.7,50.0,100.0,,,,,,
 Manangatang P-12 College,45306.0,2014,MANANGATANG,28.0,3.1,91.0,100.0,987.0,Government,Combined,130.0,-35.056234,142.884879
 Manangatang P-12 College,45306.0,2015,MANANGATANG,32.0,7.1,100.0,100.0,970.0,Government,Combined,104.0,-35.056234,142.884879
 Manangatang P-12 College,45306.0,2016,MANANGATANG,26.0,2.4,71.0,100.0,978.0,Government,Combined,97.0,-35.056234,142.884879
@@ -2804,7 +2951,7 @@ Manor Lakes P-12 College,45580.0,2019,WYNDHAM VALE,24.0,1.5,64.7,99.0,991.0,Gove
 Manor Lakes P-12 College,45580.0,2020,WYNDHAM VALE,23.0,2.1,64.6,98.0,1000.0,Government,Combined,2452.0,-37.874157,144.602275
 Manor Lakes P-12 College,45580.0,2021,WYNDHAM VALE,23.0,0.2,48.0,97.0,998.0,Government,Combined,2788.0,-37.874157,144.602275
 Manor Lakes P-12 College,45580.0,2022,WYNDHAM VALE,24.0,1.6,40.0,93.0,998.0,Government,Combined,2968.0,-37.874157,144.602275
-Manor Lakes P-12 College,,2023,WYNDHAM VALE,23.0,2.8,46.7,93.0,,,,,,
+Manor Lakes P-12 College,45580.0,2023,WYNDHAM VALE,23.0,2.8,46.7,93.0,,,,,,
 Mansfield Secondary College,45419.0,2014,MANSFIELD,30.0,6.3,66.0,100.0,1001.0,Government,Secondary,430.0,-37.062676,146.088565
 Mansfield Secondary College,45419.0,2015,MANSFIELD,30.0,3.4,63.0,100.0,992.0,Government,Secondary,443.0,-37.062676,146.088565
 Mansfield Secondary College,45419.0,2016,MANSFIELD,28.0,1.6,84.0,100.0,1003.0,Government,Secondary,421.0,-37.062676,146.088565
@@ -2814,7 +2961,7 @@ Mansfield Secondary College,45419.0,2019,MANSFIELD,27.0,0.6,70.8,98.0,1006.0,Gov
 Mansfield Secondary College,45419.0,2020,MANSFIELD,29.0,1.3,79.5,97.0,1009.0,Government,Secondary,436.0,-37.062676,146.088565
 Mansfield Secondary College,45419.0,2021,MANSFIELD,29.0,7.1,51.7,97.0,1011.0,Government,Secondary,442.0,-37.062676,146.088565
 Mansfield Secondary College,45419.0,2022,MANSFIELD,31.0,10.7,63.9,92.0,1015.0,Government,Secondary,451.0,-37.062676,146.088565
-Mansfield Secondary College,,2023,MANSFIELD,30.0,5.7,53.7,95.0,,,,,,
+Mansfield Secondary College,45419.0,2023,MANSFIELD,30.0,5.7,53.7,95.0,,,,,,
 Maranatha Christian School,46226.0,2014,ENDEAVOUR HILLS,30.0,6.6,81.0,99.0,1071.0,Independent,Combined,1028.0,-37.9709190000001,145.278034
 Maranatha Christian School,46226.0,2015,ENDEAVOUR HILLS,30.0,6.0,87.0,100.0,1079.0,Independent,Combined,943.0,-37.9709190000001,145.278034
 Maranatha Christian School,46226.0,2016,ENDEAVOUR HILLS,30.0,6.4,88.0,100.0,1075.0,Independent,Combined,797.0,-37.9709190000001,145.278034
@@ -2824,7 +2971,7 @@ Maranatha Christian School,46226.0,2019,ENDEAVOUR HILLS,30.0,5.6,79.1,100.0,1088
 Maranatha Christian School,46226.0,2020,ENDEAVOUR HILLS,30.0,8.8,93.8,100.0,1088.0,Independent,Combined,683.0,-37.9709190000001,145.278034
 Maranatha Christian School,46226.0,2021,ENDEAVOUR HILLS,32.0,6.8,82.6,100.0,1088.0,Independent,Combined,734.0,-37.9709190000001,145.278034
 Maranatha Christian School,46226.0,2022,ENDEAVOUR HILLS,31.0,1.6,89.2,100.0,1096.0,Independent,Combined,806.0,-37.9709190000001,145.278034
-Maranatha Christian School,,2023,ENDEAVOUR HILLS,31.0,8.0,65.9,100.0,,,,,,
+Maranatha Christian School,46226.0,2023,ENDEAVOUR HILLS,31.0,8.0,65.9,100.0,,,,,,
 Marcellin College,45874.0,2014,BULLEEN,32.0,10.1,95.0,100.0,1090.0,Catholic,Secondary,1310.0,-37.774782,145.082675
 Marcellin College,45874.0,2015,BULLEEN,31.0,8.8,92.0,99.0,1096.0,Catholic,Secondary,1350.0,-37.774782,145.082675
 Marcellin College,45874.0,2016,BULLEEN,31.0,6.1,94.0,100.0,1097.0,Catholic,Secondary,1384.0,-37.774782,145.082675
@@ -2834,91 +2981,37 @@ Marcellin College,45874.0,2019,BULLEEN,31.0,7.8,91.8,100.0,1093.0,Catholic,Secon
 Marcellin College,45874.0,2020,BULLEEN,30.0,7.5,94.1,100.0,1098.0,Catholic,Secondary,1420.0,-37.774782,145.082675
 Marcellin College,45874.0,2021,BULLEEN,30.0,8.5,91.1,100.0,1100.0,Catholic,Secondary,1400.0,-37.774782,145.082675
 Marcellin College,45874.0,2022,BULLEEN,30.0,6.6,88.2,100.0,1107.0,Catholic,Secondary,1328.0,-37.774782,145.082675
-Marcellin College,,2023,BULLEEN,31.0,9.0,76.5,100.0,,,,,,
+Marcellin College,45874.0,2023,BULLEEN,31.0,9.0,76.5,100.0,,,,,,
 Marian College Ararat,45700.0,2014,ARARAT,26.0,1.7,67.0,98.0,1007.0,Catholic,Secondary,572.0,-37.284744,142.937766
-Marian College Ararat,45963.0,2014,ARARAT,26.0,1.7,67.0,98.0,967.0,Catholic,Secondary,734.0,-37.787845109357946,144.80612802908314
-Marian College Ararat,46008.0,2014,ARARAT,26.0,1.7,67.0,98.0,999.0,Catholic,Secondary,233.0,-36.55334,146.72536
 Marian College Ararat,45700.0,2015,ARARAT,26.0,2.8,79.0,97.0,1007.0,Catholic,Secondary,576.0,-37.284744,142.937766
-Marian College Ararat,45963.0,2015,ARARAT,26.0,2.8,79.0,97.0,977.0,Catholic,Secondary,758.0,-37.787845109357946,144.80612802908314
-Marian College Ararat,46008.0,2015,ARARAT,26.0,2.8,79.0,97.0,1009.0,Catholic,Secondary,218.0,-36.55334,146.72536
 Marian College Ararat,45700.0,2016,ARARAT,28.0,3.1,65.0,98.0,1011.0,Catholic,Secondary,530.0,-37.284744,142.937766
-Marian College Ararat,45963.0,2016,ARARAT,28.0,3.1,65.0,98.0,971.0,Catholic,Secondary,765.0,-37.787845109357946,144.80612802908314
-Marian College Ararat,46008.0,2016,ARARAT,28.0,3.1,65.0,98.0,1010.0,Catholic,Secondary,179.0,-36.55334,146.72536
 Marian College Ararat,45700.0,2017,ARARAT,27.0,4.2,73.0,98.0,1008.0,Catholic,Secondary,492.0,-37.284744,142.937766
-Marian College Ararat,45963.0,2017,ARARAT,27.0,4.2,73.0,98.0,982.0,Catholic,Secondary,793.0,-37.787845109357946,144.80612802908314
-Marian College Ararat,46008.0,2017,ARARAT,27.0,4.2,73.0,98.0,1023.0,Catholic,Secondary,171.0,-36.55334,146.72536
 Marian College Ararat,45700.0,2018,ARARAT,26.0,3.8,78.0,98.0,1006.0,Catholic,Secondary,510.0,-37.284744,142.937766
-Marian College Ararat,45963.0,2018,ARARAT,26.0,3.8,78.0,98.0,989.0,Catholic,Secondary,779.0,-37.787845109357946,144.80612802908314
-Marian College Ararat,46008.0,2018,ARARAT,26.0,3.8,78.0,98.0,1022.0,Catholic,Secondary,177.0,-36.554523,146.724742
 Marian College Ararat,45700.0,2019,ARARAT,26.0,3.4,64.9,98.0,1008.0,Catholic,Secondary,468.0,-37.284744,142.937766
-Marian College Ararat,45963.0,2019,ARARAT,26.0,3.4,64.9,98.0,993.0,Catholic,Secondary,806.0,-37.787845109357946,144.80612802908314
-Marian College Ararat,46008.0,2019,ARARAT,26.0,3.4,64.9,98.0,1025.0,Catholic,Secondary,174.0,-36.554523,146.724742
 Marian College Ararat,45700.0,2020,ARARAT,26.0,2.2,69.4,100.0,1009.0,Catholic,Secondary,456.0,-37.284744,142.937766
-Marian College Ararat,45963.0,2020,ARARAT,26.0,2.2,69.4,100.0,995.0,Catholic,Secondary,828.0,-37.787845109357946,144.80612802908314
-Marian College Ararat,46008.0,2020,ARARAT,26.0,2.2,69.4,100.0,1024.0,Catholic,Secondary,189.0,-36.554523,146.724742
 Marian College Ararat,45700.0,2021,ARARAT,27.0,2.6,70.5,98.0,1010.0,Catholic,Secondary,437.0,-37.284744,142.937766
-Marian College Ararat,45963.0,2021,ARARAT,27.0,2.6,70.5,98.0,995.0,Catholic,Secondary,844.0,-37.787845109357946,144.80612802908314
-Marian College Ararat,46008.0,2021,ARARAT,27.0,2.6,70.5,98.0,1021.0,Catholic,Secondary,190.0,-36.554523,146.724742
 Marian College Ararat,45700.0,2022,ARARAT,29.0,2.0,66.7,97.0,1025.0,Catholic,Secondary,408.0,-37.284744,142.937766
-Marian College Ararat,45963.0,2022,ARARAT,29.0,2.0,66.7,97.0,993.0,Catholic,Secondary,840.0,-37.787845109357946,144.80612802908314
-Marian College Ararat,46008.0,2022,ARARAT,29.0,2.0,66.7,97.0,1016.0,Catholic,Secondary,181.0,-36.554523,146.724742
-Marian College Ararat,,2023,ARARAT,29.0,6.6,66.1,98.0,,,,,,
-Marian College Myrtleford,45700.0,2014,MYRTLEFORD,28.0,4.7,88.0,100.0,1007.0,Catholic,Secondary,572.0,-37.284744,142.937766
-Marian College Myrtleford,45963.0,2014,MYRTLEFORD,28.0,4.7,88.0,100.0,967.0,Catholic,Secondary,734.0,-37.787845109357946,144.80612802908314
+Marian College Ararat,45700.0,2023,ARARAT,29.0,6.6,66.1,98.0,,,,,,
 Marian College Myrtleford,46008.0,2014,MYRTLEFORD,28.0,4.7,88.0,100.0,999.0,Catholic,Secondary,233.0,-36.55334,146.72536
-Marian College Myrtleford,45700.0,2015,MYRTLEFORD,27.0,0.0,84.0,100.0,1007.0,Catholic,Secondary,576.0,-37.284744,142.937766
-Marian College Myrtleford,45963.0,2015,MYRTLEFORD,27.0,0.0,84.0,100.0,977.0,Catholic,Secondary,758.0,-37.787845109357946,144.80612802908314
 Marian College Myrtleford,46008.0,2015,MYRTLEFORD,27.0,0.0,84.0,100.0,1009.0,Catholic,Secondary,218.0,-36.55334,146.72536
-Marian College Myrtleford,45700.0,2016,MYRTLEFORD,27.0,1.1,50.0,100.0,1011.0,Catholic,Secondary,530.0,-37.284744,142.937766
-Marian College Myrtleford,45963.0,2016,MYRTLEFORD,27.0,1.1,50.0,100.0,971.0,Catholic,Secondary,765.0,-37.787845109357946,144.80612802908314
 Marian College Myrtleford,46008.0,2016,MYRTLEFORD,27.0,1.1,50.0,100.0,1010.0,Catholic,Secondary,179.0,-36.55334,146.72536
-Marian College Myrtleford,45700.0,2017,MYRTLEFORD,27.0,0.0,70.0,100.0,1008.0,Catholic,Secondary,492.0,-37.284744,142.937766
-Marian College Myrtleford,45963.0,2017,MYRTLEFORD,27.0,0.0,70.0,100.0,982.0,Catholic,Secondary,793.0,-37.787845109357946,144.80612802908314
 Marian College Myrtleford,46008.0,2017,MYRTLEFORD,27.0,0.0,70.0,100.0,1023.0,Catholic,Secondary,171.0,-36.55334,146.72536
-Marian College Myrtleford,45700.0,2018,MYRTLEFORD,27.0,1.3,69.4,97.0,1006.0,Catholic,Secondary,510.0,-37.284744,142.937766
-Marian College Myrtleford,45963.0,2018,MYRTLEFORD,27.0,1.3,69.4,97.0,989.0,Catholic,Secondary,779.0,-37.787845109357946,144.80612802908314
 Marian College Myrtleford,46008.0,2018,MYRTLEFORD,27.0,1.3,69.4,97.0,1022.0,Catholic,Secondary,177.0,-36.554523,146.724742
-Marian College Myrtleford,45700.0,2019,MYRTLEFORD,31.0,9.2,64.3,100.0,1008.0,Catholic,Secondary,468.0,-37.284744,142.937766
-Marian College Myrtleford,45963.0,2019,MYRTLEFORD,31.0,9.2,64.3,100.0,993.0,Catholic,Secondary,806.0,-37.787845109357946,144.80612802908314
 Marian College Myrtleford,46008.0,2019,MYRTLEFORD,31.0,9.2,64.3,100.0,1025.0,Catholic,Secondary,174.0,-36.554523,146.724742
-Marian College Myrtleford,45700.0,2020,MYRTLEFORD,28.0,0.0,68.0,100.0,1009.0,Catholic,Secondary,456.0,-37.284744,142.937766
-Marian College Myrtleford,45963.0,2020,MYRTLEFORD,28.0,0.0,68.0,100.0,995.0,Catholic,Secondary,828.0,-37.787845109357946,144.80612802908314
 Marian College Myrtleford,46008.0,2020,MYRTLEFORD,28.0,0.0,68.0,100.0,1024.0,Catholic,Secondary,189.0,-36.554523,146.724742
-Marian College Myrtleford,45700.0,2021,MYRTLEFORD,28.0,0.0,68.2,100.0,1010.0,Catholic,Secondary,437.0,-37.284744,142.937766
-Marian College Myrtleford,45963.0,2021,MYRTLEFORD,28.0,0.0,68.2,100.0,995.0,Catholic,Secondary,844.0,-37.787845109357946,144.80612802908314
 Marian College Myrtleford,46008.0,2021,MYRTLEFORD,28.0,0.0,68.2,100.0,1021.0,Catholic,Secondary,190.0,-36.554523,146.724742
-Marian College Myrtleford,45700.0,2022,MYRTLEFORD,28.0,3.8,68.8,100.0,1025.0,Catholic,Secondary,408.0,-37.284744,142.937766
-Marian College Myrtleford,45963.0,2022,MYRTLEFORD,28.0,3.8,68.8,100.0,993.0,Catholic,Secondary,840.0,-37.787845109357946,144.80612802908314
 Marian College Myrtleford,46008.0,2022,MYRTLEFORD,28.0,3.8,68.8,100.0,1016.0,Catholic,Secondary,181.0,-36.554523,146.724742
-Marian College Myrtleford,,2023,MYRTLEFORD,30.0,7.3,63.2,95.0,,,,,,
-Marian College Sunshine,45700.0,2014,SUNSHINE WEST,29.0,2.2,91.0,100.0,1007.0,Catholic,Secondary,572.0,-37.284744,142.937766
+Marian College Myrtleford,46008.0,2023,MYRTLEFORD,30.0,7.3,63.2,95.0,,,,,,
 Marian College Sunshine,45963.0,2014,SUNSHINE WEST,29.0,2.2,91.0,100.0,967.0,Catholic,Secondary,734.0,-37.787845109357946,144.80612802908314
-Marian College Sunshine,46008.0,2014,SUNSHINE WEST,29.0,2.2,91.0,100.0,999.0,Catholic,Secondary,233.0,-36.55334,146.72536
-Marian College Sunshine,45700.0,2015,SUNSHINE WEST,28.0,2.4,98.0,99.0,1007.0,Catholic,Secondary,576.0,-37.284744,142.937766
 Marian College Sunshine,45963.0,2015,SUNSHINE WEST,28.0,2.4,98.0,99.0,977.0,Catholic,Secondary,758.0,-37.787845109357946,144.80612802908314
-Marian College Sunshine,46008.0,2015,SUNSHINE WEST,28.0,2.4,98.0,99.0,1009.0,Catholic,Secondary,218.0,-36.55334,146.72536
-Marian College Sunshine,45700.0,2016,SUNSHINE WEST,29.0,2.6,90.0,100.0,1011.0,Catholic,Secondary,530.0,-37.284744,142.937766
 Marian College Sunshine,45963.0,2016,SUNSHINE WEST,29.0,2.6,90.0,100.0,971.0,Catholic,Secondary,765.0,-37.787845109357946,144.80612802908314
-Marian College Sunshine,46008.0,2016,SUNSHINE WEST,29.0,2.6,90.0,100.0,1010.0,Catholic,Secondary,179.0,-36.55334,146.72536
-Marian College Sunshine,45700.0,2017,SUNSHINE WEST,29.0,4.1,91.0,97.0,1008.0,Catholic,Secondary,492.0,-37.284744,142.937766
 Marian College Sunshine,45963.0,2017,SUNSHINE WEST,29.0,4.1,91.0,97.0,982.0,Catholic,Secondary,793.0,-37.787845109357946,144.80612802908314
-Marian College Sunshine,46008.0,2017,SUNSHINE WEST,29.0,4.1,91.0,97.0,1023.0,Catholic,Secondary,171.0,-36.55334,146.72536
-Marian College Sunshine,45700.0,2018,SUNSHINE WEST,28.0,2.9,85.1,99.0,1006.0,Catholic,Secondary,510.0,-37.284744,142.937766
 Marian College Sunshine,45963.0,2018,SUNSHINE WEST,28.0,2.9,85.1,99.0,989.0,Catholic,Secondary,779.0,-37.787845109357946,144.80612802908314
-Marian College Sunshine,46008.0,2018,SUNSHINE WEST,28.0,2.9,85.1,99.0,1022.0,Catholic,Secondary,177.0,-36.554523,146.724742
-Marian College Sunshine,45700.0,2019,SUNSHINE WEST,29.0,5.6,97.6,100.0,1008.0,Catholic,Secondary,468.0,-37.284744,142.937766
 Marian College Sunshine,45963.0,2019,SUNSHINE WEST,29.0,5.6,97.6,100.0,993.0,Catholic,Secondary,806.0,-37.787845109357946,144.80612802908314
-Marian College Sunshine,46008.0,2019,SUNSHINE WEST,29.0,5.6,97.6,100.0,1025.0,Catholic,Secondary,174.0,-36.554523,146.724742
-Marian College Sunshine,45700.0,2020,SUNSHINE WEST,28.0,2.8,94.1,100.0,1009.0,Catholic,Secondary,456.0,-37.284744,142.937766
 Marian College Sunshine,45963.0,2020,SUNSHINE WEST,28.0,2.8,94.1,100.0,995.0,Catholic,Secondary,828.0,-37.787845109357946,144.80612802908314
-Marian College Sunshine,46008.0,2020,SUNSHINE WEST,28.0,2.8,94.1,100.0,1024.0,Catholic,Secondary,189.0,-36.554523,146.724742
-Marian College Sunshine,45700.0,2021,SUNSHINE WEST,29.0,3.4,82.6,98.0,1010.0,Catholic,Secondary,437.0,-37.284744,142.937766
 Marian College Sunshine,45963.0,2021,SUNSHINE WEST,29.0,3.4,82.6,98.0,995.0,Catholic,Secondary,844.0,-37.787845109357946,144.80612802908314
-Marian College Sunshine,46008.0,2021,SUNSHINE WEST,29.0,3.4,82.6,98.0,1021.0,Catholic,Secondary,190.0,-36.554523,146.724742
-Marian College Sunshine,45700.0,2022,SUNSHINE WEST,28.0,4.7,94.7,99.0,1025.0,Catholic,Secondary,408.0,-37.284744,142.937766
 Marian College Sunshine,45963.0,2022,SUNSHINE WEST,28.0,4.7,94.7,99.0,993.0,Catholic,Secondary,840.0,-37.787845109357946,144.80612802908314
-Marian College Sunshine,46008.0,2022,SUNSHINE WEST,28.0,4.7,94.7,99.0,1016.0,Catholic,Secondary,181.0,-36.554523,146.724742
-Marian College Sunshine,,2023,SUNSHINE WEST,29.0,5.1,81.5,99.0,,,,,,
+Marian College Sunshine,45963.0,2023,SUNSHINE WEST,29.0,5.1,81.5,99.0,,,,,,
 Maribyrnong Sec College,45420.0,2014,MARIBYRNONG,29.0,4.7,88.0,95.0,1006.0,Government,Secondary,1094.0,-37.77954228,144.88851433
 Maribyrnong Sec College,45420.0,2015,MARIBYRNONG,30.0,5.6,92.0,96.0,1015.0,Government,Secondary,1144.0,-37.77954228,144.88851433
 Maribyrnong Sec College,45420.0,2016,MARIBYRNONG,29.0,3.6,87.0,98.0,1014.0,Government,Secondary,1212.0,-37.77954228,144.88851433
@@ -2928,19 +3021,19 @@ Maribyrnong Sec College,45420.0,2019,MARIBYRNONG,29.0,2.9,84.8,96.0,1029.0,Gover
 Maribyrnong Sec College,45420.0,2020,MARIBYRNONG,29.0,4.5,88.1,99.0,1029.0,Government,Secondary,1281.0,-37.77954228,144.88851433
 Maribyrnong Sec College,45420.0,2021,MARIBYRNONG,29.0,4.9,80.5,97.0,1031.0,Government,Secondary,1292.0,-37.77954228,144.88851433
 Maribyrnong Sec College,45420.0,2022,MARIBYRNONG,28.0,3.0,85.8,98.0,1040.0,Government,Secondary,1280.0,-37.77954228,144.88851433
-Maribyrnong Sec College,,2023,MARIBYRNONG,30.0,4.6,84.1,99.0,,,,,,
+Maribyrnong Sec College,45420.0,2023,MARIBYRNONG,30.0,4.6,84.1,99.0,,,,,,
 Marist - Sion College,45875.0,2018,WARRAGUL,29.0,2.2,65.7,99.0,1016.0,Catholic,Secondary,844.0,-38.159029,145.915266
 Marist - Sion College,45875.0,2019,WARRAGUL,30.0,3.9,71.9,99.0,1014.0,Catholic,Secondary,872.0,-38.159029,145.915266
 Marist - Sion College,45875.0,2020,WARRAGUL,29.0,3.1,75.0,100.0,1008.0,Catholic,Secondary,919.0,-38.159029,145.915266
 Marist - Sion College,45875.0,2021,WARRAGUL,29.0,4.9,74.4,98.0,1013.0,Catholic,Secondary,977.0,-38.159029,145.915266
 Marist - Sion College,45875.0,2022,WARRAGUL,29.0,5.1,78.4,96.0,1026.0,Catholic,Secondary,997.0,-38.159029,145.915266
-Marist - Sion College,,2023,WARRAGUL,27.0,4.1,62.5,95.0,,,,,,
+Marist - Sion College,45875.0,2023,WARRAGUL,27.0,4.1,62.5,95.0,,,,,,
 Marist College Bendigo,50698.0,2018,MAIDEN GULLY,30.0,3.8,,,1015.0,Catholic,Combined,766.0,-36.73171249,144.22169053
 Marist College Bendigo,50698.0,2019,MAIDEN GULLY,28.0,3.5,85.5,100.0,1016.0,Catholic,Combined,939.0,-36.73171249,144.22169053
 Marist College Bendigo,50698.0,2020,MAIDEN GULLY,28.0,4.2,79.2,100.0,1024.0,Catholic,Combined,1022.0,-36.73171249,144.22169053
 Marist College Bendigo,50698.0,2021,MAIDEN GULLY,27.0,2.0,82.6,100.0,1027.0,Catholic,Combined,1126.0,-36.73171249,144.22169053
 Marist College Bendigo,50698.0,2022,MAIDEN GULLY,29.0,5.3,81.8,100.0,1034.0,Catholic,Combined,1169.0,-36.73171249,144.22169053
-Marist College Bendigo,,2023,MAIDEN GULLY,27.0,2.9,63.9,100.0,,,,,,
+Marist College Bendigo,50698.0,2023,MAIDEN GULLY,27.0,2.9,63.9,100.0,,,,,,
 Marist Sion College,45875.0,2014,WARRAGUL,31.0,7.9,93.0,100.0,1021.0,Catholic,Secondary,880.0,-38.159029,145.915266
 Marist Sion College,45875.0,2015,WARRAGUL,29.0,3.9,79.0,100.0,1019.0,Catholic,Secondary,836.0,-38.159029,145.915266
 Marist Sion College,45875.0,2016,WARRAGUL,29.0,3.2,74.0,97.0,1019.0,Catholic,Secondary,832.0,-38.159029,145.915266
@@ -2954,7 +3047,7 @@ Mary MacKillop Catholic College,46081.0,2019,LEONGATHA,28.0,3.5,70.5,95.0,1028.0
 Mary MacKillop Catholic College,46081.0,2020,LEONGATHA,28.0,4.9,81.8,100.0,1028.0,Catholic,Secondary,609.0,-38.468091,145.963613
 Mary MacKillop Catholic College,46081.0,2021,LEONGATHA,29.0,4.9,84.2,98.0,1027.0,Catholic,Secondary,607.0,-38.468091,145.963613
 Mary MacKillop Catholic College,46081.0,2022,LEONGATHA,30.0,8.8,75.8,94.0,1029.0,Catholic,Secondary,582.0,-38.468091,145.963613
-Mary MacKillop Catholic College,,2023,LEONGATHA,30.0,6.4,69.3,99.0,,,,,,
+Mary MacKillop Catholic College,46081.0,2023,LEONGATHA,30.0,6.4,69.3,99.0,,,,,,
 Maryborough Education Centre,50200.0,2014,MARYBOROUGH,22.0,1.8,55.0,93.0,934.0,Government,Combined,1064.0,-37.041827,143.722657
 Maryborough Education Centre,50200.0,2015,MARYBOROUGH,23.0,2.2,59.0,86.0,928.0,Government,Combined,1031.0,-37.041827,143.722657
 Maryborough Education Centre,50200.0,2016,MARYBOROUGH,23.0,2.3,65.0,97.0,928.0,Government,Combined,990.0,-37.041827,143.722657
@@ -2964,7 +3057,7 @@ Maryborough Education Centre,50200.0,2019,MARYBOROUGH,28.0,1.9,63.4,90.0,915.0,G
 Maryborough Education Centre,50200.0,2020,MARYBOROUGH,27.0,1.2,81.1,95.0,917.0,Government,Combined,984.0,-37.041827,143.722657
 Maryborough Education Centre,50200.0,2021,MARYBOROUGH,26.0,0.6,81.8,95.0,921.0,Government,Combined,1007.0,-37.041827,143.722657
 Maryborough Education Centre,50200.0,2022,MARYBOROUGH,26.0,0.0,55.9,94.0,924.0,Government,Combined,988.0,-37.041827,143.722657
-Maryborough Education Centre,,2023,MARYBOROUGH,26.0,,45.2,86.0,,,,,,
+Maryborough Education Centre,50200.0,2023,MARYBOROUGH,26.0,,45.2,86.0,,,,,,
 Marymede Catholic College,46117.0,2014,SOUTH MORANG,30.0,4.8,96.0,97.0,1031.0,Catholic,Combined,1653.0,-37.643315,145.091027
 Marymede Catholic College,46117.0,2015,SOUTH MORANG,29.0,5.7,93.0,98.0,1031.0,Catholic,Combined,1727.0,-37.643315,145.091027
 Marymede Catholic College,46117.0,2016,SOUTH MORANG,30.0,2.2,87.0,99.0,1035.0,Catholic,Combined,1736.0,-37.643315,145.091027
@@ -2974,7 +3067,7 @@ Marymede Catholic College,46117.0,2019,SOUTH MORANG,30.0,4.9,91.3,100.0,1046.0,C
 Marymede Catholic College,46117.0,2020,SOUTH MORANG,30.0,6.8,93.5,100.0,1047.0,Catholic,Combined,1906.0,-37.643315,145.091027
 Marymede Catholic College,46117.0,2021,SOUTH MORANG,30.0,4.1,94.2,100.0,1048.0,Catholic,Combined,1981.0,-37.643315,145.091027
 Marymede Catholic College,46117.0,2022,SOUTH MORANG,30.0,4.5,91.1,100.0,1050.0,Catholic,Combined,2034.0,-37.643315,145.091027
-Marymede Catholic College,,2023,SOUTH MORANG,29.0,1.5,77.7,100.0,,,,,,
+Marymede Catholic College,46117.0,2023,SOUTH MORANG,29.0,1.5,77.7,100.0,,,,,,
 Mater Christi College,45970.0,2014,BELGRAVE,31.0,8.3,93.0,100.0,1072.0,Catholic,Secondary,956.0,-37.9106377,145.3588871
 Mater Christi College,45970.0,2015,BELGRAVE,30.0,6.3,96.0,100.0,1069.0,Catholic,Secondary,889.0,-37.9106377,145.3588871
 Mater Christi College,45970.0,2016,BELGRAVE,31.0,7.9,93.0,100.0,1063.0,Catholic,Secondary,805.0,-37.9106377,145.3588871
@@ -2984,7 +3077,7 @@ Mater Christi College,45970.0,2019,BELGRAVE,31.0,5.8,94.4,100.0,1067.0,Catholic,
 Mater Christi College,45970.0,2020,BELGRAVE,32.0,8.3,96.5,100.0,1070.0,Catholic,Secondary,693.0,-37.9106377,145.3588871
 Mater Christi College,45970.0,2021,BELGRAVE,32.0,12.7,93.3,100.0,1072.0,Catholic,Secondary,687.0,-37.9106377,145.3588871
 Mater Christi College,45970.0,2022,BELGRAVE,31.0,6.8,94.3,99.0,1085.0,Catholic,Secondary,684.0,-37.9106377,145.3588871
-Mater Christi College,,2023,BELGRAVE,31.0,8.3,81.6,100.0,,,,,,
+Mater Christi College,45970.0,2023,BELGRAVE,31.0,8.3,81.6,100.0,,,,,,
 Matthew Flinders Girls' SC,45422.0,2014,GEELONG,29.0,2.1,90.0,100.0,1006.0,Government,Secondary,794.0,-38.148845,144.353444
 Matthew Flinders Girls' SC,45422.0,2015,GEELONG,29.0,4.7,85.0,99.0,1005.0,Government,Secondary,710.0,-38.148845,144.353444
 Matthew Flinders Girls' SC,45422.0,2016,GEELONG,27.0,2.0,74.0,96.0,997.0,Government,Secondary,648.0,-38.148845,144.353444
@@ -2994,7 +3087,7 @@ Matthew Flinders Girls' SC,45422.0,2019,GEELONG,26.0,2.1,61.9,98.0,1014.0,Govern
 Matthew Flinders Girls' SC,45422.0,2020,GEELONG,29.0,2.0,87.0,98.0,1019.0,Government,Secondary,608.0,-38.148845,144.353444
 Matthew Flinders Girls' SC,45422.0,2021,GEELONG,28.0,6.3,81.6,98.0,1018.0,Government,Secondary,585.0,-38.148845,144.353444
 Matthew Flinders Girls' SC,45422.0,2022,GEELONG,28.0,2.9,81.7,97.0,1028.0,Government,Secondary,598.0,-38.148845,144.353444
-Matthew Flinders Girls' SC,,2023,GEELONG,27.0,2.5,49.3,96.0,,,,,,
+Matthew Flinders Girls' SC,45422.0,2023,GEELONG,27.0,2.5,49.3,96.0,,,,,,
 Mazenod College,45996.0,2014,MULGRAVE,32.0,9.8,91.0,99.0,1065.0,Catholic,Secondary,1266.0,-37.915204,145.166144
 Mazenod College,45996.0,2015,MULGRAVE,32.0,9.9,97.0,100.0,1073.0,Catholic,Secondary,1306.0,-37.915204,145.166144
 Mazenod College,45996.0,2016,MULGRAVE,32.0,11.5,99.0,99.0,1075.0,Catholic,Secondary,1348.0,-37.915204,145.166144
@@ -3004,7 +3097,7 @@ Mazenod College,45996.0,2019,MULGRAVE,32.0,11.2,93.0,99.0,1075.0,Catholic,Second
 Mazenod College,45996.0,2020,MULGRAVE,32.0,10.9,93.2,100.0,1076.0,Catholic,Secondary,1442.0,-37.915204,145.166144
 Mazenod College,45996.0,2021,MULGRAVE,32.0,11.0,92.8,100.0,1068.0,Catholic,Secondary,1448.0,-37.915204,145.166144
 Mazenod College,45996.0,2022,MULGRAVE,32.0,11.5,95.1,99.0,1071.0,Catholic,Secondary,1435.0,-37.915204,145.166144
-Mazenod College,,2023,MULGRAVE,32.0,12.6,77.6,100.0,,,,,,
+Mazenod College,45996.0,2023,MULGRAVE,32.0,12.6,77.6,100.0,,,,,,
 McClelland Secondary College,45571.0,2014,FRANKSTON,28.0,1.9,70.0,93.0,956.0,Government,Secondary,856.0,-38.14667462,145.15836583
 McClelland Secondary College,45571.0,2015,FRANKSTON,26.0,2.6,63.0,98.0,968.0,Government,Secondary,903.0,-38.14667462,145.15836583
 McClelland Secondary College,45571.0,2016,FRANKSTON,27.0,1.9,64.0,97.0,961.0,Government,Secondary,946.0,-38.14667462,145.15836583
@@ -3014,13 +3107,13 @@ McClelland Secondary College,45571.0,2019,FRANKSTON,29.0,3.5,68.4,96.0,976.0,Gov
 McClelland Secondary College,45571.0,2020,FRANKSTON,29.0,3.6,66.7,100.0,978.0,Government,Secondary,1010.0,-38.14667462,145.15836583
 McClelland Secondary College,45571.0,2021,FRANKSTON,29.0,3.6,56.3,97.0,976.0,Government,Secondary,1029.0,-38.14667462,145.15836583
 McClelland Secondary College,45571.0,2022,FRANKSTON,30.0,4.8,45.8,100.0,974.0,Government,Secondary,1041.0,-38.14667462,145.15836583
-McClelland Secondary College,,2023,FRANKSTON,29.0,4.3,28.4,97.0,,,,,,
-McGuire College,46321.0,2014,SHEPPARTON,25.0,1.3,58.0,91.0,998.0,Independent,Combined,1502.0,-37.93883681,145.1482852
-McGuire College,46321.0,2015,SHEPPARTON,25.0,0.0,82.0,96.0,1021.0,Independent,Combined,1598.0,-37.93883681,145.1482852
-McGuire College,46321.0,2016,SHEPPARTON,23.0,0.0,68.0,97.0,998.0,Independent,Combined,1684.0,-37.93883681,145.1482852
-McGuire College,46321.0,2017,SHEPPARTON,24.0,3.3,81.0,94.0,994.0,Independent,Combined,1764.0,-37.93883681,145.1482852
-McGuire College,46321.0,2018,SHEPPARTON,22.0,0.7,82.0,98.0,982.0,Independent,Combined,1803.0,-37.93863,145.149168
-McGuire College,46321.0,2019,SHEPPARTON,23.0,0.0,55.0,85.0,984.0,Independent,Combined,1852.0,-37.93863,145.149168
+McClelland Secondary College,45571.0,2023,FRANKSTON,29.0,4.3,28.4,97.0,,,,,,
+McGuire College,53105.0,2014,SHEPPARTON,25.0,1.3,58.0,91.0,,,,,,
+McGuire College,53105.0,2015,SHEPPARTON,25.0,0.0,82.0,96.0,,,,,,
+McGuire College,53105.0,2016,SHEPPARTON,23.0,0.0,68.0,97.0,,,,,,
+McGuire College,53105.0,2017,SHEPPARTON,24.0,3.3,81.0,94.0,,,,,,
+McGuire College,53105.0,2018,SHEPPARTON,22.0,0.7,82.0,98.0,,,,,,
+McGuire College,53105.0,2019,SHEPPARTON,23.0,0.0,55.0,85.0,,,,,,
 McKinnon Secondary College,45436.0,2014,MCKINNON,33.0,16.6,91.0,100.0,1123.0,Government,Secondary,1855.0,-37.912027,145.049119
 McKinnon Secondary College,45436.0,2015,MCKINNON,33.0,15.1,97.0,100.0,1121.0,Government,Secondary,1939.0,-37.912027,145.049119
 McKinnon Secondary College,45436.0,2016,MCKINNON,34.0,17.0,95.0,99.0,1118.0,Government,Secondary,1995.0,-37.912027,145.049119
@@ -3030,20 +3123,20 @@ McKinnon Secondary College,45436.0,2019,MCKINNON,33.0,16.1,93.5,99.0,1121.0,Gove
 McKinnon Secondary College,45436.0,2020,MCKINNON,33.0,17.2,96.6,100.0,1118.0,Government,Secondary,2281.0,-37.912027,145.049119
 McKinnon Secondary College,45436.0,2021,MCKINNON,32.0,12.6,94.1,99.0,1116.0,Government,Secondary,2328.0,-37.912027,145.049119
 McKinnon Secondary College,45436.0,2022,MCKINNON,33.0,15.0,92.6,99.0,1118.0,Government,Secondary,2538.0,-37.912027,145.049119
-McKinnon Secondary College,,2023,MCKINNON,33.0,18.4,88.4,100.0,,,,,,
-Melba College,46354.0,2014,CROYDON,25.0,1.5,80.0,96.0,1129.0,Independent,Secondary,71.0,-37.843225,145.045173
-Melba College,46354.0,2015,CROYDON,25.0,0.7,81.0,97.0,1091.0,Independent,Secondary,88.0,-37.843225,145.045173
-Melba College,46354.0,2016,CROYDON,26.0,3.2,67.0,98.0,1115.0,Independent,Secondary,86.0,-37.843225,145.045173
-Melba College,46354.0,2017,CROYDON,28.0,4.1,57.0,96.0,1098.0,Independent,Secondary,76.0,-37.843225,145.045173
-Melba College,46354.0,2018,CROYDON,27.0,2.5,67.1,99.0,1097.0,Independent,Secondary,71.0,-37.843225,145.045173
-Melba College,46354.0,2019,CROYDON,28.0,3.4,69.6,96.0,996.0,Independent,Secondary,72.0,-37.843225,145.045173
-Melba College,46354.0,2020,CROYDON,29.0,1.7,82.1,100.0,1043.0,Independent,Secondary,68.0,-37.843225,145.045173
-Melba College,46354.0,2021,CROYDON,27.0,2.0,70.2,96.0,1054.0,Independent,Secondary,68.0,-37.843225,145.045173
-Melba College,46354.0,2022,CROYDON,27.0,3.5,70.4,100.0,1115.0,Independent,Secondary,91.0,-37.843225,145.045173
-Melba College,,2023,CROYDON,29.0,2.9,34.7,98.0,,,,,,
-Melbourne City Mission,45423.0,2015,SOUTH MELBOURNE,,,,,1179.0,Government,Secondary,1369.0,-37.836829,144.995314
-Melbourne City Mission,45423.0,2016,SOUTH MELBOURNE,,,,,1170.0,Government,Secondary,1368.0,-37.836829,144.995314
-Melbourne City Mission,45423.0,2019,SOUTH MELBOURNE,,,,,1168.0,Government,Secondary,1364.0,-37.836829,144.995314
+McKinnon Secondary College,45436.0,2023,MCKINNON,33.0,18.4,88.4,100.0,,,,,,
+Melba College,45421.0,2014,CROYDON,25.0,1.5,80.0,96.0,959.0,Government,Secondary,767.0,-37.7953,145.261
+Melba College,45421.0,2015,CROYDON,25.0,0.7,81.0,97.0,955.0,Government,Secondary,686.0,-37.7953,145.261
+Melba College,45421.0,2016,CROYDON,26.0,3.2,67.0,98.0,950.0,Government,Secondary,627.0,-37.7953,145.261
+Melba College,45421.0,2017,CROYDON,28.0,4.1,57.0,96.0,953.0,Government,Secondary,563.0,-37.7953,145.261
+Melba College,45421.0,2018,CROYDON,27.0,2.5,67.1,99.0,955.0,Government,Secondary,539.0,-37.7953,145.261
+Melba College,45421.0,2019,CROYDON,28.0,3.4,69.6,96.0,974.0,Government,Secondary,567.0,-37.7953,145.261
+Melba College,45421.0,2020,CROYDON,29.0,1.7,82.1,100.0,973.0,Government,Secondary,601.0,-37.7953,145.261
+Melba College,45421.0,2021,CROYDON,27.0,2.0,70.2,96.0,982.0,Government,Secondary,623.0,-37.7953,145.261
+Melba College,45421.0,2022,CROYDON,27.0,3.5,70.4,100.0,981.0,Government,Secondary,624.0,-37.7953,145.261
+Melba College,45421.0,2023,CROYDON,29.0,2.9,34.7,98.0,,,,,,
+Melbourne City Mission,,2015,SOUTH MELBOURNE,,,,,,,,,,
+Melbourne City Mission,,2016,SOUTH MELBOURNE,,,,,,,,,,
+Melbourne City Mission,,2019,SOUTH MELBOURNE,,,,,,,,,,
 Melbourne Girls Grammar,46157.0,2014,SOUTH YARRA,36.0,25.4,100.0,100.0,1172.0,Independent,Combined,882.0,-37.835293,144.988851
 Melbourne Girls Grammar,46157.0,2015,SOUTH YARRA,36.0,26.9,99.0,100.0,1184.0,Independent,Combined,913.0,-37.835293,144.988851
 Melbourne Girls Grammar,46157.0,2016,SOUTH YARRA,36.0,26.4,97.0,100.0,1180.0,Independent,Combined,933.0,-37.835293,144.988851
@@ -3053,7 +3146,7 @@ Melbourne Girls Grammar,46157.0,2019,SOUTH YARRA,34.0,24.6,96.1,99.0,1165.0,Inde
 Melbourne Girls Grammar,46157.0,2020,SOUTH YARRA,35.0,21.3,95.9,100.0,1165.0,Independent,Combined,1016.0,-37.835293,144.988851
 Melbourne Girls Grammar,46157.0,2021,SOUTH YARRA,34.0,18.4,95.6,100.0,1178.0,Independent,Combined,1024.0,-37.835293,144.988851
 Melbourne Girls Grammar,46157.0,2022,SOUTH YARRA,34.0,18.7,100.0,100.0,1181.0,Independent,Combined,1039.0,-37.835293,144.988851
-Melbourne Girls Grammar,,2023,SOUTH YARRA,34.0,19.9,99.2,99.0,,,,,,
+Melbourne Girls Grammar,46157.0,2023,SOUTH YARRA,34.0,19.9,99.2,99.0,,,,,,
 Melbourne Girls' College,45557.0,2014,RICHMOND,33.0,15.6,98.0,100.0,1109.0,Government,Secondary,1323.0,-37.822507,145.014334
 Melbourne Girls' College,45557.0,2015,RICHMOND,33.0,15.4,94.0,99.0,1114.0,Government,Secondary,1339.0,-37.822507,145.014334
 Melbourne Girls' College,45557.0,2016,RICHMOND,34.0,18.6,94.0,99.0,1116.0,Government,Secondary,1422.0,-37.822507,145.014334
@@ -3063,7 +3156,7 @@ Melbourne Girls' College,45557.0,2019,RICHMOND,33.0,16.4,94.8,100.0,1114.0,Gover
 Melbourne Girls' College,45557.0,2020,RICHMOND,33.0,16.8,95.6,100.0,1122.0,Government,Secondary,1490.0,-37.822507,145.014334
 Melbourne Girls' College,45557.0,2021,RICHMOND,33.0,16.0,94.0,100.0,1129.0,Government,Secondary,1441.0,-37.822507,145.014334
 Melbourne Girls' College,45557.0,2022,RICHMOND,32.0,10.5,93.1,99.0,1137.0,Government,Secondary,1403.0,-37.822507,145.014334
-Melbourne Girls' College,,2023,RICHMOND,33.0,14.4,91.5,100.0,,,,,,
+Melbourne Girls' College,45557.0,2023,RICHMOND,33.0,14.4,91.5,100.0,,,,,,
 Melbourne Grammar School,46137.0,2014,MELBOURNE,35.0,24.2,99.0,100.0,1187.0,Independent,Combined,1803.0,-37.833451,144.975911
 Melbourne Grammar School,46137.0,2015,MELBOURNE,34.0,22.0,99.0,100.0,1193.0,Independent,Combined,1797.0,-37.833451,144.975911
 Melbourne Grammar School,46137.0,2016,MELBOURNE,34.0,22.7,99.0,100.0,1184.0,Independent,Combined,1797.0,-37.833451,144.975911
@@ -3073,7 +3166,7 @@ Melbourne Grammar School,46137.0,2019,MELBOURNE,35.0,23.7,98.0,100.0,1171.0,Inde
 Melbourne Grammar School,46137.0,2020,MELBOURNE,34.0,23.4,99.5,100.0,1171.0,Independent,Combined,1803.0,-37.833451,144.975911
 Melbourne Grammar School,46137.0,2021,MELBOURNE,35.0,24.5,96.9,99.0,1172.0,Independent,Combined,1806.0,-37.833451,144.975911
 Melbourne Grammar School,46137.0,2022,MELBOURNE,35.0,25.8,98.1,100.0,1187.0,Independent,Combined,1809.0,-37.833451,144.975911
-Melbourne Grammar School,,2023,MELBOURNE,35.0,27.1,96.0,100.0,,,,,,
+Melbourne Grammar School,46137.0,2023,MELBOURNE,35.0,27.1,96.0,100.0,,,,,,
 Melbourne High School,45423.0,2014,SOUTH YARRA,37.0,35.5,97.0,100.0,1173.0,Government,Secondary,1370.0,-37.836829,144.995314
 Melbourne High School,45423.0,2015,SOUTH YARRA,37.0,35.3,96.0,100.0,1179.0,Government,Secondary,1369.0,-37.836829,144.995314
 Melbourne High School,45423.0,2016,SOUTH YARRA,37.0,31.7,98.0,100.0,1170.0,Government,Secondary,1368.0,-37.836829,144.995314
@@ -3083,17 +3176,17 @@ Melbourne High School,45423.0,2019,SOUTH YARRA,36.0,29.4,98.3,99.0,1168.0,Govern
 Melbourne High School,45423.0,2020,SOUTH YARRA,37.0,30.4,98.5,100.0,1166.0,Government,Secondary,1359.0,-37.836829,144.995314
 Melbourne High School,45423.0,2021,SOUTH YARRA,36.0,30.2,98.1,99.0,1166.0,Government,Secondary,1363.0,-37.836829,144.995314
 Melbourne High School,45423.0,2022,SOUTH YARRA,36.0,27.0,98.8,100.0,1166.0,Government,Secondary,1369.0,-37.836829,144.995314
-Melbourne High School,,2023,SOUTH YARRA,36.0,27.9,95.8,100.0,,,,,,
+Melbourne High School,45423.0,2023,SOUTH YARRA,36.0,27.9,95.8,100.0,,,,,,
 Melbourne Montessori School,46244.0,2020,BRIGHTON EAST,,,,,1112.0,Independent,Combined,265.0,-37.888167,145.025671
 Melbourne Montessori School,46244.0,2021,BRIGHTON EAST,,,100.0,,1118.0,Independent,Combined,272.0,-37.888167,145.025671
 Melbourne Polytechnic,,2015,PRESTON,,,,,,,,,,
 Melbourne Polytechnic,,2016,PRESTON,,,,,,,,,,
-Melbourne Polytechnic,46244.0,2017,PRESTON,,,,,1122.0,Independent,Combined,266.0,-37.888167,145.025671
-Melbourne Polytechnic,46244.0,2018,PRESTON,,,,,1113.0,Independent,Combined,274.0,-37.888167,145.025671
-Melbourne Polytechnic,46244.0,2019,PRESTON,,,,,1112.0,Independent,Combined,285.0,-37.888167,145.025671
-Melbourne Polytechnic,46244.0,2020,PRESTON,,,,,1112.0,Independent,Combined,265.0,-37.888167,145.025671
-Melbourne Polytechnic,46244.0,2021,PRESTON,,,,,1118.0,Independent,Combined,272.0,-37.888167,145.025671
-Melbourne Polytechnic,46244.0,2022,PRESTON,,,,,1109.0,Independent,Combined,265.0,-37.888167,145.025671
+Melbourne Polytechnic,,2017,PRESTON,,,,,,,,,,
+Melbourne Polytechnic,,2018,PRESTON,,,,,,,,,,
+Melbourne Polytechnic,,2019,PRESTON,,,,,,,,,,
+Melbourne Polytechnic,,2020,PRESTON,,,,,,,,,,
+Melbourne Polytechnic,,2021,PRESTON,,,,,,,,,,
+Melbourne Polytechnic,,2022,PRESTON,,,,,,,,,,
 Melbourne Polytechnic,,2023,PRESTON,,,12.5,63.0,,,,,,
 Melbourne Rudolf Steiner Schl,46230.0,2014,WARRANWOOD,31.0,4.3,97.0,100.0,,Independent,Combined,471.0,-37.777221,145.248811
 Melbourne Rudolf Steiner Schl,46230.0,2015,WARRANWOOD,30.0,6.6,90.0,100.0,,Independent,Combined,467.0,-37.777221,145.248811
@@ -3104,8 +3197,8 @@ Melbourne Rudolf Steiner Schl,46230.0,2019,WARRANWOOD,29.0,5.2,100.0,100.0,1066.
 Melbourne Rudolf Steiner Schl,46230.0,2020,WARRANWOOD,31.0,3.4,97.0,97.0,1101.0,Independent,Combined,452.0,-37.777221,145.248811
 Melbourne Rudolf Steiner Schl,46230.0,2021,WARRANWOOD,32.0,13.8,94.9,100.0,1093.0,Independent,Combined,463.0,-37.777221,145.248811
 Melbourne Rudolf Steiner Schl,46230.0,2022,WARRANWOOD,31.0,8.4,87.0,96.0,1099.0,Independent,Combined,462.0,-37.777221,145.248811
-Melbourne Rudolf Steiner Schl,,2023,WARRANWOOD,30.0,8.2,78.9,97.0,,,,,,
-Melbourne Senior Sec College,45557.0,2014,MELBOURNE,21.0,1.4,65.0,73.0,1109.0,Government,Secondary,1323.0,-37.822507,145.014334
+Melbourne Rudolf Steiner Schl,46230.0,2023,WARRANWOOD,30.0,8.2,78.9,97.0,,,,,,
+Melbourne Senior Sec College,,2014,MELBOURNE,21.0,1.4,65.0,73.0,,,,,,
 Melton Christian College,46303.0,2014,MELTON SOUTH,29.0,3.9,95.0,100.0,1039.0,Independent,Combined,593.0,-37.701012,144.560365
 Melton Christian College,46303.0,2015,MELTON SOUTH,30.0,3.0,79.0,100.0,1045.0,Independent,Combined,613.0,-37.701012,144.560365
 Melton Christian College,46303.0,2016,MELTON SOUTH,30.0,8.1,83.0,100.0,1042.0,Independent,Combined,658.0,-37.701012,144.560365
@@ -3115,7 +3208,7 @@ Melton Christian College,46303.0,2019,BROOKFIELD,26.0,0.6,91.7,100.0,1046.0,Inde
 Melton Christian College,46303.0,2020,BROOKFIELD,26.0,0.6,76.5,100.0,1046.0,Independent,Combined,822.0,-37.701012,144.560365
 Melton Christian College,46303.0,2021,BROOKFIELD,26.0,1.4,77.4,98.0,1044.0,Independent,Combined,865.0,-37.701012,144.560365
 Melton Christian College,46303.0,2022,BROOKFIELD,26.0,0.5,81.4,98.0,1044.0,Independent,Combined,940.0,-37.701012,144.560365
-Melton Christian College,,2023,BROOKFIELD,27.0,2.3,65.9,100.0,,,,,,
+Melton Christian College,46303.0,2023,BROOKFIELD,27.0,2.3,65.9,100.0,,,,,,
 Melton Secondary College,45424.0,2014,MELTON,27.0,1.7,71.0,96.0,939.0,Government,Secondary,755.0,-37.68244498,144.56688187
 Melton Secondary College,45424.0,2015,MELTON,24.0,2.1,69.0,98.0,938.0,Government,Secondary,871.0,-37.68244498,144.56688187
 Melton Secondary College,45424.0,2016,MELTON,26.0,0.8,69.0,94.0,930.0,Government,Secondary,955.0,-37.68244498,144.56688187
@@ -3125,7 +3218,7 @@ Melton Secondary College,45424.0,2019,MELTON,28.0,1.5,88.2,97.0,946.0,Government
 Melton Secondary College,45424.0,2020,MELTON,26.0,4.7,85.1,95.0,952.0,Government,Secondary,1213.0,-37.68244498,144.56688187
 Melton Secondary College,45424.0,2021,MELTON,27.0,1.0,75.3,84.0,951.0,Government,Secondary,1329.0,-37.68244498,144.56688187
 Melton Secondary College,45424.0,2022,MELTON,27.0,1.1,91.5,97.0,940.0,Government,Secondary,1383.0,-37.68244498,144.56688187
-Melton Secondary College,,2023,MELTON,24.0,1.1,56.4,99.0,,,,,,
+Melton Secondary College,45424.0,2023,MELTON,24.0,1.1,56.4,99.0,,,,,,
 Mentone Girls' Grammar School,46195.0,2014,MENTONE,34.0,25.0,97.0,100.0,1175.0,Independent,Combined,667.0,-37.989376,145.064534
 Mentone Girls' Grammar School,46195.0,2015,MENTONE,36.0,27.9,100.0,100.0,1168.0,Independent,Combined,675.0,-37.989376,145.064534
 Mentone Girls' Grammar School,46195.0,2016,MENTONE,35.0,24.9,100.0,100.0,1160.0,Independent,Combined,717.0,-37.989376,145.064534
@@ -3135,7 +3228,7 @@ Mentone Girls' Grammar School,46195.0,2019,MENTONE,35.0,22.3,100.0,100.0,1150.0,
 Mentone Girls' Grammar School,46195.0,2020,MENTONE,35.0,17.9,100.0,100.0,1152.0,Independent,Combined,693.0,-37.989376,145.064534
 Mentone Girls' Grammar School,46195.0,2021,MENTONE,34.0,19.5,100.0,100.0,1153.0,Independent,Combined,655.0,-37.989376,145.064534
 Mentone Girls' Grammar School,46195.0,2022,MENTONE,35.0,21.2,98.7,100.0,1164.0,Independent,Combined,598.0,-37.989376,145.064534
-Mentone Girls' Grammar School,,2023,MENTONE,36.0,29.4,100.0,100.0,,,,,,
+Mentone Girls' Grammar School,46195.0,2023,MENTONE,36.0,29.4,100.0,100.0,,,,,,
 Mentone Girls' Sec College,45425.0,2014,MENTONE,32.0,7.4,96.0,100.0,1075.0,Government,Secondary,1088.0,-37.98035,145.053969
 Mentone Girls' Sec College,45425.0,2015,MENTONE,31.0,8.9,92.0,98.0,1075.0,Government,Secondary,1112.0,-37.98035,145.053969
 Mentone Girls' Sec College,45425.0,2016,MENTONE,31.0,7.1,95.0,99.0,1071.0,Government,Secondary,1134.0,-37.98035,145.053969
@@ -3145,7 +3238,7 @@ Mentone Girls' Sec College,45425.0,2019,MENTONE,30.0,7.7,82.3,99.0,1075.0,Govern
 Mentone Girls' Sec College,45425.0,2020,MENTONE,30.0,7.6,95.1,100.0,1079.0,Government,Secondary,1087.0,-37.98035,145.053969
 Mentone Girls' Sec College,45425.0,2021,MENTONE,30.0,7.1,92.0,100.0,1082.0,Government,Secondary,1066.0,-37.98035,145.053969
 Mentone Girls' Sec College,45425.0,2022,MENTONE,30.0,7.8,84.3,99.0,1086.0,Government,Secondary,1038.0,-37.98035,145.053969
-Mentone Girls' Sec College,,2023,MENTONE,32.0,11.4,89.4,99.0,,,,,,
+Mentone Girls' Sec College,45425.0,2023,MENTONE,32.0,11.4,89.4,99.0,,,,,,
 Mentone Grammar School,46184.0,2014,MENTONE,33.0,15.7,97.0,99.0,1140.0,Independent,Combined,1268.0,-37.987688,145.068124
 Mentone Grammar School,46184.0,2015,MENTONE,34.0,17.4,99.0,100.0,1142.0,Independent,Combined,1315.0,-37.987688,145.068124
 Mentone Grammar School,46184.0,2016,MENTONE,34.0,18.2,97.0,100.0,1139.0,Independent,Combined,1375.0,-37.987688,145.068124
@@ -3155,8 +3248,8 @@ Mentone Grammar School,46184.0,2019,MENTONE,35.0,22.0,99.4,100.0,1142.0,Independ
 Mentone Grammar School,46184.0,2020,MENTONE,34.0,16.7,97.3,100.0,1145.0,Independent,Combined,1551.0,-37.987688,145.068124
 Mentone Grammar School,46184.0,2021,MENTONE,34.0,19.9,94.2,100.0,1142.0,Independent,Combined,1658.0,-37.987688,145.068124
 Mentone Grammar School,46184.0,2022,MENTONE,34.0,20.9,96.2,100.0,1139.0,Independent,Combined,1770.0,-37.987688,145.068124
-Mentone Grammar School,,2023,MENTONE,35.0,21.1,95.8,100.0,,,,,,
-Merbein P-10 College,,2023,MERBEIN,,,,,,,,,,
+Mentone Grammar School,46184.0,2023,MENTONE,35.0,21.1,95.8,100.0,,,,,,
+Merbein P-10 College,45612.0,2023,MERBEIN,,,,,,,,,,
 Mercy College,45985.0,2014,COBURG,28.0,2.1,100.0,100.0,1005.0,Catholic,Secondary,506.0,-37.730398,144.964562
 Mercy College,45985.0,2015,COBURG,29.0,4.8,100.0,97.0,1008.0,Catholic,Secondary,467.0,-37.730398,144.964562
 Mercy College,45985.0,2016,COBURG,28.0,3.5,100.0,100.0,1001.0,Catholic,Secondary,480.0,-37.730398,144.964562
@@ -3166,7 +3259,7 @@ Mercy College,45985.0,2019,COBURG,30.0,4.0,100.0,100.0,1018.0,Catholic,Secondary
 Mercy College,45985.0,2020,COBURG,29.0,6.0,100.0,100.0,1024.0,Catholic,Secondary,451.0,-37.730398,144.964562
 Mercy College,45985.0,2021,COBURG,29.0,5.2,97.4,99.0,1023.0,Catholic,Secondary,434.0,-37.730398,144.964562
 Mercy College,45985.0,2022,COBURG,29.0,4.9,92.3,96.0,1028.0,Catholic,Secondary,390.0,-37.730398,144.964562
-Mercy College,,2023,COBURG,29.0,2.5,96.2,98.0,,,,,,
+Mercy College,45985.0,2023,COBURG,29.0,2.5,96.2,98.0,,,,,,
 Mercy Regional College,45745.0,2014,CAMPERDOWN,30.0,3.4,93.0,100.0,1026.0,Catholic,Secondary,490.0,-38.234124,143.140746
 Mercy Regional College,45745.0,2015,CAMPERDOWN,28.0,1.9,86.0,100.0,1023.0,Catholic,Secondary,485.0,-38.234124,143.140746
 Mercy Regional College,45745.0,2016,CAMPERDOWN,27.0,0.8,80.0,100.0,1021.0,Catholic,Secondary,463.0,-38.234124,143.140746
@@ -3176,7 +3269,7 @@ Mercy Regional College,45745.0,2019,CAMPERDOWN,27.0,2.1,80.0,98.0,1027.0,Catholi
 Mercy Regional College,45745.0,2020,CAMPERDOWN,26.0,1.1,52.7,100.0,1028.0,Catholic,Secondary,417.0,-38.234124,143.140746
 Mercy Regional College,45745.0,2021,CAMPERDOWN,27.0,1.4,58.7,98.0,1031.0,Catholic,Secondary,411.0,-38.234124,143.140746
 Mercy Regional College,45745.0,2022,CAMPERDOWN,25.0,0.5,73.7,100.0,1027.0,Catholic,Secondary,374.0,-38.234124,143.140746
-Mercy Regional College,,2023,CAMPERDOWN,29.0,2.4,45.6,100.0,,,,,,
+Mercy Regional College,45745.0,2023,CAMPERDOWN,29.0,2.4,45.6,100.0,,,,,,
 Merinda Park Learning Centre,,2014,CRANBOURNE,,,,,,,,,,
 Merinda Park Learning Centre,,2015,CRANBOURNE,,,,,,,,,,
 Merinda Park Learning Centre,,2016,CRANBOURNE,,,,,,,,,,
@@ -3184,10 +3277,10 @@ Merinda Park Learning Centre,,2017,CRANBOURNE,,,,,,,,,,
 Merinda Park Learning Centre,,2018,CRANBOURNE,,,,,,,,,,
 Merinda Park Learning Centre,,2019,CRANBOURNE,,,,,,,,,,
 Merinda Park Learning Centre,,2020,CRANBOURNE,,,,,,,,,,
-Merinda Park Learning Centre,53015.0,2021,CRANBOURNE,,,,,,Catholic,Secondary,23.0,-37.82215686,144.9981578
+Merinda Park Learning Centre,,2021,CRANBOURNE,,,,,,,,,,
 Mernda Central P-12 College,52478.0,2021,MERNDA,33.0,5.3,,,1009.0,Government,Combined,1405.0,-37.603959,145.087925
 Mernda Central P-12 College,52478.0,2022,MERNDA,25.0,1.1,73.3,100.0,1009.0,Government,Combined,1502.0,-37.603959,145.087925
-Mernda Central P-12 College,,2023,MERNDA,28.0,3.2,68.4,99.0,,,,,,
+Mernda Central P-12 College,52478.0,2023,MERNDA,28.0,3.2,68.4,99.0,,,,,,
 Methodist Ladies College,46144.0,2014,KEW,35.0,23.9,98.0,100.0,1199.0,Independent,Combined,2059.0,-37.81479076,145.03845598
 Methodist Ladies College,46144.0,2015,KEW,35.0,22.2,99.0,100.0,1196.0,Independent,Combined,2050.0,-37.81479076,145.03845598
 Methodist Ladies College,46144.0,2016,KEW,34.0,22.5,100.0,100.0,1188.0,Independent,Combined,2027.0,-37.81479076,145.03845598
@@ -3197,7 +3290,7 @@ Methodist Ladies College,46144.0,2019,KEW,35.0,25.0,97.5,100.0,1174.0,Independen
 Methodist Ladies College,46144.0,2020,KEW,36.0,27.6,99.0,100.0,1174.0,Independent,Combined,2034.0,-37.81479076,145.03845598
 Methodist Ladies College,46144.0,2021,KEW,36.0,29.7,98.5,100.0,1181.0,Independent,Combined,2018.0,-37.81479076,145.03845598
 Methodist Ladies College,46144.0,2022,KEW,34.0,22.6,98.6,100.0,1195.0,Independent,Combined,2019.0,-37.81479076,145.03845598
-Methodist Ladies College,,2023,KEW,33.0,19.6,97.7,100.0,,,,,,
+Methodist Ladies College,46144.0,2023,KEW,33.0,19.6,97.7,100.0,,,,,,
 Mildura Senior College,40562.0,2014,MILDURA,28.0,2.2,58.0,96.0,,Government,Secondary,882.0,-34.19800387,142.14539009
 Mildura Senior College,40562.0,2015,MILDURA,28.0,3.9,59.0,95.0,,Government,Secondary,950.0,-34.19800387,142.14539009
 Mildura Senior College,40562.0,2016,MILDURA,28.0,3.4,60.0,95.0,,Government,Secondary,880.0,-34.19800387,142.14539009
@@ -3207,7 +3300,7 @@ Mildura Senior College,40562.0,2019,MILDURA,27.0,2.8,76.3,98.0,987.0,Government,
 Mildura Senior College,40562.0,2020,MILDURA,25.0,1.3,62.8,98.0,978.0,Government,Secondary,933.0,-34.19800387,142.14539009
 Mildura Senior College,40562.0,2021,MILDURA,26.0,1.7,59.2,97.0,985.0,Government,Secondary,837.0,-34.19800387,142.14539009
 Mildura Senior College,40562.0,2022,MILDURA,27.0,2.2,56.2,97.0,972.0,Government,Secondary,803.0,-34.19800387,142.14539009
-Mildura Senior College,,2023,MILDURA,26.0,2.0,42.7,94.0,,,,,,
+Mildura Senior College,40562.0,2023,MILDURA,26.0,2.0,42.7,94.0,,,,,,
 Mill Park Secondary College,45524.0,2014,EPPING,26.0,3.0,87.0,95.0,984.0,Government,Secondary,1603.0,-37.66390279,145.06286022
 Mill Park Secondary College,45524.0,2015,EPPING,25.0,2.1,79.0,93.0,987.0,Government,Secondary,1558.0,-37.66390279,145.06286022
 Mill Park Secondary College,45524.0,2016,EPPING,25.0,2.1,77.0,94.0,986.0,Government,Secondary,1574.0,-37.66390279,145.06286022
@@ -3217,7 +3310,7 @@ Mill Park Secondary College,45524.0,2019,EPPING,24.0,2.4,87.6,93.0,999.0,Governm
 Mill Park Secondary College,45524.0,2020,EPPING,25.0,1.7,78.9,98.0,998.0,Government,Secondary,1384.0,-37.66390279,145.06286022
 Mill Park Secondary College,45524.0,2021,EPPING,24.0,1.6,80.0,94.0,1004.0,Government,Secondary,1307.0,-37.66390279,145.06286022
 Mill Park Secondary College,45524.0,2022,EPPING,25.0,1.3,88.5,95.0,1007.0,Government,Secondary,1171.0,-37.66390279,145.06286022
-Mill Park Secondary College,,2023,EPPING,26.0,1.9,75.8,97.0,,,,,,
+Mill Park Secondary College,45524.0,2023,EPPING,26.0,1.9,75.8,97.0,,,,,,
 Minaret College,46321.0,2014,SPRINGVALE,28.0,6.2,100.0,100.0,998.0,Independent,Combined,1502.0,-37.93883681,145.1482852
 Minaret College,46321.0,2015,SPRINGVALE,29.0,6.4,99.0,99.0,1021.0,Independent,Combined,1598.0,-37.93883681,145.1482852
 Minaret College,46321.0,2016,SPRINGVALE,27.0,5.3,99.0,100.0,998.0,Independent,Combined,1684.0,-37.93883681,145.1482852
@@ -3234,8 +3327,8 @@ Minaret College,46321.0,2021,OFFICER,26.0,2.3,81.8,100.0,983.0,Independent,Combi
 Minaret College,46321.0,2021,SPRINGVALE,28.0,3.6,97.6,99.0,983.0,Independent,Combined,2261.0,-37.93863,145.149168
 Minaret College,46321.0,2022,OFFICER,27.0,1.3,100.0,98.0,980.0,Independent,Combined,2423.0,-37.93863,145.149168
 Minaret College,46321.0,2022,SPRINGVALE,27.0,4.0,84.6,100.0,980.0,Independent,Combined,2423.0,-37.93863,145.149168
-Minaret College,,2023,OFFICER,26.0,1.3,91.4,98.0,,,,,,
-Minaret College,,2023,SPRINGVALE,25.0,2.9,88.0,100.0,,,,,,
+Minaret College,46321.0,2023,OFFICER,26.0,1.3,91.4,98.0,,,,,,
+Minaret College,46321.0,2023,SPRINGVALE,25.0,2.9,88.0,100.0,,,,,,
 Mirboo North Sec College,45426.0,2014,MIRBOO NORTH,29.0,2.6,85.0,100.0,999.0,Government,Secondary,337.0,-38.40018,146.148821
 Mirboo North Sec College,45426.0,2015,MIRBOO NORTH,28.0,4.1,70.0,97.0,991.0,Government,Secondary,323.0,-38.40018,146.148821
 Mirboo North Sec College,45426.0,2016,MIRBOO NORTH,30.0,7.8,82.0,97.0,993.0,Government,Secondary,318.0,-38.40018,146.148821
@@ -3245,7 +3338,7 @@ Mirboo North Sec College,45426.0,2019,MIRBOO NORTH,27.0,2.3,71.4,100.0,992.0,Gov
 Mirboo North Sec College,45426.0,2020,MIRBOO NORTH,26.0,1.9,75.0,100.0,994.0,Government,Secondary,367.0,-38.40018,146.148821
 Mirboo North Sec College,45426.0,2021,MIRBOO NORTH,28.0,2.3,53.1,91.0,995.0,Government,Secondary,381.0,-38.40018,146.148821
 Mirboo North Sec College,45426.0,2022,MIRBOO NORTH,24.0,3.5,51.9,96.0,1002.0,Government,Secondary,402.0,-38.40018,146.148821
-Mirboo North Sec College,,2023,MIRBOO NORTH,27.0,3.3,71.1,92.0,,,,,,
+Mirboo North Sec College,45426.0,2023,MIRBOO NORTH,27.0,3.3,71.1,92.0,,,,,,
 Monbulk College,45427.0,2014,MONBULK,26.0,1.7,87.0,100.0,1020.0,Government,Secondary,507.0,-37.88317535,145.42780676
 Monbulk College,45427.0,2015,MONBULK,27.0,4.2,86.0,98.0,1023.0,Government,Secondary,534.0,-37.88317535,145.42780676
 Monbulk College,45427.0,2016,MONBULK,28.0,4.5,84.0,98.0,1029.0,Government,Secondary,537.0,-37.88317535,145.42780676
@@ -3255,7 +3348,7 @@ Monbulk College,45427.0,2019,MONBULK,27.0,2.7,84.7,97.0,1027.0,Government,Second
 Monbulk College,45427.0,2020,MONBULK,27.0,5.6,57.6,97.0,1030.0,Government,Secondary,567.0,-37.88317535,145.42780676
 Monbulk College,45427.0,2021,MONBULK,27.0,4.0,51.6,94.0,1033.0,Government,Secondary,560.0,-37.88317535,145.42780676
 Monbulk College,45427.0,2022,MONBULK,25.0,1.3,70.8,94.0,1033.0,Government,Secondary,537.0,-37.88317535,145.42780676
-Monbulk College,,2023,MONBULK,25.0,4.9,35.8,92.0,,,,,,
+Monbulk College,45427.0,2023,MONBULK,25.0,4.9,35.8,92.0,,,,,,
 Monivae College,45893.0,2014,HAMILTON,30.0,5.9,74.0,100.0,1001.0,Catholic,Secondary,608.0,-37.74203709,142.04945362
 Monivae College,45893.0,2015,HAMILTON,29.0,3.3,69.0,100.0,1016.0,Catholic,Secondary,568.0,-37.74203709,142.04945362
 Monivae College,45893.0,2016,HAMILTON,30.0,4.9,69.0,99.0,1017.0,Catholic,Secondary,558.0,-37.74203709,142.04945362
@@ -3265,7 +3358,7 @@ Monivae College,45893.0,2019,HAMILTON,28.0,2.2,78.8,100.0,1018.0,Catholic,Second
 Monivae College,45893.0,2020,HAMILTON,28.0,4.5,75.8,100.0,1021.0,Catholic,Secondary,529.0,-37.74203709,142.04945362
 Monivae College,45893.0,2021,HAMILTON,28.0,3.5,62.7,100.0,1024.0,Catholic,Secondary,514.0,-37.74203709,142.04945362
 Monivae College,45893.0,2022,HAMILTON,28.0,3.2,57.7,100.0,1033.0,Catholic,Secondary,539.0,-37.74203709,142.04945362
-Monivae College,,2023,HAMILTON,27.0,3.4,58.3,100.0,,,,,,
+Monivae College,45893.0,2023,HAMILTON,27.0,3.4,58.3,100.0,,,,,,
 Monterey Secondary College,45547.0,2014,FRANKSTON NORTH,25.0,0.0,60.0,85.0,922.0,Government,Secondary,312.0,-38.12672883,145.14793052
 Monterey Secondary College,45547.0,2015,FRANKSTON NORTH,22.0,0.0,75.0,95.0,923.0,Government,Secondary,310.0,-38.12672883,145.14793052
 Monterey Secondary College,45547.0,2016,FRANKSTON NORTH,24.0,0.0,67.0,94.0,915.0,Government,Secondary,300.0,-38.12672883,145.14793052
@@ -3275,7 +3368,7 @@ Monterey Secondary College,45547.0,2019,FRANKSTON NORTH,25.0,4.3,41.2,76.0,938.0
 Monterey Secondary College,45547.0,2020,FRANKSTON NORTH,26.0,0.0,66.7,100.0,931.0,Government,Secondary,268.0,-38.12672883,145.14793052
 Monterey Secondary College,45547.0,2021,FRANKSTON NORTH,28.0,0.0,63.6,100.0,925.0,Government,Secondary,302.0,-38.12672883,145.14793052
 Monterey Secondary College,45547.0,2022,FRANKSTON NORTH,24.0,0.0,100.0,100.0,910.0,Government,Secondary,325.0,-38.12672883,145.14793052
-Monterey Secondary College,,2023,FRANKSTON NORTH,25.0,,22.2,96.0,,,,,,
+Monterey Secondary College,45547.0,2023,FRANKSTON NORTH,25.0,,22.2,96.0,,,,,,
 Montmorency Sec College,45428.0,2014,MONTMORENCY,29.0,4.3,90.0,99.0,1026.0,Government,Secondary,700.0,-37.714075,145.113611
 Montmorency Sec College,45428.0,2015,MONTMORENCY,30.0,5.6,90.0,98.0,1032.0,Government,Secondary,728.0,-37.714075,145.113611
 Montmorency Sec College,45428.0,2016,MONTMORENCY,30.0,8.0,89.0,100.0,1031.0,Government,Secondary,794.0,-37.714075,145.113611
@@ -3285,7 +3378,7 @@ Montmorency Sec College,45428.0,2019,MONTMORENCY,29.0,5.0,86.7,99.0,1042.0,Gover
 Montmorency Sec College,45428.0,2020,MONTMORENCY,29.0,4.5,96.4,99.0,1051.0,Government,Secondary,1121.0,-37.714075,145.113611
 Montmorency Sec College,45428.0,2021,MONTMORENCY,29.0,4.3,62.5,97.0,1055.0,Government,Secondary,1128.0,-37.714075,145.113611
 Montmorency Sec College,45428.0,2022,MONTMORENCY,28.0,4.3,80.0,100.0,1064.0,Government,Secondary,1122.0,-37.714075,145.113611
-Montmorency Sec College,,2023,MONTMORENCY,30.0,6.6,67.0,99.0,,,,,,
+Montmorency Sec College,45428.0,2023,MONTMORENCY,30.0,6.6,67.0,99.0,,,,,,
 Mooroolbark College,45429.0,2014,MOOROOLBARK,29.0,4.3,91.0,99.0,988.0,Government,Secondary,1096.0,-37.77508326,145.31423044
 Mooroolbark College,45429.0,2015,MOOROOLBARK,30.0,1.9,85.0,93.0,985.0,Government,Secondary,1073.0,-37.77508326,145.31423044
 Mooroolbark College,45429.0,2016,MOOROOLBARK,28.0,1.1,81.0,96.0,993.0,Government,Secondary,1148.0,-37.77508326,145.31423044
@@ -3295,13 +3388,13 @@ Mooroolbark College,45429.0,2019,MOOROOLBARK,28.0,4.9,69.3,91.0,995.0,Government
 Mooroolbark College,45429.0,2020,MOOROOLBARK,28.0,2.9,70.5,98.0,994.0,Government,Secondary,1164.0,-37.77508326,145.31423044
 Mooroolbark College,45429.0,2021,MOOROOLBARK,28.0,5.1,61.2,99.0,994.0,Government,Secondary,1168.0,-37.77508326,145.31423044
 Mooroolbark College,45429.0,2022,MOOROOLBARK,29.0,3.9,59.4,99.0,988.0,Government,Secondary,1052.0,-37.77508326,145.31423044
-Mooroolbark College,,2023,MOOROOLBARK,28.0,2.7,48.8,90.0,,,,,,
-Mooroopna Secondary College,45443.0,2014,MOOROOPNA,25.0,0.6,75.0,97.0,1024.0,Government,Secondary,1083.0,-37.800473,145.238246
-Mooroopna Secondary College,45443.0,2015,MOOROOPNA,26.0,2.0,54.0,88.0,1025.0,Government,Secondary,1088.0,-37.800473,145.238246
-Mooroopna Secondary College,45443.0,2016,MOOROOPNA,24.0,0.0,60.0,93.0,1026.0,Government,Secondary,1073.0,-37.800473,145.238246
-Mooroopna Secondary College,45443.0,2017,MOOROOPNA,23.0,1.3,62.0,97.0,1025.0,Government,Secondary,1043.0,-37.800473,145.238246
-Mooroopna Secondary College,45443.0,2018,MOOROOPNA,26.0,0.0,61.3,100.0,1028.0,Government,Secondary,1022.0,-37.800473,145.238246
-Mooroopna Secondary College,45443.0,2019,MOOROOPNA,22.0,0.0,54.5,91.0,1034.0,Government,Secondary,1013.0,-37.800473,145.238246
+Mooroolbark College,45429.0,2023,MOOROOLBARK,28.0,2.7,48.8,90.0,,,,,,
+Mooroopna Secondary College,53105.0,2014,MOOROOPNA,25.0,0.6,75.0,97.0,,,,,,
+Mooroopna Secondary College,53105.0,2015,MOOROOPNA,26.0,2.0,54.0,88.0,,,,,,
+Mooroopna Secondary College,53105.0,2016,MOOROOPNA,24.0,0.0,60.0,93.0,,,,,,
+Mooroopna Secondary College,53105.0,2017,MOOROOPNA,23.0,1.3,62.0,97.0,,,,,,
+Mooroopna Secondary College,53105.0,2018,MOOROOPNA,26.0,0.0,61.3,100.0,,,,,,
+Mooroopna Secondary College,53105.0,2019,MOOROOPNA,22.0,0.0,54.5,91.0,,,,,,
 Mordialloc College,45431.0,2014,MORDIALLOC,28.0,1.3,81.0,99.0,1011.0,Government,Secondary,566.0,-38.012301,145.09199
 Mordialloc College,45431.0,2015,MORDIALLOC,27.0,2.0,91.0,98.0,1018.0,Government,Secondary,617.0,-38.012301,145.09199
 Mordialloc College,45431.0,2016,MORDIALLOC,27.0,1.2,88.0,98.0,1021.0,Government,Secondary,669.0,-38.012301,145.09199
@@ -3311,7 +3404,7 @@ Mordialloc College,45431.0,2019,MORDIALLOC,29.0,3.9,87.7,98.0,1041.0,Government,
 Mordialloc College,45431.0,2020,MORDIALLOC,30.0,7.7,91.5,99.0,1046.0,Government,Secondary,1077.0,-38.012301,145.09199
 Mordialloc College,45431.0,2021,MORDIALLOC,28.0,6.7,88.7,99.0,1050.0,Government,Secondary,1103.0,-38.012301,145.09199
 Mordialloc College,45431.0,2022,MORDIALLOC,30.0,5.2,82.7,98.0,1055.0,Government,Secondary,1189.0,-38.012301,145.09199
-Mordialloc College,,2023,MORDIALLOC,30.0,6.4,65.4,96.0,,,,,,
+Mordialloc College,45431.0,2023,MORDIALLOC,30.0,6.4,65.4,96.0,,,,,,
 Mornington Secondary College,45542.0,2014,MORNINGTON,29.0,4.0,76.0,96.0,992.0,Government,Secondary,1399.0,-38.2182617,145.05881042
 Mornington Secondary College,45542.0,2015,MORNINGTON,27.0,2.1,66.0,98.0,998.0,Government,Secondary,1445.0,-38.2182617,145.05881042
 Mornington Secondary College,45542.0,2016,MORNINGTON,27.0,2.2,69.0,97.0,998.0,Government,Secondary,1534.0,-38.2182617,145.05881042
@@ -3321,7 +3414,7 @@ Mornington Secondary College,45542.0,2019,MORNINGTON,26.0,2.7,53.3,96.0,1016.0,G
 Mornington Secondary College,45542.0,2020,MORNINGTON,27.0,4.0,70.2,99.0,1014.0,Government,Secondary,1589.0,-38.2182617,145.05881042
 Mornington Secondary College,45542.0,2021,MORNINGTON,28.0,2.9,57.5,97.0,1014.0,Government,Secondary,1529.0,-38.2182617,145.05881042
 Mornington Secondary College,45542.0,2022,MORNINGTON,28.0,3.9,57.6,99.0,1006.0,Government,Secondary,1329.0,-38.2182617,145.05881042
-Mornington Secondary College,,2023,MORNINGTON,27.0,2.1,47.1,91.0,,,,,,
+Mornington Secondary College,45542.0,2023,MORNINGTON,27.0,2.1,47.1,91.0,,,,,,
 Mortlake College,45184.0,2014,MORTLAKE,27.0,4.8,64.0,100.0,970.0,Government,Combined,253.0,-38.086366,142.80955
 Mortlake College,45184.0,2015,MORTLAKE,30.0,5.0,64.0,100.0,989.0,Government,Combined,246.0,-38.086366,142.80955
 Mortlake College,45184.0,2016,MORTLAKE,35.0,14.3,56.0,100.0,980.0,Government,Combined,240.0,-38.086366,142.80955
@@ -3331,7 +3424,7 @@ Mortlake College,45184.0,2019,MORTLAKE,27.0,4.1,30.0,100.0,984.0,Government,Comb
 Mortlake College,45184.0,2020,MORTLAKE,33.0,4.3,83.3,100.0,982.0,Government,Combined,202.0,-38.086366,142.80955
 Mortlake College,45184.0,2021,MORTLAKE,32.0,5.1,80.0,100.0,986.0,Government,Combined,191.0,-38.086366,142.80955
 Mortlake College,45184.0,2022,MORTLAKE,31.0,2.9,85.7,100.0,973.0,Government,Combined,174.0,-38.086366,142.80955
-Mortlake College,,2023,MORTLAKE,31.0,3.6,40.0,100.0,,,,,,
+Mortlake College,45184.0,2023,MORTLAKE,31.0,3.6,40.0,100.0,,,,,,
 Mount Alexander 7-12 Coll,45375.0,2014,FLEMINGTON,25.0,1.9,63.0,78.0,959.0,Government,Secondary,317.0,-37.782458,144.933057
 Mount Alexander 7-12 Coll,45375.0,2015,FLEMINGTON,26.0,3.9,91.0,88.0,959.0,Government,Secondary,319.0,-37.782458,144.933057
 Mount Alexander 7-12 Coll,45375.0,2016,FLEMINGTON,23.0,4.2,79.0,96.0,952.0,Government,Secondary,324.0,-37.782458,144.933057
@@ -3341,7 +3434,7 @@ Mount Alexander 7-12 Coll,45375.0,2019,FLEMINGTON,27.0,2.2,88.5,100.0,1030.0,Gov
 Mount Alexander 7-12 Coll,45375.0,2020,FLEMINGTON,31.0,3.8,77.3,95.0,1047.0,Government,Secondary,507.0,-37.782458,144.933057
 Mount Alexander 7-12 Coll,45375.0,2021,FLEMINGTON,28.0,2.7,74.4,95.0,1052.0,Government,Secondary,586.0,-37.782458,144.933057
 Mount Alexander 7-12 Coll,45375.0,2022,FLEMINGTON,29.0,5.0,76.1,89.0,1065.0,Government,Secondary,628.0,-37.782458,144.933057
-Mount Alexander 7-12 Coll,,2023,FLEMINGTON,29.0,6.8,66.2,96.0,,,,,,
+Mount Alexander 7-12 Coll,45375.0,2023,FLEMINGTON,29.0,6.8,66.2,96.0,,,,,,
 Mount Beauty Sec College,45432.0,2014,MOUNT BEAUTY,28.0,3.8,68.0,100.0,1016.0,Government,Secondary,174.0,-36.740307,147.167284
 Mount Beauty Sec College,45432.0,2015,MOUNT BEAUTY,29.0,6.2,70.0,100.0,1018.0,Government,Secondary,163.0,-36.740307,147.167284
 Mount Beauty Sec College,45432.0,2016,MOUNT BEAUTY,31.0,3.6,71.0,96.0,1023.0,Government,Secondary,170.0,-36.740307,147.167284
@@ -3351,7 +3444,7 @@ Mount Beauty Sec College,45432.0,2019,MOUNT BEAUTY,26.0,2.0,64.7,100.0,1043.0,Go
 Mount Beauty Sec College,45432.0,2020,MOUNT BEAUTY,28.0,2.7,72.7,91.0,1052.0,Government,Secondary,185.0,-36.740307,147.167284
 Mount Beauty Sec College,45432.0,2021,MOUNT BEAUTY,26.0,1.2,47.4,79.0,1052.0,Government,Secondary,197.0,-36.740307,147.167284
 Mount Beauty Sec College,45432.0,2022,MOUNT BEAUTY,27.0,2.6,57.1,100.0,1049.0,Government,Secondary,173.0,-36.740307,147.167284
-Mount Beauty Sec College,,2023,MOUNT BEAUTY,28.0,2.9,53.3,100.0,,,,,,
+Mount Beauty Sec College,45432.0,2023,MOUNT BEAUTY,28.0,2.9,53.3,100.0,,,,,,
 Mount Clear College,45339.0,2014,MOUNT CLEAR,27.0,2.1,55.0,91.0,968.0,Government,Secondary,1058.0,-37.60741829,143.8767265
 Mount Clear College,45339.0,2015,MOUNT CLEAR,24.0,2.0,53.0,90.0,972.0,Government,Secondary,1059.0,-37.60741829,143.8767265
 Mount Clear College,45339.0,2016,MOUNT CLEAR,25.0,2.2,55.0,85.0,967.0,Government,Secondary,1018.0,-37.60741829,143.8767265
@@ -3361,7 +3454,7 @@ Mount Clear College,45339.0,2019,MOUNT CLEAR,26.0,1.6,56.0,91.0,983.0,Government
 Mount Clear College,45339.0,2020,MOUNT CLEAR,27.0,2.1,75.3,97.0,990.0,Government,Secondary,1063.0,-37.60741829,143.8767265
 Mount Clear College,45339.0,2021,MOUNT CLEAR,27.0,0.3,45.1,93.0,990.0,Government,Secondary,1075.0,-37.60741829,143.8767265
 Mount Clear College,45339.0,2022,MOUNT CLEAR,28.0,2.3,73.8,97.0,989.0,Government,Secondary,1055.0,-37.60741829,143.8767265
-Mount Clear College,,2023,MOUNT CLEAR,26.0,3.4,50.0,93.0,,,,,,
+Mount Clear College,45339.0,2023,MOUNT CLEAR,26.0,3.4,50.0,93.0,,,,,,
 Mount Eliza Sec College,45433.0,2014,MOUNT ELIZA,30.0,5.4,92.0,97.0,1033.0,Government,Secondary,620.0,-38.190138,145.093813
 Mount Eliza Sec College,45433.0,2015,MOUNT ELIZA,28.0,5.5,82.0,94.0,1038.0,Government,Secondary,551.0,-38.190138,145.093813
 Mount Eliza Sec College,45433.0,2016,MOUNT ELIZA,30.0,4.7,93.0,100.0,1038.0,Government,Secondary,505.0,-38.190138,145.093813
@@ -3371,17 +3464,17 @@ Mount Eliza Sec College,45433.0,2019,MOUNT ELIZA,28.0,5.4,83.3,98.0,1048.0,Gover
 Mount Eliza Sec College,45433.0,2020,MOUNT ELIZA,31.0,6.2,92.2,96.0,1052.0,Government,Secondary,569.0,-38.190138,145.093813
 Mount Eliza Sec College,45433.0,2021,MOUNT ELIZA,30.0,6.5,89.0,99.0,1053.0,Government,Secondary,662.0,-38.190138,145.093813
 Mount Eliza Sec College,45433.0,2022,MOUNT ELIZA,29.0,5.4,89.7,100.0,1057.0,Government,Secondary,697.0,-38.190138,145.093813
-Mount Eliza Sec College,,2023,MOUNT ELIZA,29.0,3.7,59.3,99.0,,,,,,
-Mount Erin College,45339.0,2014,FRANKSTON,29.0,3.6,79.0,91.0,968.0,Government,Secondary,1058.0,-37.60741829,143.8767265
-Mount Erin College,45339.0,2015,FRANKSTON,30.0,3.4,86.0,100.0,972.0,Government,Secondary,1059.0,-37.60741829,143.8767265
-Mount Erin College,45339.0,2016,FRANKSTON,28.0,3.6,68.0,93.0,967.0,Government,Secondary,1018.0,-37.60741829,143.8767265
-Mount Erin College,45339.0,2017,FRANKSTON,27.0,0.9,69.0,99.0,963.0,Government,Secondary,1059.0,-37.60741829,143.8767265
-Mount Erin College,45339.0,2018,FRANKSTON,28.0,1.6,91.4,97.0,973.0,Government,Secondary,1032.0,-37.60741829,143.8767265
-Mount Erin College,45339.0,2019,FRANKSTON,28.0,2.0,64.9,95.0,983.0,Government,Secondary,1074.0,-37.60741829,143.8767265
-Mount Erin College,45339.0,2020,FRANKSTON,27.0,1.0,69.9,96.0,990.0,Government,Secondary,1063.0,-37.60741829,143.8767265
-Mount Erin College,45339.0,2021,FRANKSTON,27.0,0.7,54.5,94.0,990.0,Government,Secondary,1075.0,-37.60741829,143.8767265
-Mount Erin College,45339.0,2022,FRANKSTON SOUTH,26.0,1.3,70.2,96.0,989.0,Government,Secondary,1055.0,-37.60741829,143.8767265
-Mount Erin College,,2023,FRANKSTON SOUTH,26.0,0.8,45.7,99.0,,,,,,
+Mount Eliza Sec College,45433.0,2023,MOUNT ELIZA,29.0,3.7,59.3,99.0,,,,,,
+Mount Erin College,45324.0,2014,FRANKSTON,29.0,3.6,79.0,91.0,981.0,Government,Secondary,867.0,-38.173964,145.146081
+Mount Erin College,45324.0,2015,FRANKSTON,30.0,3.4,86.0,100.0,974.0,Government,Secondary,895.0,-38.173964,145.146081
+Mount Erin College,45324.0,2016,FRANKSTON,28.0,3.6,68.0,93.0,981.0,Government,Secondary,966.0,-38.173964,145.146081
+Mount Erin College,45324.0,2017,FRANKSTON,27.0,0.9,69.0,99.0,986.0,Government,Secondary,887.0,-38.173964,145.146081
+Mount Erin College,45324.0,2018,FRANKSTON,28.0,1.6,91.4,97.0,989.0,Government,Secondary,898.0,-38.173964,145.146081
+Mount Erin College,45324.0,2019,FRANKSTON,28.0,2.0,64.9,95.0,996.0,Government,Secondary,891.0,-38.173964,145.146081
+Mount Erin College,45324.0,2020,FRANKSTON,27.0,1.0,69.9,96.0,994.0,Government,Secondary,896.0,-38.173964,145.146081
+Mount Erin College,45324.0,2021,FRANKSTON,27.0,0.7,54.5,94.0,993.0,Government,Secondary,905.0,-38.173964,145.146081
+Mount Erin College,45324.0,2022,FRANKSTON SOUTH,26.0,1.3,70.2,96.0,988.0,Government,Secondary,807.0,-38.173964,145.146081
+Mount Erin College,45324.0,2023,FRANKSTON SOUTH,26.0,0.8,45.7,99.0,,,,,,
 Mount Evelyn Christian School,46229.0,2014,MOUNT EVELYN,30.0,5.7,81.0,100.0,1054.0,Independent,Combined,619.0,-37.79883442,145.3670969
 Mount Evelyn Christian School,46229.0,2015,MOUNT EVELYN,31.0,6.6,90.0,100.0,1067.0,Independent,Combined,615.0,-37.79883442,145.3670969
 Mount Evelyn Christian School,46229.0,2016,MOUNT EVELYN,29.0,3.2,82.0,100.0,1051.0,Independent,Combined,625.0,-37.79883442,145.3670969
@@ -3391,7 +3484,7 @@ Mount Evelyn Christian School,46229.0,2019,MOUNT EVELYN,29.0,4.5,67.6,100.0,1060
 Mount Evelyn Christian School,46229.0,2020,MOUNT EVELYN,31.0,9.8,73.7,97.0,1060.0,Independent,Combined,693.0,-37.79883442,145.3670969
 Mount Evelyn Christian School,46229.0,2021,MOUNT EVELYN,28.0,4.7,60.0,100.0,1058.0,Independent,Combined,728.0,-37.79883442,145.3670969
 Mount Evelyn Christian School,46229.0,2022,MOUNT EVELYN,29.0,3.9,76.5,100.0,1060.0,Independent,Combined,695.0,-37.79883442,145.3670969
-Mount Evelyn Christian School,,2023,MOUNT EVELYN,31.0,1.9,37.0,98.0,,,,,,
+Mount Evelyn Christian School,46229.0,2023,MOUNT EVELYN,31.0,1.9,37.0,98.0,,,,,,
 Mount Lilydale Mercy College,45706.0,2014,LILYDALE,30.0,6.7,88.0,100.0,1019.0,Catholic,Secondary,1449.0,-37.75075881,145.3577545
 Mount Lilydale Mercy College,45706.0,2015,LILYDALE,30.0,4.8,86.0,99.0,1025.0,Catholic,Secondary,1446.0,-37.75075881,145.3577545
 Mount Lilydale Mercy College,45706.0,2016,LILYDALE,30.0,6.1,90.0,98.0,1024.0,Catholic,Secondary,1455.0,-37.75075881,145.3577545
@@ -3401,7 +3494,7 @@ Mount Lilydale Mercy College,45706.0,2019,LILYDALE,29.0,1.8,82.3,100.0,1035.0,Ca
 Mount Lilydale Mercy College,45706.0,2020,LILYDALE,28.0,2.4,77.1,99.0,1036.0,Catholic,Secondary,1475.0,-37.75075881,145.3577545
 Mount Lilydale Mercy College,45706.0,2021,LILYDALE,30.0,4.0,81.3,99.0,1035.0,Catholic,Secondary,1484.0,-37.75075881,145.3577545
 Mount Lilydale Mercy College,45706.0,2022,LILYDALE,29.0,3.9,77.0,99.0,1038.0,Catholic,Secondary,1488.0,-37.75075881,145.3577545
-Mount Lilydale Mercy College,,2023,LILYDALE,29.0,4.0,69.6,100.0,,,,,,
+Mount Lilydale Mercy College,45706.0,2023,LILYDALE,29.0,4.0,69.6,100.0,,,,,,
 Mount Ridley P-12 College,45585.0,2014,CRAIGIEBURN,29.0,10.7,,,971.0,Government,Combined,1768.0,-37.58027078,144.92342175
 Mount Ridley P-12 College,45585.0,2015,CRAIGIEBURN,24.0,0.9,87.0,98.0,969.0,Government,Combined,1951.0,-37.58027078,144.92342175
 Mount Ridley P-12 College,45585.0,2016,CRAIGIEBURN,24.0,0.7,94.0,99.0,969.0,Government,Combined,2040.0,-37.58027078,144.92342175
@@ -3411,12 +3504,12 @@ Mount Ridley P-12 College,45585.0,2019,CRAIGIEBURN,25.0,0.7,96.6,99.0,972.0,Gove
 Mount Ridley P-12 College,45585.0,2020,CRAIGIEBURN,25.0,0.7,95.7,100.0,972.0,Government,Combined,2561.0,-37.58027078,144.92342175
 Mount Ridley P-12 College,45585.0,2021,CRAIGIEBURN,25.0,2.0,79.6,97.0,973.0,Government,Combined,2628.0,-37.58027078,144.92342175
 Mount Ridley P-12 College,45585.0,2022,CRAIGIEBURN,23.0,0.6,81.8,95.0,965.0,Government,Combined,2718.0,-37.58027078,144.92342175
-Mount Ridley P-12 College,,2023,CRAIGIEBURN,25.0,2.2,76.8,97.0,,,,,,
+Mount Ridley P-12 College,45585.0,2023,CRAIGIEBURN,25.0,2.2,76.8,97.0,,,,,,
 Mount Rowan Secondary College,45565.0,2019,WENDOUREE,26.0,2.3,50.0,100.0,931.0,Government,Secondary,372.0,-37.51987872,143.83419003
 Mount Rowan Secondary College,45565.0,2020,WENDOUREE,25.0,0.0,81.8,100.0,936.0,Government,Secondary,412.0,-37.51987872,143.83419003
 Mount Rowan Secondary College,45565.0,2021,WENDOUREE,29.0,0.0,60.0,100.0,937.0,Government,Secondary,464.0,-37.51987872,143.83419003
 Mount Rowan Secondary College,45565.0,2022,WENDOUREE,26.0,5.8,53.3,87.0,932.0,Government,Secondary,565.0,-37.51987872,143.83419003
-Mount Rowan Secondary College,,2023,WENDOUREE,27.0,1.4,60.9,96.0,,,,,,
+Mount Rowan Secondary College,45565.0,2023,WENDOUREE,27.0,1.4,60.9,96.0,,,,,,
 Mount Scopus Memorial College,46208.0,2014,BURWOOD,38.0,40.1,99.0,100.0,1173.0,Independent,Combined,1003.0,-37.847216,145.117774
 Mount Scopus Memorial College,46208.0,2015,BURWOOD,37.0,35.0,99.0,99.0,1178.0,Independent,Combined,964.0,-37.847216,145.117774
 Mount Scopus Memorial College,46208.0,2016,BURWOOD,37.0,35.4,99.0,100.0,1174.0,Independent,Combined,1283.0,-37.847216,145.117774
@@ -3426,7 +3519,7 @@ Mount Scopus Memorial College,46208.0,2019,BURWOOD,38.0,37.4,98.0,100.0,1173.0,I
 Mount Scopus Memorial College,46208.0,2020,BURWOOD,38.0,39.7,99.0,100.0,1171.0,Independent,Combined,1302.0,-37.847216,145.117774
 Mount Scopus Memorial College,46208.0,2021,BURWOOD,36.0,31.9,97.4,100.0,1169.0,Independent,Combined,1284.0,-37.847216,145.117774
 Mount Scopus Memorial College,46208.0,2022,BURWOOD,37.0,31.4,100.0,100.0,1167.0,Independent,Combined,1263.0,-37.847216,145.117774
-Mount Scopus Memorial College,,2023,BURWOOD,37.0,31.5,100.0,100.0,,,,,,
+Mount Scopus Memorial College,46208.0,2023,BURWOOD,37.0,31.5,100.0,100.0,,,,,,
 Mount St Joseph Girls' College,45964.0,2014,ALTONA,31.0,5.4,100.0,99.0,1050.0,Catholic,Secondary,918.0,-37.863902,144.811674
 Mount St Joseph Girls' College,45964.0,2015,ALTONA,30.0,3.9,98.0,99.0,1047.0,Catholic,Secondary,889.0,-37.863902,144.811674
 Mount St Joseph Girls' College,45964.0,2016,ALTONA,30.0,6.1,99.0,99.0,1051.0,Catholic,Secondary,917.0,-37.863902,144.811674
@@ -3436,7 +3529,7 @@ Mount St Joseph Girls' College,45964.0,2019,ALTONA,31.0,10.3,93.9,99.0,1072.0,Ca
 Mount St Joseph Girls' College,45964.0,2020,ALTONA,31.0,8.6,99.1,100.0,1070.0,Catholic,Secondary,1056.0,-37.863902,144.811674
 Mount St Joseph Girls' College,45964.0,2021,ALTONA,31.0,6.5,95.8,100.0,1078.0,Catholic,Secondary,1128.0,-37.863902,144.811674
 Mount St Joseph Girls' College,45964.0,2022,ALTONA,30.0,5.8,90.4,100.0,1085.0,Catholic,Secondary,1153.0,-37.863902,144.811674
-Mount St Joseph Girls' College,,2023,ALTONA,30.0,7.8,84.3,99.0,,,,,,
+Mount St Joseph Girls' College,45964.0,2023,ALTONA,30.0,7.8,84.3,99.0,,,,,,
 Mount Waverley Sec College,45434.0,2014,MOUNT WAVERLEY,31.0,11.5,96.0,99.0,1083.0,Government,Secondary,1804.0,-37.86879,145.13163
 Mount Waverley Sec College,45434.0,2015,MOUNT WAVERLEY,31.0,8.7,97.0,99.0,1093.0,Government,Secondary,1820.0,-37.86879,145.13163
 Mount Waverley Sec College,45434.0,2016,MOUNT WAVERLEY,31.0,7.8,97.0,100.0,1098.0,Government,Secondary,1844.0,-37.86879,145.13163
@@ -3446,7 +3539,7 @@ Mount Waverley Sec College,45434.0,2019,MOUNT WAVERLEY,32.0,8.4,94.6,99.0,1095.0
 Mount Waverley Sec College,45434.0,2020,MOUNT WAVERLEY,31.0,8.1,94.3,100.0,1104.0,Government,Secondary,1841.0,-37.86879,145.13163
 Mount Waverley Sec College,45434.0,2021,MOUNT WAVERLEY,30.0,8.3,90.2,100.0,1105.0,Government,Secondary,1774.0,-37.86879,145.13163
 Mount Waverley Sec College,45434.0,2022,MOUNT WAVERLEY,30.0,6.7,93.2,99.0,1112.0,Government,Secondary,1790.0,-37.86879,145.13163
-Mount Waverley Sec College,,2023,MOUNT WAVERLEY,31.0,7.4,89.3,100.0,,,,,,
+Mount Waverley Sec College,45434.0,2023,MOUNT WAVERLEY,31.0,7.4,89.3,100.0,,,,,,
 Mountain District Christian SC,46258.0,2015,MONBULK,28.0,1.4,92.0,100.0,1046.0,Independent,Combined,264.0,-37.85664819,145.4527149
 Mountain District Christian SC,46258.0,2016,MONBULK,28.0,2.8,67.0,100.0,1048.0,Independent,Combined,237.0,-37.85664819,145.4527149
 Mountain District Christian SC,46258.0,2017,MONBULK,30.0,2.9,57.0,93.0,1037.0,Independent,Combined,203.0,-37.85664819,145.4527149
@@ -3457,7 +3550,7 @@ Mountain District Christian SC,46258.0,2021,MONBULK,27.0,7.7,33.3,100.0,1059.0,I
 Mountain District Christian SC,46258.0,2022,MONBULK,29.0,4.7,75.0,100.0,1062.0,Independent,Combined,160.0,-37.85664819,145.4527149
 Mountain District Christian Schl,46258.0,2014,MONBULK,26.0,7.1,81.0,100.0,1064.0,Independent,Combined,271.0,-37.85664819,145.4527149
 Mountain District Comm College,53091.0,2022,FERNTREE GULLY,,,,,997.0,Independent,Secondary,52.0,-37.8830903439396,145.293394497312
-Mountain District Comm College,,2023,FERNTREE GULLY,,,,64.0,,,,,,
+Mountain District Comm College,53091.0,2023,FERNTREE GULLY,,,,64.0,,,,,,
 Mountain District Learn Centre,,2018,FERNTREE GULLY,,,,,,,,,,
 Mountain District Learn Centre,,2019,FERNTREE GULLY,,,,,,,,,,
 Mountain District Learn Centre,,2020,FERNTREE GULLY,,,,,,,,,,
@@ -3475,7 +3568,7 @@ Mt Hira College,46359.0,2019,KEYSBOROUGH,25.0,2.4,100.0,100.0,1017.0,Independent
 Mt Hira College,46359.0,2020,KEYSBOROUGH,26.0,3.5,90.3,100.0,1017.0,Independent,Combined,611.0,-38.013991,145.175471
 Mt Hira College,46359.0,2021,KEYSBOROUGH,31.0,5.0,100.0,100.0,1006.0,Independent,Combined,657.0,-38.013991,145.175471
 Mt Hira College,46359.0,2022,KEYSBOROUGH,29.0,2.3,66.7,100.0,998.0,Independent,Combined,725.0,-38.013991,145.175471
-Mt Hira College,,2023,KEYSBOROUGH,28.0,3.0,69.0,100.0,,,,,,
+Mt Hira College,46359.0,2023,KEYSBOROUGH,28.0,3.0,69.0,100.0,,,,,,
 Mullauna College,45519.0,2014,MITCHAM,30.0,6.3,89.0,98.0,1017.0,Government,Secondary,517.0,-37.80685322,145.19031295
 Mullauna College,45519.0,2015,MITCHAM,28.0,5.2,90.0,99.0,1018.0,Government,Secondary,478.0,-37.80685322,145.19031295
 Mullauna College,45519.0,2016,MITCHAM,31.0,8.8,97.0,100.0,1017.0,Government,Secondary,467.0,-37.80685322,145.19031295
@@ -3485,7 +3578,7 @@ Mullauna College,45519.0,2019,MITCHAM,29.0,4.0,83.9,100.0,1052.0,Government,Seco
 Mullauna College,45519.0,2020,MITCHAM,28.0,3.3,86.4,98.0,1054.0,Government,Secondary,498.0,-37.80685322,145.19031295
 Mullauna College,45519.0,2021,MITCHAM,29.0,7.9,84.3,100.0,1059.0,Government,Secondary,513.0,-37.80685322,145.19031295
 Mullauna College,45519.0,2022,MITCHAM,30.0,9.6,65.9,95.0,1056.0,Government,Secondary,512.0,-37.80685322,145.19031295
-Mullauna College,,2023,MITCHAM,31.0,5.3,73.6,87.0,,,,,,
+Mullauna College,45519.0,2023,MITCHAM,31.0,5.3,73.6,87.0,,,,,,
 Murrayville Community College,45223.0,2014,MURRAYVILLE,26.0,0.0,75.0,88.0,1007.0,Government,Combined,114.0,-35.26557452,141.17733647
 Murrayville Community College,45223.0,2015,MURRAYVILLE,29.0,2.5,73.0,100.0,999.0,Government,Combined,113.0,-35.26557452,141.17733647
 Murrayville Community College,45223.0,2016,MURRAYVILLE,32.0,22.9,67.0,100.0,1000.0,Government,Combined,120.0,-35.26557452,141.17733647
@@ -3495,17 +3588,17 @@ Murrayville Community College,45223.0,2019,MURRAYVILLE,27.0,10.3,71.4,100.0,994.
 Murrayville Community College,45223.0,2020,MURRAYVILLE,29.0,0.0,75.0,75.0,991.0,Government,Combined,92.0,-35.26557452,141.17733647
 Murrayville Community College,45223.0,2021,MURRAYVILLE,28.0,0.0,50.0,100.0,999.0,Government,Combined,89.0,-35.26557452,141.17733647
 Murrayville Community College,45223.0,2022,MURRAYVILLE,21.0,0.0,40.0,100.0,992.0,Government,Combined,82.0,-35.26557452,141.17733647
-Murrayville Community College,,2023,MURRAYVILLE,22.0,,,100.0,,,,,,
-Murtoa P-12 College,45184.0,2014,MURTOA,30.0,9.0,83.0,100.0,970.0,Government,Combined,253.0,-38.086366,142.80955
-Murtoa P-12 College,45184.0,2015,MURTOA,32.0,6.5,63.0,100.0,989.0,Government,Combined,246.0,-38.086366,142.80955
-Murtoa P-12 College,45184.0,2016,MURTOA,29.0,4.3,80.0,95.0,980.0,Government,Combined,240.0,-38.086366,142.80955
-Murtoa P-12 College,45184.0,2017,MURTOA,28.0,2.4,84.0,96.0,971.0,Government,Combined,242.0,-38.086366,142.80955
-Murtoa P-12 College,45184.0,2018,MURTOA,29.0,8.9,75.0,94.0,976.0,Government,Combined,223.0,-38.086366,142.80955
-Murtoa P-12 College,45184.0,2019,MURTOA,28.0,3.0,64.3,86.0,984.0,Government,Combined,224.0,-38.086366,142.80955
-Murtoa P-12 College,45184.0,2020,MURTOA,26.0,3.9,53.3,100.0,982.0,Government,Combined,202.0,-38.086366,142.80955
-Murtoa P-12 College,45184.0,2021,MURTOA,28.0,3.2,92.3,100.0,986.0,Government,Combined,191.0,-38.086366,142.80955
-Murtoa P-12 College,45184.0,2022,MURTOA,24.0,1.2,61.1,94.0,973.0,Government,Combined,174.0,-38.086366,142.80955
-Murtoa P-12 College,,2023,MURTOA,26.0,6.0,80.0,90.0,,,,,,
+Murrayville Community College,45223.0,2023,MURRAYVILLE,22.0,,,100.0,,,,,,
+Murtoa P-12 College,44306.0,2014,MURTOA,30.0,9.0,83.0,100.0,969.0,Government,Combined,276.0,-36.623495,142.475745
+Murtoa P-12 College,44306.0,2015,MURTOA,32.0,6.5,63.0,100.0,979.0,Government,Combined,271.0,-36.623495,142.475745
+Murtoa P-12 College,44306.0,2016,MURTOA,29.0,4.3,80.0,95.0,975.0,Government,Combined,268.0,-36.623495,142.475745
+Murtoa P-12 College,44306.0,2017,MURTOA,28.0,2.4,84.0,96.0,975.0,Government,Combined,264.0,-36.623495,142.475745
+Murtoa P-12 College,44306.0,2018,MURTOA,29.0,8.9,75.0,94.0,956.0,Government,Combined,265.0,-36.623495,142.475745
+Murtoa P-12 College,44306.0,2019,MURTOA,28.0,3.0,64.3,86.0,973.0,Government,Combined,261.0,-36.623495,142.475745
+Murtoa P-12 College,44306.0,2020,MURTOA,26.0,3.9,53.3,100.0,973.0,Government,Combined,273.0,-36.623495,142.475745
+Murtoa P-12 College,44306.0,2021,MURTOA,28.0,3.2,92.3,100.0,965.0,Government,Combined,272.0,-36.623495,142.475745
+Murtoa P-12 College,44306.0,2022,MURTOA,24.0,1.2,61.1,94.0,948.0,Government,Combined,261.0,-36.623495,142.475745
+Murtoa P-12 College,44306.0,2023,MURTOA,26.0,6.0,80.0,90.0,,,,,,
 Myrtleford P-12 College,40584.0,2014,MYRTLEFORD,26.0,3.4,73.0,91.0,954.0,Government,Combined,267.0,-36.54888702,146.72614474
 Myrtleford P-12 College,40584.0,2015,MYRTLEFORD,25.0,1.4,100.0,100.0,957.0,Government,Combined,295.0,-36.54888702,146.72614474
 Myrtleford P-12 College,40584.0,2016,MYRTLEFORD,28.0,0.0,70.0,100.0,967.0,Government,Combined,319.0,-36.54888702,146.72614474
@@ -3515,7 +3608,7 @@ Myrtleford P-12 College,40584.0,2019,MYRTLEFORD,31.0,4.0,33.3,100.0,978.0,Govern
 Myrtleford P-12 College,40584.0,2020,MYRTLEFORD,28.0,3.9,75.0,100.0,979.0,Government,Combined,380.0,-36.54888702,146.72614474
 Myrtleford P-12 College,40584.0,2021,MYRTLEFORD,28.0,0.0,72.7,100.0,988.0,Government,Combined,383.0,-36.54888702,146.72614474
 Myrtleford P-12 College,40584.0,2022,MYRTLEFORD,29.0,2.3,53.8,100.0,992.0,Government,Combined,363.0,-36.54888702,146.72614474
-Myrtleford P-12 College,,2023,MYRTLEFORD,30.0,2.1,44.4,100.0,,,,,,
+Myrtleford P-12 College,40584.0,2023,MYRTLEFORD,30.0,2.1,44.4,100.0,,,,,,
 Nagle College,45933.0,2014,BAIRNSDALE,29.0,4.1,70.0,99.0,1004.0,Catholic,Secondary,971.0,-37.837096,147.587656
 Nagle College,45933.0,2015,BAIRNSDALE,28.0,2.9,66.0,100.0,998.0,Catholic,Secondary,915.0,-37.837096,147.587656
 Nagle College,45933.0,2016,BAIRNSDALE,27.0,2.0,64.0,100.0,1006.0,Catholic,Secondary,852.0,-37.837096,147.587656
@@ -3525,7 +3618,12 @@ Nagle College,45933.0,2019,BAIRNSDALE,29.0,3.1,67.1,97.0,1014.0,Catholic,Seconda
 Nagle College,45933.0,2020,BAIRNSDALE,29.0,3.0,59.5,97.0,1016.0,Catholic,Secondary,823.0,-37.837096,147.587656
 Nagle College,45933.0,2021,BAIRNSDALE,28.0,2.6,63.4,100.0,1016.0,Catholic,Secondary,812.0,-37.837096,147.587656
 Nagle College,45933.0,2022,BAIRNSDALE,28.0,2.1,61.2,100.0,1019.0,Catholic,Secondary,827.0,-37.837096,147.587656
-Nagle College,,2023,BAIRNSDALE,28.0,3.0,38.0,95.0,,,,,,
+Nagle College,45933.0,2023,BAIRNSDALE,28.0,3.0,38.0,95.0,,,,,,
+Narre Community Learn Centre,,2014,NARRE WARREN,,,,,,,,,,
+Narre Community Learn Centre,,2015,NARRE WARREN,,,,,,,,,,
+Narre Community Learn Centre,,2016,NARRE WARREN,,,,,,,,,,
+Narre Community Learn Centre,,2017,NARRE WARREN,,,,,,,,,,
+Narre Community Learn Centre,,2018,NARRE WARREN,,,,,,,,,,
 Narre Warren Sth P-12 College,45573.0,2014,NARRE WARREN SOUTH,31.0,5.4,97.0,97.0,948.0,Government,Combined,1906.0,-38.04991303,145.28574201
 Narre Warren Sth P-12 College,45573.0,2015,NARRE WARREN SOUTH,31.0,3.0,97.0,98.0,951.0,Government,Combined,1940.0,-38.04991303,145.28574201
 Narre Warren Sth P-12 College,45573.0,2016,NARRE WARREN SOUT,30.0,4.6,98.0,100.0,948.0,Government,Combined,2026.0,-38.04991303,145.28574201
@@ -3535,7 +3633,7 @@ Narre Warren Sth P-12 College,45573.0,2019,NARRE WARREN SOUTH,32.0,8.2,98.2,100.
 Narre Warren Sth P-12 College,45573.0,2020,NARRE WARREN SOUTH,33.0,13.4,100.0,100.0,940.0,Government,Combined,2459.0,-38.04991303,145.28574201
 Narre Warren Sth P-12 College,45573.0,2021,NARRE WARREN SOUTH,32.0,6.1,99.0,97.0,938.0,Government,Combined,2530.0,-38.04991303,145.28574201
 Narre Warren Sth P-12 College,45573.0,2022,NARRE WARREN SOUTH,30.0,1.1,90.0,96.0,927.0,Government,Combined,2597.0,-38.04991303,145.28574201
-Narre Warren Sth P-12 College,,2023,NARRE WARREN SOUTH,27.0,1.1,65.8,96.0,,,,,,
+Narre Warren Sth P-12 College,45573.0,2023,NARRE WARREN SOUTH,27.0,1.1,65.8,96.0,,,,,,
 Nathalia Secondary College,45438.0,2014,NATHALIA,31.0,4.5,88.0,100.0,939.0,Government,Secondary,126.0,-36.059901,145.208438
 Nathalia Secondary College,45438.0,2015,NATHALIA,25.0,0.0,43.0,100.0,927.0,Government,Secondary,139.0,-36.059901,145.208438
 Nathalia Secondary College,45438.0,2016,NATHALIA,23.0,2.0,27.0,100.0,931.0,Government,Secondary,134.0,-36.059901,145.208438
@@ -3545,7 +3643,7 @@ Nathalia Secondary College,45438.0,2019,NATHALIA,22.0,0.0,33.3,100.0,931.0,Gover
 Nathalia Secondary College,45438.0,2020,NATHALIA,28.0,0.0,42.9,100.0,933.0,Government,Secondary,115.0,-36.059901,145.208438
 Nathalia Secondary College,45438.0,2021,NATHALIA,25.0,0.0,33.3,83.0,933.0,Government,Secondary,112.0,-36.059901,145.208438
 Nathalia Secondary College,45438.0,2022,NATHALIA,31.0,12.5,30.0,100.0,934.0,Government,Secondary,108.0,-36.059901,145.208438
-Nathalia Secondary College,,2023,NATHALIA,20.0,,7.7,85.0,,,,,,
+Nathalia Secondary College,45438.0,2023,NATHALIA,20.0,,7.7,85.0,,,,,,
 Nazareth College,46079.0,2014,NOBLE PARK NORTH,29.0,3.9,97.0,97.0,1024.0,Catholic,Secondary,809.0,-37.940226,145.195459
 Nazareth College,46079.0,2015,NOBLE PARK NORTH,30.0,4.2,94.0,99.0,1023.0,Catholic,Secondary,760.0,-37.940226,145.195459
 Nazareth College,46079.0,2016,NOBLE PARK NORTH,31.0,5.4,97.0,100.0,1022.0,Catholic,Secondary,712.0,-37.940226,145.195459
@@ -3555,7 +3653,7 @@ Nazareth College,46079.0,2019,NOBLE PARK NORTH,29.0,5.9,94.0,100.0,1025.0,Cathol
 Nazareth College,46079.0,2020,NOBLE PARK NORTH,29.0,9.1,93.6,100.0,1028.0,Catholic,Secondary,650.0,-37.940226,145.195459
 Nazareth College,46079.0,2021,NOBLE PARK NORTH,30.0,5.6,88.0,100.0,1035.0,Catholic,Secondary,676.0,-37.940226,145.195459
 Nazareth College,46079.0,2022,NOBLE PARK NORTH,28.0,5.6,92.3,99.0,1040.0,Catholic,Secondary,746.0,-37.940226,145.195459
-Nazareth College,,2023,NOBLE PARK NORTH,28.0,3.8,77.3,98.0,,,,,,
+Nazareth College,46079.0,2023,NOBLE PARK NORTH,28.0,3.8,77.3,98.0,,,,,,
 Neerim District Sec College,45439.0,2014,NEERIM SOUTH,26.0,1.2,60.0,100.0,992.0,Government,Secondary,142.0,-38.016936,145.95668
 Neerim District Sec College,45439.0,2015,NEERIM SOUTH,27.0,0.0,80.0,100.0,984.0,Government,Secondary,147.0,-38.016936,145.95668
 Neerim District Sec College,45439.0,2016,NEERIM SOUTH,24.0,1.1,83.0,100.0,966.0,Government,Secondary,157.0,-38.016936,145.95668
@@ -3565,7 +3663,7 @@ Neerim District Sec College,45439.0,2019,NEERIM SOUTH,29.0,0.0,88.2,100.0,982.0,
 Neerim District Sec College,45439.0,2020,NEERIM SOUTH,25.0,0.0,50.0,83.0,982.0,Government,Secondary,201.0,-38.016936,145.95668
 Neerim District Sec College,45439.0,2021,NEERIM SOUTH,25.0,0.0,53.8,100.0,978.0,Government,Secondary,209.0,-38.016936,145.95668
 Neerim District Sec College,45439.0,2022,NEERIM SOUTH,23.0,3.8,100.0,100.0,965.0,Government,Secondary,203.0,-38.016936,145.95668
-Neerim District Sec College,,2023,NEERIM SOUTH,23.0,,,100.0,,,,,,
+Neerim District Sec College,45439.0,2023,NEERIM SOUTH,23.0,,,100.0,,,,,,
 Newcomb Secondary College,45440.0,2014,NEWCOMB,25.0,0.9,73.0,93.0,924.0,Government,Secondary,537.0,-38.171306,144.395063
 Newcomb Secondary College,45440.0,2015,NEWCOMB,23.0,0.8,63.0,95.0,927.0,Government,Secondary,503.0,-38.171306,144.395063
 Newcomb Secondary College,45440.0,2016,NEWCOMB,25.0,1.2,56.0,98.0,923.0,Government,Secondary,456.0,-38.171306,144.395063
@@ -3575,7 +3673,7 @@ Newcomb Secondary College,45440.0,2019,NEWCOMB,23.0,0.0,16.7,96.0,934.0,Governme
 Newcomb Secondary College,45440.0,2020,NEWCOMB,26.0,3.2,40.0,97.0,940.0,Government,Secondary,480.0,-38.171306,144.395063
 Newcomb Secondary College,45440.0,2021,NEWCOMB,27.0,3.6,32.0,88.0,938.0,Government,Secondary,477.0,-38.171306,144.395063
 Newcomb Secondary College,45440.0,2022,NEWCOMB,25.0,0.0,16.7,96.0,936.0,Government,Secondary,446.0,-38.171306,144.395063
-Newcomb Secondary College,,2023,NEWCOMB,26.0,6.7,55.0,95.0,,,,,,
+Newcomb Secondary College,45440.0,2023,NEWCOMB,26.0,6.7,55.0,95.0,,,,,,
 Newhaven College,46260.0,2014,NEWHAVEN,30.0,6.1,90.0,100.0,1076.0,Independent,Combined,830.0,-38.489711,145.26554
 Newhaven College,46260.0,2015,NEWHAVEN,30.0,7.0,84.0,100.0,,Independent,Combined,877.0,-38.489711,145.26554
 Newhaven College,46260.0,2016,NEWHAVEN,30.0,8.6,85.0,100.0,,Independent,Combined,914.0,-38.489711,145.26554
@@ -3585,7 +3683,7 @@ Newhaven College,46260.0,2019,RHYLL,30.0,9.5,83.1,100.0,,Independent,Combined,91
 Newhaven College,46260.0,2020,RHYLL,31.0,8.8,87.1,99.0,,Independent,Combined,933.0,-38.489711,145.26554
 Newhaven College,46260.0,2021,RHYLL,31.0,9.6,73.1,100.0,1071.0,Independent,Combined,931.0,-38.489711,145.26554
 Newhaven College,46260.0,2022,RHYLL,27.0,2.4,75.8,100.0,1073.0,Independent,Combined,915.0,-38.489711,145.26554
-Newhaven College,,2023,RHYLL,29.0,6.7,75.0,100.0,,,,,,
+Newhaven College,46260.0,2023,RHYLL,29.0,6.7,75.0,100.0,,,,,,
 Nhill College,45569.0,2014,NHILL,27.0,3.4,57.0,100.0,971.0,Government,Combined,343.0,-36.33260253,141.65886004
 Nhill College,45569.0,2015,NHILL,30.0,2.5,67.0,100.0,960.0,Government,Combined,348.0,-36.33260253,141.65886004
 Nhill College,45569.0,2016,NHILL,30.0,6.1,79.0,96.0,970.0,Government,Combined,313.0,-36.33260253,141.65886004
@@ -3595,7 +3693,7 @@ Nhill College,45569.0,2019,NHILL,27.0,1.9,68.4,95.0,959.0,Government,Combined,25
 Nhill College,45569.0,2020,NHILL,27.0,1.3,57.1,93.0,952.0,Government,Combined,240.0,-36.33260253,141.65886004
 Nhill College,45569.0,2021,NHILL,27.0,2.6,40.0,93.0,953.0,Government,Combined,235.0,-36.33260253,141.65886004
 Nhill College,45569.0,2022,NHILL,29.0,3.6,30.0,90.0,949.0,Government,Combined,233.0,-36.33260253,141.65886004
-Nhill College,,2023,NHILL,25.0,,35.7,93.0,,,,,,
+Nhill College,45569.0,2023,NHILL,25.0,,35.7,93.0,,,,,,
 Noble Park Secondary College,45551.0,2014,NOBLE PARK,25.0,0.3,73.0,94.0,926.0,Government,Secondary,459.0,-37.970209,145.182369
 Noble Park Secondary College,45551.0,2015,NOBLE PARK,24.0,1.0,76.0,96.0,934.0,Government,Secondary,418.0,-37.970209,145.182369
 Noble Park Secondary College,45551.0,2016,NOBLE PARK,25.0,1.0,79.0,94.0,905.0,Government,Secondary,443.0,-37.970209,145.182369
@@ -3605,7 +3703,7 @@ Noble Park Secondary College,45551.0,2019,NOBLE PARK,25.0,0.4,85.7,98.0,956.0,Go
 Noble Park Secondary College,45551.0,2020,NOBLE PARK,25.0,1.5,71.9,100.0,943.0,Government,Secondary,481.0,-37.970209,145.182369
 Noble Park Secondary College,45551.0,2021,NOBLE PARK,28.0,2.0,81.0,100.0,931.0,Government,Secondary,463.0,-37.970209,145.182369
 Noble Park Secondary College,45551.0,2022,NOBLE PARK,26.0,0.8,88.9,100.0,903.0,Government,Secondary,451.0,-37.970209,145.182369
-Noble Park Secondary College,,2023,NOBLE PARK,25.0,1.8,72.5,92.0,,,,,,
+Noble Park Secondary College,45551.0,2023,NOBLE PARK,25.0,1.8,72.5,92.0,,,,,,
 North Geelong Sec College,45392.0,2014,GEELONG NORTH,24.0,0.4,78.0,93.0,902.0,Government,Secondary,656.0,-38.110384,144.341359
 North Geelong Sec College,45392.0,2015,GEELONG NORTH,24.0,0.9,75.0,88.0,913.0,Government,Secondary,742.0,-38.110384,144.341359
 North Geelong Sec College,45392.0,2016,GEELONG NORTH,25.0,1.4,57.0,98.0,920.0,Government,Secondary,814.0,-38.110384,144.341359
@@ -3615,10 +3713,11 @@ North Geelong Sec College,45392.0,2019,GEELONG NORTH,26.0,4.3,60.7,96.0,948.0,Go
 North Geelong Sec College,45392.0,2020,GEELONG NORTH,25.0,0.9,58.8,99.0,948.0,Government,Secondary,1041.0,-38.110384,144.341359
 North Geelong Sec College,45392.0,2021,GEELONG NORTH,27.0,3.8,43.4,91.0,950.0,Government,Secondary,971.0,-38.110384,144.341359
 North Geelong Sec College,45392.0,2022,GEELONG NORTH,28.0,3.6,68.8,95.0,937.0,Government,Secondary,961.0,-38.110384,144.341359
-North Geelong Sec College,,2023,NORTH GEELONG,28.0,4.2,39.8,100.0,,,,,,
-North Melbourne Grammar Coll,46137.0,2017,NORTH MELBOURNE,22.0,0.0,73.0,80.0,1182.0,Independent,Combined,1794.0,-37.833451,144.975911
-North Melbourne Grammar Coll,46137.0,2018,NORTH MELBOURNE,25.0,0.0,70.6,88.0,1180.0,Independent,Combined,1799.0,-37.833451,144.975911
-North Melbourne Grammar Coll,46137.0,2019,NORTH MELBOURNE,15.0,0.0,69.2,85.0,1171.0,Independent,Combined,1795.0,-37.833451,144.975911
+North Geelong Sec College,45392.0,2023,NORTH GEELONG,28.0,4.2,39.8,100.0,,,,,,
+North Melbourne Grammar Coll,,2017,NORTH MELBOURNE,22.0,0.0,73.0,80.0,,,,,,
+North Melbourne Grammar Coll,,2018,NORTH MELBOURNE,25.0,0.0,70.6,88.0,,,,,,
+North Melbourne Grammar Coll,,2019,NORTH MELBOURNE,15.0,0.0,69.2,85.0,,,,,,
+North Ringwood Comm House,,2018,RINGWOOD NORTH,,,,,,,,,,
 Northcote High School,45442.0,2014,NORTHCOTE,31.0,9.0,90.0,97.0,1097.0,Government,Secondary,1618.0,-37.774156,144.989706
 Northcote High School,45442.0,2015,NORTHCOTE,31.0,12.1,95.0,99.0,1103.0,Government,Secondary,1647.0,-37.774156,144.989706
 Northcote High School,45442.0,2016,NORTHCOTE,31.0,10.8,91.0,99.0,1107.0,Government,Secondary,1675.0,-37.774156,144.989706
@@ -3628,7 +3727,7 @@ Northcote High School,45442.0,2019,NORTHCOTE,30.0,8.3,87.7,96.0,1121.0,Governmen
 Northcote High School,45442.0,2020,NORTHCOTE,31.0,6.3,95.5,99.0,1129.0,Government,Secondary,1833.0,-37.774156,144.989706
 Northcote High School,45442.0,2021,NORTHCOTE,31.0,10.3,91.7,98.0,1137.0,Government,Secondary,1803.0,-37.774156,144.989706
 Northcote High School,45442.0,2022,NORTHCOTE,31.0,7.8,92.5,97.0,1146.0,Government,Secondary,1763.0,-37.774156,144.989706
-Northcote High School,,2023,NORTHCOTE,31.0,6.6,86.9,99.0,,,,,,
+Northcote High School,45442.0,2023,NORTHCOTE,31.0,6.6,86.9,99.0,,,,,,
 Northern Bay P-12 College,50291.0,2014,CORIO,22.0,0.0,50.0,86.0,881.0,Government,Combined,2000.0,-38.079288,144.355525
 Northern Bay P-12 College,50291.0,2015,CORIO,22.0,1.0,39.0,85.0,884.0,Government,Combined,2014.0,-38.079288,144.355525
 Northern Bay P-12 College,50291.0,2016,CORIO,22.0,0.0,57.0,96.0,875.0,Government,Combined,2031.0,-38.079288,144.355525
@@ -3638,7 +3737,7 @@ Northern Bay P-12 College,50291.0,2019,CORIO,21.0,0.6,67.4,86.0,882.0,Government
 Northern Bay P-12 College,50291.0,2020,CORIO,24.0,1.9,52.5,83.0,882.0,Government,Combined,1841.0,-38.079288,144.355525
 Northern Bay P-12 College,50291.0,2021,CORIO,23.0,1.9,43.8,92.0,883.0,Government,Combined,1719.0,-38.079288,144.355525
 Northern Bay P-12 College,50291.0,2022,CORIO,26.0,2.7,62.2,91.0,867.0,Government,Combined,1672.0,-38.079288,144.355525
-Northern Bay P-12 College,,2023,CORIO,23.0,0.7,51.0,90.0,,,,,,
+Northern Bay P-12 College,50291.0,2023,CORIO,23.0,0.7,51.0,90.0,,,,,,
 Northern College of Arts & Tech,45341.0,2014,PRESTON EAST,24.0,2.9,25.0,96.0,,Government,Secondary,357.0,-37.740069,145.025372
 Northern College of Arts & Tech,45341.0,2015,PRESTON EAST,24.0,0.8,21.0,100.0,,Government,Secondary,371.0,-37.740069,145.025372
 Northern College of Arts & Tech,45341.0,2016,PRESTON EAST,26.0,1.4,40.0,98.0,,Government,Secondary,372.0,-37.740069,145.025372
@@ -3648,7 +3747,8 @@ Northern College of Arts & Tech,45341.0,2019,PRESTON EAST,27.0,2.9,30.2,100.0,10
 Northern College of Arts & Tech,45341.0,2020,PRESTON EAST,26.0,1.5,63.3,95.0,1029.0,Government,Secondary,454.0,-37.740069,145.025372
 Northern College of Arts & Tech,45341.0,2021,PRESTON EAST,28.0,2.1,75.7,97.0,1031.0,Government,Secondary,401.0,-37.740069,145.025372
 Northern College of Arts & Tech,45341.0,2022,PRESTON EAST,29.0,1.4,92.1,97.0,1029.0,Government,Secondary,369.0,-37.740069,145.025372
-Northern College of Arts & Tech,,2023,PRESTON EAST,28.0,2.0,42.3,95.0,,,,,,
+Northern College of Arts & Tech,45341.0,2023,PRESTON EAST,28.0,2.0,42.3,95.0,,,,,,
+Northern Melbourne Inst of TAFE,,2014,PRESTON,,,,,,,,,,
 Northside Christian College,46251.0,2014,BUNDOORA,27.0,0.0,56.0,94.0,1052.0,Independent,Combined,265.0,-37.69501422,145.0546707
 Northside Christian College,46251.0,2015,BUNDOORA,29.0,6.5,78.0,96.0,1061.0,Independent,Combined,272.0,-37.69501422,145.0546707
 Northside Christian College,46251.0,2016,BUNDOORA,27.0,5.1,69.0,100.0,1058.0,Independent,Combined,283.0,-37.69501422,145.0546707
@@ -3658,7 +3758,7 @@ Northside Christian College,46251.0,2019,BUNDOORA,30.0,4.4,81.0,100.0,1087.0,Ind
 Northside Christian College,46251.0,2020,BUNDOORA,31.0,7.9,92.9,100.0,1087.0,Independent,Combined,447.0,-37.69501422,145.0546707
 Northside Christian College,46251.0,2021,BUNDOORA,30.0,6.5,85.0,100.0,1093.0,Independent,Combined,486.0,-37.69501422,145.0546707
 Northside Christian College,46251.0,2022,BUNDOORA,31.0,4.1,93.8,100.0,1094.0,Independent,Combined,522.0,-37.69501422,145.0546707
-Northside Christian College,,2023,BUNDOORA,28.0,11.6,74.1,96.0,,,,,,
+Northside Christian College,46251.0,2023,BUNDOORA,28.0,11.6,74.1,96.0,,,,,,
 Norwood Secondary College,45443.0,2014,RINGWOOD,29.0,5.3,74.0,100.0,1024.0,Government,Secondary,1083.0,-37.800473,145.238246
 Norwood Secondary College,45443.0,2015,RINGWOOD,28.0,5.1,76.0,99.0,1025.0,Government,Secondary,1088.0,-37.800473,145.238246
 Norwood Secondary College,45443.0,2016,RINGWOOD,29.0,4.9,73.0,100.0,1026.0,Government,Secondary,1073.0,-37.800473,145.238246
@@ -3668,7 +3768,7 @@ Norwood Secondary College,45443.0,2019,RINGWOOD,29.0,5.4,66.2,99.0,1034.0,Govern
 Norwood Secondary College,45443.0,2020,RINGWOOD,29.0,2.4,60.0,99.0,1036.0,Government,Secondary,1040.0,-37.800473,145.238246
 Norwood Secondary College,45443.0,2021,RINGWOOD,28.0,4.4,70.1,98.0,1036.0,Government,Secondary,1083.0,-37.800473,145.238246
 Norwood Secondary College,45443.0,2022,RINGWOOD,28.0,3.2,68.3,98.0,1038.0,Government,Secondary,1066.0,-37.800473,145.238246
-Norwood Secondary College,,2023,RINGWOOD,28.0,3.9,48.8,98.0,,,,,,
+Norwood Secondary College,45443.0,2023,RINGWOOD,28.0,3.9,48.8,98.0,,,,,,
 Nossal High School,45594.0,2014,BERWICK,35.0,24.7,100.0,100.0,1129.0,Government,Secondary,826.0,-38.03906593,145.33631372
 Nossal High School,45594.0,2015,BERWICK,36.0,27.1,100.0,100.0,1135.0,Government,Secondary,823.0,-38.03906593,145.33631372
 Nossal High School,45594.0,2016,BERWICK,35.0,22.7,99.0,100.0,1114.0,Government,Secondary,832.0,-38.03906593,145.33631372
@@ -3678,7 +3778,7 @@ Nossal High School,45594.0,2019,BERWICK,35.0,21.9,99.0,99.0,1135.0,Government,Se
 Nossal High School,45594.0,2020,BERWICK,36.0,26.3,100.0,100.0,1138.0,Government,Secondary,833.0,-38.03906593,145.33631372
 Nossal High School,45594.0,2021,BERWICK,36.0,26.9,100.0,100.0,1136.0,Government,Secondary,832.0,-38.03906593,145.33631372
 Nossal High School,45594.0,2022,BERWICK,36.0,24.0,100.0,100.0,1136.0,Government,Secondary,831.0,-38.03906593,145.33631372
-Nossal High School,,2023,BERWICK,36.0,27.0,100.0,100.0,,,,,,
+Nossal High School,45594.0,2023,BERWICK,36.0,27.0,100.0,100.0,,,,,,
 Notre Dame College,45715.0,2014,SHEPPARTON,29.0,4.4,80.0,99.0,1012.0,Catholic,Secondary,1652.0,-36.37470646,145.40763629
 Notre Dame College,45715.0,2015,SHEPPARTON,28.0,2.6,78.0,99.0,1009.0,Catholic,Secondary,1698.0,-36.37470646,145.40763629
 Notre Dame College,45715.0,2016,SHEPPARTON,29.0,3.2,80.0,99.0,1008.0,Catholic,Secondary,1696.0,-36.37470646,145.40763629
@@ -3688,7 +3788,7 @@ Notre Dame College,45715.0,2019,SHEPPARTON,28.0,3.6,73.0,99.0,1010.0,Catholic,Se
 Notre Dame College,45715.0,2020,SHEPPARTON,28.0,4.1,76.2,100.0,1007.0,Catholic,Secondary,1628.0,-36.37470646,145.40763629
 Notre Dame College,45715.0,2021,SHEPPARTON,26.0,3.2,65.5,99.0,1006.0,Catholic,Secondary,1663.0,-36.37470646,145.40763629
 Notre Dame College,45715.0,2022,SHEPPARTON,28.0,4.5,61.9,98.0,1022.0,Catholic,Secondary,1674.0,-36.37470646,145.40763629
-Notre Dame College,,2023,SHEPPARTON,27.0,2.0,62.0,98.0,,,,,,
+Notre Dame College,45715.0,2023,SHEPPARTON,27.0,2.0,62.0,98.0,,,,,,
 Numurkah Secondary College,45444.0,2014,NUMURKAH,26.0,2.2,72.0,100.0,939.0,Government,Secondary,276.0,-36.079948,145.446271
 Numurkah Secondary College,45444.0,2015,NUMURKAH,24.0,1.5,57.0,89.0,936.0,Government,Secondary,275.0,-36.079948,145.446271
 Numurkah Secondary College,45444.0,2016,NUMURKAH,26.0,0.0,63.0,100.0,937.0,Government,Secondary,274.0,-36.079948,145.446271
@@ -3698,7 +3798,7 @@ Numurkah Secondary College,45444.0,2019,NUMURKAH,22.0,0.0,40.7,96.0,942.0,Govern
 Numurkah Secondary College,45444.0,2020,NUMURKAH,24.0,0.0,50.0,100.0,933.0,Government,Secondary,262.0,-36.079948,145.446271
 Numurkah Secondary College,45444.0,2021,NUMURKAH,27.0,1.3,72.2,100.0,934.0,Government,Secondary,257.0,-36.079948,145.446271
 Numurkah Secondary College,45444.0,2022,NUMURKAH,26.0,0.0,60.0,100.0,927.0,Government,Secondary,246.0,-36.079948,145.446271
-Numurkah Secondary College,,2023,NUMURKAH,22.0,,50.0,88.0,,,,,,
+Numurkah Secondary College,45444.0,2023,NUMURKAH,22.0,,50.0,88.0,,,,,,
 Nunawading Christian College,46231.0,2014,NUNAWADING,35.0,19.3,100.0,100.0,,Independent,Secondary,170.0,-37.82254717,145.1690183
 Nunawading Christian College,46231.0,2015,NUNAWADING,31.0,8.1,100.0,100.0,,Independent,Secondary,185.0,-37.82254717,145.1690183
 Nunawading Christian College,46231.0,2016,NUNAWADING,32.0,14.1,100.0,100.0,,Independent,Secondary,184.0,-37.82254717,145.1690183
@@ -3708,7 +3808,7 @@ Nunawading Christian College,46231.0,2019,NUNAWADING,33.0,7.5,100.0,100.0,1094.0
 Nunawading Christian College,46231.0,2020,NUNAWADING,30.0,4.1,89.5,100.0,1094.0,Independent,Secondary,190.0,-37.82254717,145.1690183
 Nunawading Christian College,46231.0,2021,NUNAWADING,31.0,9.1,97.2,100.0,1065.0,Independent,Secondary,216.0,-37.82254717,145.1690183
 Nunawading Christian College,46231.0,2022,NUNAWADING,32.0,11.1,94.4,100.0,1053.0,Independent,Secondary,207.0,-37.82254717,145.1690183
-Nunawading Christian College,,2023,NUNAWADING,30.0,5.3,100.0,100.0,,,,,,
+Nunawading Christian College,46231.0,2023,NUNAWADING,30.0,5.3,100.0,100.0,,,,,,
 Oakleigh Grammar,46287.0,2014,OAKLEIGH,30.0,5.0,98.0,100.0,1055.0,Independent,Combined,510.0,-37.895907,145.082819
 Oakleigh Grammar,46287.0,2015,OAKLEIGH,31.0,6.4,94.0,100.0,1062.0,Independent,Combined,529.0,-37.895907,145.082819
 Oakleigh Grammar,46287.0,2016,OAKLEIGH,30.0,4.3,92.0,100.0,,Independent,Combined,627.0,-37.895907,145.082819
@@ -3718,7 +3818,7 @@ Oakleigh Grammar,46287.0,2019,OAKLEIGH,30.0,3.9,84.7,100.0,1073.0,Independent,Co
 Oakleigh Grammar,46287.0,2020,OAKLEIGH,31.0,3.4,80.9,96.0,1082.0,Independent,Combined,672.0,-37.895907,145.082819
 Oakleigh Grammar,46287.0,2021,OAKLEIGH,29.0,4.4,86.4,100.0,1075.0,Independent,Combined,589.0,-37.895907,145.082819
 Oakleigh Grammar,46287.0,2022,OAKLEIGH,31.0,6.2,86.8,100.0,1078.0,Independent,Combined,605.0,-37.895907,145.082819
-Oakleigh Grammar,,2023,OAKLEIGH,30.0,4.6,84.9,100.0,,,,,,
+Oakleigh Grammar,46287.0,2023,OAKLEIGH,30.0,4.6,84.9,100.0,,,,,,
 Oakwood School,45468.0,2015,CAULFIELD NORTH,,,,,934.0,Government,Secondary,491.0,-37.87398,145.034173
 Oakwood School,45468.0,2016,CAULFIELD NORTH,25.0,0.0,,,933.0,Government,Secondary,507.0,-37.87398,145.034173
 Oakwood School,45468.0,2017,CAULFIELD NORTH,,,100.0,100.0,926.0,Government,Secondary,437.0,-37.87398,145.034173
@@ -3726,7 +3826,7 @@ Oakwood School,45468.0,2018,CAULFIELD NORTH,,,,,947.0,Government,Secondary,457.0
 Oakwood School,45468.0,2019,CAULFIELD NORTH,,,,,930.0,Government,Secondary,513.0,-37.87398,145.034173
 Oakwood School,45468.0,2020,CAULFIELD NORTH,,,,,931.0,Government,Secondary,452.0,-37.87398,145.034173
 Oakwood School,45468.0,2021,CAULFIELD NORTH,,,,,935.0,Government,Secondary,426.0,-37.87398,145.034173
-Oakwood School,,2023,CAULFIELD NORTH,,,,100.0,,,,,,
+Oakwood School,45468.0,2023,CAULFIELD NORTH,,,,100.0,,,,,,
 Oberon High School,45445.0,2014,BELMONT,27.0,1.1,65.0,99.0,1004.0,Government,Secondary,687.0,-38.18665,144.337409
 Oberon High School,45445.0,2015,BELMONT,28.0,2.6,84.0,95.0,1000.0,Government,Secondary,634.0,-38.18665,144.337409
 Oberon High School,45445.0,2016,BELMONT,29.0,3.5,72.0,97.0,1011.0,Government,Secondary,565.0,-38.18665,144.337409
@@ -3736,16 +3836,16 @@ Oberon High School,45445.0,2019,BELMONT,29.0,3.3,67.8,97.0,1022.0,Government,Sec
 Oberon High School,45445.0,2020,ARMSTRONG CREEK,29.0,4.0,56.9,95.0,1023.0,Government,Secondary,747.0,-38.23066802,144.3640703
 Oberon High School,45445.0,2021,ARMSTRONG CREEK,30.0,3.0,66.1,100.0,1024.0,Government,Secondary,811.0,-38.23066802,144.3640703
 Oberon High School,45445.0,2022,ARMSTRONG CREEK,30.0,7.5,70.0,100.0,1022.0,Government,Secondary,892.0,-38.23066802,144.3640703
-Oberon High School,,2023,ARMSTRONG CREEK,29.0,5.5,57.7,92.0,,,,,,
+Oberon High School,45445.0,2023,ARMSTRONG CREEK,29.0,5.5,57.7,92.0,,,,,,
 Officer Secondary College,51485.0,2019,OFFICER,26.0,1.7,,,986.0,Government,Secondary,927.0,-38.06970435,145.41146304
 Officer Secondary College,51485.0,2020,OFFICER,25.0,1.1,72.6,99.0,990.0,Government,Secondary,1065.0,-38.06970435,145.41146304
 Officer Secondary College,51485.0,2021,OFFICER,26.0,0.8,71.6,97.0,994.0,Government,Secondary,1053.0,-38.06970435,145.41146304
 Officer Secondary College,51485.0,2022,OFFICER,24.0,0.7,80.2,97.0,1001.0,Government,Secondary,1011.0,-38.06970435,145.41146304
-Officer Secondary College,,2023,OFFICER,25.0,0.9,58.4,84.0,,,,,,
+Officer Secondary College,51485.0,2023,OFFICER,25.0,0.9,58.4,84.0,,,,,,
 OneSchool Global Vic,46360.0,2020,MELTON,31.0,5.4,0.0,100.0,1001.0,Independent,Combined,552.0,-37.64322649,145.13881141
 OneSchool Global Vic,46360.0,2021,MELTON WEST,32.0,11.2,0.0,100.0,998.0,Independent,Combined,557.0,-37.6863089083551,144.54225576943
 OneSchool Global Vic,46360.0,2022,MELTON WEST,31.0,12.7,0.0,100.0,993.0,Independent,Combined,540.0,-37.6863089083551,144.54225576943
-OneSchool Global Vic,,2023,MELTON WEST,32.0,9.9,,100.0,,,,,,
+OneSchool Global Vic,46360.0,2023,MELTON WEST,32.0,9.9,,100.0,,,,,,
 Orbost Secondary College,45446.0,2014,ORBOST,29.0,4.2,67.0,97.0,929.0,Government,Secondary,263.0,-37.704106,148.466353
 Orbost Secondary College,45446.0,2015,ORBOST,28.0,5.8,95.0,100.0,925.0,Government,Secondary,257.0,-37.704106,148.466353
 Orbost Secondary College,45446.0,2016,ORBOST,24.0,0.9,54.0,92.0,929.0,Government,Secondary,246.0,-37.704106,148.466353
@@ -3755,7 +3855,7 @@ Orbost Secondary College,45446.0,2019,ORBOST,27.0,2.1,66.7,100.0,942.0,Governmen
 Orbost Secondary College,45446.0,2020,ORBOST,29.0,10.4,72.7,95.0,941.0,Government,Secondary,238.0,-37.704106,148.466353
 Orbost Secondary College,45446.0,2021,ORBOST,27.0,0.0,33.3,80.0,942.0,Government,Secondary,222.0,-37.704106,148.466353
 Orbost Secondary College,45446.0,2022,ORBOST,26.0,1.4,88.9,100.0,928.0,Government,Secondary,224.0,-37.704106,148.466353
-Orbost Secondary College,,2023,ORBOST,27.0,3.4,68.8,94.0,,,,,,
+Orbost Secondary College,45446.0,2023,ORBOST,27.0,3.4,68.8,94.0,,,,,,
 Our Lady of Mercy College,45760.0,2014,HEIDELBERG,33.0,11.5,98.0,100.0,1093.0,Catholic,Secondary,1139.0,-37.75793,145.067586
 Our Lady of Mercy College,45760.0,2015,HEIDELBERG,33.0,11.9,97.0,100.0,1098.0,Catholic,Secondary,1148.0,-37.75793,145.067586
 Our Lady of Mercy College,45760.0,2016,HEIDELBERG,33.0,10.3,96.0,100.0,1090.0,Catholic,Secondary,1171.0,-37.75793,145.067586
@@ -3765,7 +3865,7 @@ Our Lady of Mercy College,45760.0,2019,HEIDELBERG,33.0,11.1,95.2,100.0,1100.0,Ca
 Our Lady of Mercy College,45760.0,2020,HEIDELBERG,32.0,11.6,99.5,100.0,1102.0,Catholic,Secondary,1198.0,-37.75793,145.067586
 Our Lady of Mercy College,45760.0,2021,HEIDELBERG,32.0,9.8,100.0,100.0,1102.0,Catholic,Secondary,1202.0,-37.75793,145.067586
 Our Lady of Mercy College,45760.0,2022,HEIDELBERG,32.0,9.8,95.7,100.0,1102.0,Catholic,Secondary,1189.0,-37.75793,145.067586
-Our Lady of Mercy College,,2023,HEIDELBERG,32.0,7.7,92.5,100.0,,,,,,
+Our Lady of Mercy College,45760.0,2023,HEIDELBERG,32.0,7.7,92.5,100.0,,,,,,
 Our Lady of Sacred Heart Coll,45868.0,2014,BENTLEIGH,32.0,9.2,100.0,100.0,1051.0,Catholic,Secondary,681.0,-37.925723,145.039942
 Our Lady of Sacred Heart Coll,45868.0,2015,BENTLEIGH,32.0,9.0,100.0,100.0,1063.0,Catholic,Secondary,654.0,-37.925723,145.039942
 Our Lady of Sacred Heart Coll,45868.0,2016,BENTLEIGH,31.0,8.5,99.0,100.0,1064.0,Catholic,Secondary,657.0,-37.925723,145.039942
@@ -3775,7 +3875,7 @@ Our Lady of Sacred Heart Coll,45868.0,2019,BENTLEIGH,32.0,10.1,98.9,100.0,1084.0
 Our Lady of Sacred Heart Coll,45868.0,2020,BENTLEIGH,33.0,12.2,97.8,100.0,1091.0,Catholic,Secondary,737.0,-37.925723,145.039942
 Our Lady of Sacred Heart Coll,45868.0,2021,BENTLEIGH,31.0,8.3,99.0,100.0,1092.0,Catholic,Secondary,739.0,-37.925723,145.039942
 Our Lady of Sacred Heart Coll,45868.0,2022,BENTLEIGH,31.0,11.0,95.5,97.0,1097.0,Catholic,Secondary,728.0,-37.925723,145.039942
-Our Lady of Sacred Heart Coll,,2023,BENTLEIGH,31.0,11.0,87.2,99.0,,,,,,
+Our Lady of Sacred Heart Coll,45868.0,2023,BENTLEIGH,31.0,11.0,87.2,99.0,,,,,,
 Our Lady of Sion College,45823.0,2014,BOX HILL,34.0,17.4,94.0,100.0,1099.0,Catholic,Secondary,889.0,-37.8184,145.13
 Our Lady of Sion College,45823.0,2015,BOX HILL,33.0,11.0,98.0,100.0,1101.0,Catholic,Secondary,899.0,-37.8184,145.13
 Our Lady of Sion College,45823.0,2016,BOX HILL,33.0,8.9,99.0,100.0,1100.0,Catholic,Secondary,928.0,-37.8184,145.13
@@ -3785,7 +3885,7 @@ Our Lady of Sion College,45823.0,2019,BOX HILL,33.0,14.2,95.6,100.0,1105.0,Catho
 Our Lady of Sion College,45823.0,2020,BOX HILL,32.0,10.4,97.1,99.0,1104.0,Catholic,Secondary,974.0,-37.8184,145.13
 Our Lady of Sion College,45823.0,2021,BOX HILL,32.0,9.3,96.7,100.0,1104.0,Catholic,Secondary,977.0,-37.8184,145.13
 Our Lady of Sion College,45823.0,2022,BOX HILL,33.0,11.7,96.5,100.0,1098.0,Catholic,Secondary,949.0,-37.8184,145.13
-Our Lady of Sion College,,2023,BOX HILL,33.0,9.3,90.7,100.0,,,,,,
+Our Lady of Sion College,45823.0,2023,BOX HILL,33.0,9.3,90.7,100.0,,,,,,
 Ouyen P-12 College,45447.0,2014,OUYEN,30.0,6.7,82.0,100.0,970.0,Government,Combined,248.0,-35.064571,142.322608
 Ouyen P-12 College,45447.0,2015,OUYEN,29.0,1.5,64.0,100.0,962.0,Government,Combined,251.0,-35.064571,142.322608
 Ouyen P-12 College,45447.0,2016,OUYEN,31.0,7.9,81.0,100.0,958.0,Government,Combined,252.0,-35.064571,142.322608
@@ -3795,7 +3895,7 @@ Ouyen P-12 College,45447.0,2019,OUYEN,27.0,0.0,71.4,100.0,958.0,Government,Combi
 Ouyen P-12 College,45447.0,2020,OUYEN,27.0,0.0,33.3,100.0,955.0,Government,Combined,212.0,-35.064571,142.322608
 Ouyen P-12 College,45447.0,2021,OUYEN,27.0,4.4,75.0,100.0,957.0,Government,Combined,216.0,-35.064571,142.322608
 Ouyen P-12 College,45447.0,2022,OUYEN,31.0,10.8,71.4,100.0,952.0,Government,Combined,207.0,-35.064571,142.322608
-Ouyen P-12 College,,2023,OUYEN,33.0,21.4,54.5,82.0,,,,,,
+Ouyen P-12 College,45447.0,2023,OUYEN,33.0,21.4,54.5,82.0,,,,,,
 Overnewton Anglican Comm Coll,46310.0,2014,KEILOR,31.0,8.2,96.0,99.0,1097.0,Independent,Combined,2142.0,-37.706557,144.82318
 Overnewton Anglican Comm Coll,46310.0,2015,KEILOR,31.0,6.5,93.0,99.0,1095.0,Independent,Combined,2113.0,-37.706557,144.82318
 Overnewton Anglican Comm Coll,46310.0,2016,KEILOR,30.0,8.5,92.0,100.0,1096.0,Independent,Combined,2101.0,-37.706557,144.82318
@@ -3805,7 +3905,7 @@ Overnewton Anglican Comm Coll,46310.0,2019,KEILOR,30.0,3.7,92.5,100.0,1097.0,Ind
 Overnewton Anglican Comm Coll,46310.0,2020,KEILOR,31.0,7.3,95.2,100.0,1097.0,Independent,Combined,2013.0,-37.706557,144.82318
 Overnewton Anglican Comm Coll,46310.0,2021,KEILOR,30.0,4.1,94.4,100.0,1102.0,Independent,Combined,1973.0,-37.706557,144.82318
 Overnewton Anglican Comm Coll,46310.0,2022,KEILOR,30.0,4.4,92.9,98.0,1109.0,Independent,Combined,2001.0,-37.706557,144.82318
-Overnewton Anglican Comm Coll,,2023,KEILOR,32.0,8.9,94.4,99.0,,,,,,
+Overnewton Anglican Comm Coll,46310.0,2023,KEILOR,32.0,8.9,94.4,99.0,,,,,,
 Oxley Christian College,46255.0,2014,CHIRNSIDE PARK,31.0,9.1,96.0,100.0,1078.0,Independent,Combined,844.0,-37.76293666,145.3043162
 Oxley Christian College,46255.0,2015,CHIRNSIDE PARK,31.0,10.0,100.0,100.0,1087.0,Independent,Combined,825.0,-37.76293666,145.3043162
 Oxley Christian College,46255.0,2016,CHIRNSIDE PARK,32.0,11.4,98.0,99.0,1086.0,Independent,Combined,809.0,-37.76293666,145.3043162
@@ -3815,7 +3915,7 @@ Oxley Christian College,46255.0,2019,CHIRNSIDE PARK,32.0,10.4,78.9,97.0,1102.0,I
 Oxley Christian College,46255.0,2020,CHIRNSIDE PARK,31.0,7.7,87.3,100.0,1102.0,Independent,Combined,838.0,-37.76293666,145.3043162
 Oxley Christian College,46255.0,2021,CHIRNSIDE PARK,32.0,9.2,83.3,100.0,1106.0,Independent,Combined,819.0,-37.76293666,145.3043162
 Oxley Christian College,46255.0,2022,CHIRNSIDE PARK,31.0,8.0,91.0,100.0,1111.0,Independent,Combined,811.0,-37.76293666,145.3043162
-Oxley Christian College,,2023,CHIRNSIDE PARK,33.0,16.4,87.0,100.0,,,,,,
+Oxley Christian College,46255.0,2023,CHIRNSIDE PARK,33.0,16.4,87.0,100.0,,,,,,
 Ozford College,40714.0,2014,MELBOURNE,19.0,0.0,50.0,100.0,,Independent,Secondary,61.0,-37.81066,144.968683
 Ozford College,40714.0,2015,MELBOURNE,21.0,1.1,58.0,95.0,,Independent,Secondary,94.0,-37.81066,144.968683
 Ozford College,40714.0,2016,MELBOURNE,21.0,0.0,80.0,100.0,,Independent,Secondary,91.0,-37.81066,144.968683
@@ -3834,7 +3934,7 @@ Padua College,45713.0,2019,MORNINGTON,30.0,4.7,78.9,100.0,1061.0,Catholic,Second
 Padua College,45713.0,2020,MORNINGTON,30.0,5.1,77.5,99.0,1062.0,Catholic,Secondary,2457.0,-38.2182566625499,145.07200429078
 Padua College,45713.0,2021,MORNINGTON,29.0,6.1,68.7,99.0,1063.0,Catholic,Secondary,2481.0,-38.2182566625499,145.07200429078
 Padua College,45713.0,2022,MORNINGTON,29.0,4.2,62.3,99.0,1061.0,Catholic,Secondary,2548.0,-38.2182566625499,145.07200429078
-Padua College,,2023,MORNINGTON,28.0,4.4,56.6,99.0,,,,,,
+Padua College,45713.0,2023,MORNINGTON,28.0,4.4,56.6,99.0,,,,,,
 Pakenham Secondary College,45449.0,2014,PAKENHAM,26.0,0.4,85.0,92.0,944.0,Government,Secondary,918.0,-38.06907933,145.47110079
 Pakenham Secondary College,45449.0,2015,PAKENHAM,26.0,1.6,79.0,84.0,945.0,Government,Secondary,814.0,-38.06907933,145.47110079
 Pakenham Secondary College,45449.0,2016,PAKENHAM,26.0,1.1,93.0,98.0,955.0,Government,Secondary,755.0,-38.06907933,145.47110079
@@ -3844,7 +3944,7 @@ Pakenham Secondary College,45449.0,2019,PAKENHAM,26.0,0.8,93.7,97.0,963.0,Govern
 Pakenham Secondary College,45449.0,2020,PAKENHAM,27.0,0.6,95.0,90.0,965.0,Government,Secondary,773.0,-38.06907933,145.47110079
 Pakenham Secondary College,45449.0,2021,PAKENHAM,26.0,0.6,97.4,100.0,964.0,Government,Secondary,799.0,-38.06907933,145.47110079
 Pakenham Secondary College,45449.0,2022,PAKENHAM,28.0,0.6,95.8,100.0,958.0,Government,Secondary,785.0,-38.06907933,145.47110079
-Pakenham Secondary College,,2023,PAKENHAM,29.0,1.9,57.4,96.0,,,,,,
+Pakenham Secondary College,45449.0,2023,PAKENHAM,29.0,1.9,57.4,96.0,,,,,,
 Parade College,45629.0,2014,BUNDOORA,30.0,6.0,92.0,100.0,1048.0,Catholic,Secondary,1863.0,-37.690178,145.066978
 Parade College,45629.0,2015,BUNDOORA,31.0,7.8,87.0,100.0,1050.0,Catholic,Secondary,1852.0,-37.690178,145.066978
 Parade College,45629.0,2016,BUNDOORA,31.0,9.1,81.0,99.0,1051.0,Catholic,Secondary,1905.0,-37.690178,145.066978
@@ -3854,7 +3954,7 @@ Parade College,45629.0,2019,BUNDOORA,31.0,8.5,87.6,100.0,1059.0,Catholic,Seconda
 Parade College,45629.0,2020,BUNDOORA,30.0,3.2,91.0,100.0,1063.0,Catholic,Secondary,1937.0,-37.690178,145.066978
 Parade College,45629.0,2021,BUNDOORA,30.0,6.5,89.6,100.0,1064.0,Catholic,Secondary,1950.0,-37.690178,145.066978
 Parade College,45629.0,2022,BUNDOORA,30.0,5.8,84.0,100.0,1074.0,Catholic,Secondary,1925.0,-37.690178,145.066978
-Parade College,,2023,BUNDOORA,30.0,4.5,72.0,99.0,,,,,,
+Parade College,45629.0,2023,BUNDOORA,30.0,4.5,72.0,99.0,,,,,,
 Parkdale Secondary College,45450.0,2014,MORDIALLOC,29.0,3.3,77.0,99.0,1038.0,Government,Secondary,1362.0,-37.989637,145.094101
 Parkdale Secondary College,45450.0,2015,MORDIALLOC,28.0,5.1,76.0,96.0,1042.0,Government,Secondary,1451.0,-37.989637,145.094101
 Parkdale Secondary College,45450.0,2016,MORDIALLOC,29.0,6.3,66.0,99.0,1047.0,Government,Secondary,1559.0,-37.989637,145.094101
@@ -3864,7 +3964,7 @@ Parkdale Secondary College,45450.0,2019,MORDIALLOC,30.0,4.6,64.0,98.0,1064.0,Gov
 Parkdale Secondary College,45450.0,2020,MORDIALLOC,30.0,4.5,72.1,98.0,1065.0,Government,Secondary,1815.0,-37.989637,145.094101
 Parkdale Secondary College,45450.0,2021,MORDIALLOC,30.0,7.5,62.3,97.0,1068.0,Government,Secondary,1779.0,-37.989637,145.094101
 Parkdale Secondary College,45450.0,2022,MORDIALLOC,30.0,6.5,68.8,99.0,1068.0,Government,Secondary,1716.0,-37.989637,145.094101
-Parkdale Secondary College,,2023,MORDIALLOC,29.0,4.7,55.6,99.0,,,,,,
+Parkdale Secondary College,45450.0,2023,MORDIALLOC,29.0,4.7,55.6,99.0,,,,,,
 Parkville College,50576.0,2016,PARKVILLE,,,0.0,50.0,,Government,Special,191.0,-37.778764,144.942622
 Parkville College,50576.0,2017,PARKVILLE,,,0.0,,,Government,Special,297.0,-37.778764,144.942622
 Parkville College,50576.0,2018,PARKVILLE,,,0.0,100.0,980.0,Government,Special,301.0,-37.778764,144.942622
@@ -3872,7 +3972,7 @@ Parkville College,50576.0,2019,PARKVILLE,,,0.0,,,Government,Special,305.0,-37.77
 Parkville College,50576.0,2020,PARKVILLE,,,,,,Government,Special,,-37.778764,144.942622
 Parkville College,50576.0,2021,PARKVILLE,,,,,,Government,Special,,-37.778764,144.942622
 Parkville College,50576.0,2022,PARKVILLE,,,100.0,100.0,,Government,Special,,-37.778764,144.942622
-Parkville College,,2023,PARKVILLE,,,,,,,,,,
+Parkville College,50576.0,2023,PARKVILLE,,,,,,,,,,
 Pascoe Vale Girls Sec College,45452.0,2014,PASCOE VALE,28.0,3.6,96.0,99.0,968.0,Government,Secondary,1268.0,-37.717664,144.935384
 Pascoe Vale Girls Sec College,45452.0,2015,PASCOE VALE,28.0,4.4,92.0,99.0,969.0,Government,Secondary,1181.0,-37.717664,144.935384
 Pascoe Vale Girls Sec College,45452.0,2016,PASCOE VALE,28.0,2.3,96.0,99.0,966.0,Government,Secondary,1123.0,-37.717664,144.935384
@@ -3882,7 +3982,7 @@ Pascoe Vale Girls Sec College,45452.0,2019,PASCOE VALE,27.0,3.0,94.9,97.0,977.0,
 Pascoe Vale Girls Sec College,45452.0,2020,PASCOE VALE,26.0,2.2,93.2,95.0,978.0,Government,Secondary,996.0,-37.717664,144.935384
 Pascoe Vale Girls Sec College,45452.0,2021,PASCOE VALE,27.0,1.0,94.5,100.0,978.0,Government,Secondary,885.0,-37.717664,144.935384
 Pascoe Vale Girls Sec College,45452.0,2022,PASCOE VALE,28.0,4.1,89.6,98.0,973.0,Government,Secondary,885.0,-37.717664,144.935384
-Pascoe Vale Girls Sec College,,2023,PASCOE VALE,26.0,1.7,80.5,98.0,,,,,,
+Pascoe Vale Girls Sec College,45452.0,2023,PASCOE VALE,26.0,1.7,80.5,98.0,,,,,,
 Patterson River Sec College,45509.0,2014,CARRUM,29.0,4.9,77.0,96.0,973.0,Government,Secondary,1145.0,-38.083284,145.134825
 Patterson River Sec College,45509.0,2015,CARRUM,29.0,6.1,77.0,98.0,979.0,Government,Secondary,1106.0,-38.083284,145.134825
 Patterson River Sec College,45509.0,2016,CARRUM,28.0,3.0,60.0,93.0,984.0,Government,Secondary,1047.0,-38.083284,145.134825
@@ -3892,16 +3992,16 @@ Patterson River Sec College,45509.0,2019,CARRUM,25.0,0.9,53.4,93.0,995.0,Governm
 Patterson River Sec College,45509.0,2020,CARRUM,26.0,1.4,60.3,91.0,1000.0,Government,Secondary,1142.0,-38.083284,145.134825
 Patterson River Sec College,45509.0,2021,CARRUM,26.0,1.2,59.1,95.0,1003.0,Government,Secondary,1210.0,-38.083284,145.134825
 Patterson River Sec College,45509.0,2022,CARRUM,25.0,0.8,65.1,100.0,1006.0,Government,Secondary,1192.0,-38.083284,145.134825
-Patterson River Sec College,,2023,CARRUM,25.0,2.0,38.9,98.0,,,,,,
+Patterson River Sec College,45509.0,2023,CARRUM,25.0,2.0,38.9,98.0,,,,,,
 Peninsula Grammar,46219.0,2017,MOUNT ELIZA,33.0,14.9,93.0,100.0,1120.0,Independent,Combined,1282.0,-38.198174,145.090692
 Peninsula Grammar,46219.0,2018,MOUNT ELIZA,32.0,10.0,96.3,99.0,1110.0,Independent,Combined,1290.0,-38.198174,145.090692
 Peninsula Grammar,46219.0,2019,MOUNT ELIZA,34.0,16.4,93.2,99.0,1113.0,Independent,Combined,1265.0,-38.198174,145.090692
 Peninsula Grammar,46219.0,2020,MOUNT ELIZA,33.0,12.8,91.0,100.0,1113.0,Independent,Combined,1238.0,-38.198174,145.090692
 Peninsula Grammar,46219.0,2021,MOUNT ELIZA,33.0,14.7,89.5,98.0,1119.0,Independent,Combined,1188.0,-38.198174,145.090692
 Peninsula Grammar,46219.0,2022,MOUNT ELIZA,32.0,12.9,91.2,100.0,1118.0,Independent,Combined,1205.0,-38.198174,145.090692
-Peninsula Grammar,,2023,MOUNT ELIZA,31.0,11.6,81.6,100.0,,,,,,
-Peninsula Train & Employment,46219.0,2014,ROSEBUD,,,,,1121.0,Independent,Combined,1363.0,-38.198174,145.090692
-Peninsula Train & Employment,46219.0,2015,ROSEBUD WEST,,,,,1130.0,Independent,Combined,1328.0,-38.198174,145.090692
+Peninsula Grammar,46219.0,2023,MOUNT ELIZA,31.0,11.6,81.6,100.0,,,,,,
+Peninsula Train & Employment,,2014,ROSEBUD,,,,,,,,,,
+Peninsula Train & Employment,,2015,ROSEBUD WEST,,,,,,,,,,
 Penleigh & Essendon Grammar,46180.0,2014,KEILOR EAST,36.0,26.4,99.0,100.0,1157.0,Independent,Combined,2251.0,-37.732154,144.870337
 Penleigh & Essendon Grammar,46180.0,2015,KEILOR EAST,36.0,26.2,97.0,100.0,1163.0,Independent,Combined,2272.0,-37.732154,144.870337
 Penleigh & Essendon Grammar,46180.0,2016,KEILOR EAST,36.0,25.5,93.0,100.0,1165.0,Independent,Combined,2383.0,-37.732154,144.870337
@@ -3911,7 +4011,7 @@ Penleigh & Essendon Grammar,46180.0,2019,KEILOR EAST,35.0,22.5,97.3,100.0,1162.0
 Penleigh & Essendon Grammar,46180.0,2020,KEILOR EAST,35.0,23.0,96.4,100.0,1162.0,Independent,Combined,2723.0,-37.732154,144.870337
 Penleigh & Essendon Grammar,46180.0,2021,KEILOR EAST,34.0,19.0,98.9,100.0,1166.0,Independent,Combined,2790.0,-37.732154,144.870337
 Penleigh & Essendon Grammar,46180.0,2022,KEILOR EAST,34.0,19.7,98.1,100.0,1169.0,Independent,Combined,2847.0,-37.732154,144.870337
-Penleigh & Essendon Grammar,,2023,KEILOR EAST,34.0,20.3,98.3,100.0,,,,,,
+Penleigh & Essendon Grammar,46180.0,2023,KEILOR EAST,34.0,20.3,98.3,100.0,,,,,,
 Penola Catholic College,46096.0,2014,BROADMEADOWS,28.0,2.1,87.0,100.0,966.0,Catholic,Secondary,1595.0,-37.6888,144.92
 Penola Catholic College,46096.0,2015,BROADMEADOWS,28.0,2.7,93.0,100.0,965.0,Catholic,Secondary,1527.0,-37.6888,144.92
 Penola Catholic College,46096.0,2016,BROADMEADOWS,28.0,2.2,85.0,100.0,967.0,Catholic,Secondary,1470.0,-37.6888,144.92
@@ -3921,17 +4021,17 @@ Penola Catholic College,46096.0,2019,BROADMEADOWS,28.0,2.6,85.8,99.0,979.0,Catho
 Penola Catholic College,46096.0,2020,BROADMEADOWS,27.0,1.0,84.9,99.0,982.0,Catholic,Secondary,1466.0,-37.6888,144.92
 Penola Catholic College,46096.0,2021,BROADMEADOWS,26.0,2.3,76.4,99.0,987.0,Catholic,Secondary,1464.0,-37.6888,144.92
 Penola Catholic College,46096.0,2022,BROADMEADOWS,27.0,1.5,85.8,98.0,989.0,Catholic,Secondary,1478.0,-37.6888,144.92
-Penola Catholic College,,2023,BROADMEADOWS,27.0,2.3,76.0,100.0,,,,,,
+Penola Catholic College,46096.0,2023,BROADMEADOWS,27.0,2.3,76.0,100.0,,,,,,
 Peter Lalor Secondary College,45334.0,2021,LALOR,,,,,887.0,Government,Secondary,151.0,-37.66690584,145.01315591
 Peter Lalor Secondary College,45334.0,2022,LALOR,,,0.0,,928.0,Government,Secondary,124.0,-37.66690584,145.01315591
-Peter Lalor Secondary College,,2023,LALOR,,,,82.0,,,,,,
-Peter Lalor Vocational Coll,45334.0,2014,LALOR,,,,,,Government,Secondary,186.0,-37.66690584,145.01315591
-Peter Lalor Vocational Coll,45334.0,2015,LALOR,,,,,,Government,Secondary,207.0,-37.66690584,145.01315591
-Peter Lalor Vocational Coll,45334.0,2016,LALOR,,,,,,Government,Secondary,136.0,-37.66690584,145.01315591
-Peter Lalor Vocational Coll,45334.0,2017,LALOR,,,,,,Government,Secondary,135.0,-37.66690584,145.01315591
-Peter Lalor Vocational Coll,45334.0,2018,LALOR,,,,,959.0,Government,Secondary,134.0,-37.66690584,145.01315591
-Peter Lalor Vocational Coll,45334.0,2019,LALOR,,,,,871.0,Government,Secondary,180.0,-37.66690584,145.01315591
-Peter Lalor Vocational Coll,45334.0,2020,LALOR,,,,,892.0,Government,Secondary,181.0,-37.66690584,145.01315591
+Peter Lalor Secondary College,45334.0,2023,LALOR,,,,82.0,,,,,,
+Peter Lalor Vocational Coll,,2014,LALOR,,,,,,,,,,
+Peter Lalor Vocational Coll,,2015,LALOR,,,,,,,,,,
+Peter Lalor Vocational Coll,,2016,LALOR,,,,,,,,,,
+Peter Lalor Vocational Coll,,2017,LALOR,,,,,,,,,,
+Peter Lalor Vocational Coll,,2018,LALOR,,,,,,,,,,
+Peter Lalor Vocational Coll,,2019,LALOR,,,,,,,,,,
+Peter Lalor Vocational Coll,,2020,LALOR,,,,,,,,,,
 Phoenix P-12 Comm Coll,50268.0,2014,SEBASTOPOL,26.0,1.0,80.0,97.0,934.0,Government,Combined,1067.0,-37.58661037,143.83350593
 Phoenix P-12 Comm Coll,50268.0,2015,SEBASTOPOL,27.0,1.5,82.0,94.0,942.0,Government,Combined,1108.0,-37.58661037,143.83350593
 Phoenix P-12 Comm Coll,50268.0,2016,SEBASTOPOL,27.0,1.1,80.0,93.0,939.0,Government,Combined,1159.0,-37.58661037,143.83350593
@@ -3941,9 +4041,17 @@ Phoenix P-12 Comm Coll,50268.0,2019,SEBASTOPOL,27.0,0.0,76.7,100.0,951.0,Governm
 Phoenix P-12 Comm Coll,50268.0,2020,SEBASTOPOL,26.0,1.4,76.2,97.0,954.0,Government,Combined,1467.0,-37.58661037,143.83350593
 Phoenix P-12 Comm Coll,50268.0,2021,SEBASTOPOL,27.0,4.0,67.2,98.0,953.0,Government,Combined,1568.0,-37.58661037,143.83350593
 Phoenix P-12 Comm Coll,50268.0,2022,SEBASTOPOL,28.0,4.3,83.8,99.0,944.0,Government,Combined,1581.0,-37.58661037,143.83350593
-Phoenix P-12 Comm Coll,,2023,SEBASTOPOL,28.0,1.9,53.4,95.0,,,,,,
+Phoenix P-12 Comm Coll,50268.0,2023,SEBASTOPOL,28.0,1.9,53.4,95.0,,,,,,
+Pines Learning,,2014,DONCASTER EAST,,,,,,,,,,
+Pines Learning,,2015,DONCASTER EAST,,,,,,,,,,
+Pines Learning,,2016,DONCASTER EAST,,,,,,,,,,
+Pines Learning,,2017,DONCASTER EAST,,,,,,,,,,
+Pines Learning,,2018,DONCASTER EAST,,,,,,,,,,
+Pines Learning,,2019,DONCASTER EAST,,,,,,,,,,
+Pines Learning,,2020,DONCASTER EAST,,,,,,,,,,
+Pines Learning,,2021,DONCASTER EAST,,,,,,,,,,
 Plenty River College,53092.0,2022,GREENSBOROUGH,,,,,980.0,Independent,Secondary,40.0,-37.6485660479857,145.081567715345
-Plenty River College,,2023,SOUTH MORANG,,,,100.0,,,,,,
+Plenty River College,53092.0,2023,SOUTH MORANG,,,,100.0,,,,,,
 Plenty Valley Christian College,46269.0,2014,DOREEN,31.0,7.5,93.0,100.0,1092.0,Independent,Combined,815.0,-37.613463,145.138791
 Plenty Valley Christian College,46269.0,2015,DOREEN,31.0,10.6,90.0,100.0,1092.0,Independent,Combined,798.0,-37.613463,145.138791
 Plenty Valley Christian College,46269.0,2016,DOREEN,31.0,7.9,92.0,100.0,1089.0,Independent,Combined,773.0,-37.613463,145.138791
@@ -3953,7 +4061,7 @@ Plenty Valley Christian College,46269.0,2019,DOREEN,30.0,5.4,89.8,98.0,1106.0,In
 Plenty Valley Christian College,46269.0,2020,DOREEN,31.0,4.1,90.8,100.0,1106.0,Independent,Combined,759.0,-37.613463,145.138791
 Plenty Valley Christian College,46269.0,2021,DOREEN,29.0,1.7,75.4,100.0,1107.0,Independent,Combined,770.0,-37.613463,145.138791
 Plenty Valley Christian College,46269.0,2022,DOREEN,31.0,4.6,80.8,100.0,1105.0,Independent,Combined,780.0,-37.613463,145.138791
-Plenty Valley Christian College,,2023,DOREEN,30.0,7.3,70.0,100.0,,,,,,
+Plenty Valley Christian College,46269.0,2023,DOREEN,30.0,7.3,70.0,100.0,,,,,,
 Point Cook Senior Sec College,40786.0,2014,POINT COOK,27.0,2.4,77.0,94.0,,Government,Secondary,762.0,-37.886718,144.73282
 Point Cook Senior Sec College,40786.0,2015,POINT COOK,25.0,1.8,77.0,92.0,,Government,Secondary,819.0,-37.886718,144.73282
 Point Cook Senior Sec College,40786.0,2016,POINT COOK,27.0,2.1,79.0,92.0,,Government,Secondary,849.0,-37.886718,144.73282
@@ -3963,7 +4071,7 @@ Point Cook Senior Sec College,40786.0,2019,POINT COOK,28.0,2.5,89.4,92.0,1017.0,
 Point Cook Senior Sec College,40786.0,2020,POINT COOK,28.0,2.7,92.3,96.0,1018.0,Government,Secondary,839.0,-37.886718,144.73282
 Point Cook Senior Sec College,40786.0,2021,POINT COOK,27.0,2.3,88.5,98.0,1018.0,Government,Secondary,804.0,-37.886718,144.73282
 Point Cook Senior Sec College,40786.0,2022,POINT COOK,27.0,2.1,86.4,90.0,1015.0,Government,Secondary,745.0,-37.886718,144.73282
-Point Cook Senior Sec College,,2023,POINT COOK,27.0,2.7,68.0,95.0,,,,,,
+Point Cook Senior Sec College,40786.0,2023,POINT COOK,27.0,2.7,68.0,95.0,,,,,,
 Portland Secondary College,45534.0,2014,PORTLAND,26.0,1.5,75.0,98.0,944.0,Government,Secondary,676.0,-38.35882225,141.59550333
 Portland Secondary College,45534.0,2015,PORTLAND,26.0,0.7,67.0,93.0,950.0,Government,Secondary,689.0,-38.35882225,141.59550333
 Portland Secondary College,45534.0,2016,PORTLAND,26.0,1.7,77.0,96.0,956.0,Government,Secondary,703.0,-38.35882225,141.59550333
@@ -3973,11 +4081,12 @@ Portland Secondary College,45534.0,2019,PORTLAND,27.0,1.1,68.8,98.0,949.0,Govern
 Portland Secondary College,45534.0,2020,PORTLAND,28.0,3.2,73.1,97.0,950.0,Government,Secondary,660.0,-38.35882225,141.59550333
 Portland Secondary College,45534.0,2021,PORTLAND,25.0,0.3,51.7,97.0,945.0,Government,Secondary,614.0,-38.35882225,141.59550333
 Portland Secondary College,45534.0,2022,PORTLAND,26.0,1.5,67.5,95.0,942.0,Government,Secondary,582.0,-38.35882225,141.59550333
-Portland Secondary College,,2023,PORTLAND,27.0,3.0,44.2,95.0,,,,,,
-Prahran Community Centre,46299.0,2014,PRAHRAN,,,,,1076.0,Independent,Combined,2150.0,-38.26334,145.167227
-Prahran Community Centre,46299.0,2015,PRAHRAN,,,,,1079.0,Independent,Combined,2102.0,-38.26334,145.167227
-Prahran Community Centre,46299.0,2016,PRAHRAN,,,,,1078.0,Independent,Combined,2035.0,-38.26334,145.167227
-Prahran High School,,2023,WINDSOR,32.0,10.1,,,,,,,,
+Portland Secondary College,45534.0,2023,PORTLAND,27.0,3.0,44.2,95.0,,,,,,
+Prahran Community Centre,,2014,PRAHRAN,,,,,,,,,,
+Prahran Community Centre,,2015,PRAHRAN,,,,,,,,,,
+Prahran Community Centre,,2016,PRAHRAN,,,,,,,,,,
+Prahran Community Learn Centre,,2021,PRAHRAN,,,,,,,,,,
+Prahran High School,52698.0,2023,WINDSOR,32.0,10.1,,,,,,,,
 Presbyterian Ladies' College,46162.0,2014,BURWOOD,37.0,28.8,100.0,100.0,1193.0,Independent,Combined,1409.0,-37.848946,145.107125
 Presbyterian Ladies' College,46162.0,2015,BURWOOD,36.0,24.0,100.0,100.0,,Independent,Combined,1410.0,-37.848946,145.107125
 Presbyterian Ladies' College,46162.0,2016,BURWOOD,35.0,22.4,100.0,100.0,1208.0,Independent,Combined,1426.0,-37.848946,145.107125
@@ -3987,21 +4096,31 @@ Presbyterian Ladies' College,46162.0,2019,BURWOOD,35.0,20.1,100.0,100.0,1202.0,I
 Presbyterian Ladies' College,46162.0,2020,BURWOOD,36.0,27.6,100.0,100.0,1199.0,Independent,Combined,1471.0,-37.848946,145.107125
 Presbyterian Ladies' College,46162.0,2021,BURWOOD,36.0,30.4,98.8,100.0,1199.0,Independent,Combined,1463.0,-37.848946,145.107125
 Presbyterian Ladies' College,46162.0,2022,BURWOOD,35.0,21.2,98.3,100.0,1210.0,Independent,Combined,1471.0,-37.848946,145.107125
-Presbyterian Ladies' College,,2023,BURWOOD,35.0,23.0,98.7,100.0,,,,,,
-Presentation College,45638.0,2014,WINDSOR,30.0,6.1,94.0,100.0,1069.0,Catholic,Secondary,851.0,-37.55686069,143.8234695
-Presentation College,45638.0,2015,WINDSOR,30.0,6.5,98.0,100.0,1066.0,Catholic,Secondary,875.0,-37.55686069,143.8234695
-Presentation College,45638.0,2016,WINDSOR,31.0,9.5,93.0,100.0,1061.0,Catholic,Secondary,895.0,-37.55686069,143.8234695
-Presentation College,45638.0,2017,WINDSOR,30.0,6.6,96.0,99.0,1067.0,Catholic,Secondary,918.0,-37.55686069,143.8234695
-Presentation College,45638.0,2018,WINDSOR,30.0,7.5,95.2,99.0,1067.0,Catholic,Secondary,925.0,-37.55686069,143.8234695
-Presentation College,45638.0,2019,WINDSOR,30.0,9.3,90.4,97.0,1073.0,Catholic,Secondary,929.0,-37.55686069,143.8234695
-Presentation College,45638.0,2020,WINDSOR,29.0,3.9,98.2,100.0,1072.0,Catholic,Secondary,981.0,-37.55686069,143.8234695
-Preshil The Margaret Lyttle MS,,2023,KEW,,,,,,,,,,
-Preshil The Margaret Lyttle SC,,2015,KEW,31.0,8.2,85.0,100.0,,,,,,
+Presbyterian Ladies' College,46162.0,2023,BURWOOD,35.0,23.0,98.7,100.0,,,,,,
+Presentation College,,2014,WINDSOR,30.0,6.1,94.0,100.0,,,,,,
+Presentation College,,2015,WINDSOR,30.0,6.5,98.0,100.0,,,,,,
+Presentation College,,2016,WINDSOR,31.0,9.5,93.0,100.0,,,,,,
+Presentation College,,2017,WINDSOR,30.0,6.6,96.0,99.0,,,,,,
+Presentation College,,2018,WINDSOR,30.0,7.5,95.2,99.0,,,,,,
+Presentation College,,2019,WINDSOR,30.0,9.3,90.4,97.0,,,,,,
+Presentation College,,2020,WINDSOR,29.0,3.9,98.2,100.0,,,,,,
+Preshil The Margaret Lyttle MS,46206.0,2023,KEW,,,,,,,,,,
+Preshil The Margaret Lyttle SC,46206.0,2015,KEW,31.0,8.2,85.0,100.0,,,,,,
 Preshil The Margaret Lyttle SC,46206.0,2016,KEW,27.0,3.0,72.0,96.0,1103.0,Independent,Combined,238.0,-37.815934,145.052212
 Preshil The Margaret Lyttle SC,46206.0,2017,KEW,29.0,3.0,85.0,96.0,1140.0,Independent,Combined,238.0,-37.815934,145.052212
 Preshil The Margaret Lyttle SC,46206.0,2018,KEW,30.0,3.7,84.6,96.0,1139.0,Independent,Combined,234.0,-37.815934,145.052212
-Preshil The Margaret Lyttle Schl,,2014,KEW,29.0,7.0,86.0,100.0,,,,,,
-Preston High School,,2023,PRESTON,32.0,16.7,,,,,,,,
+Preshil The Margaret Lyttle Schl,46206.0,2014,KEW,29.0,7.0,86.0,100.0,,,,,,
+Preston High School,52699.0,2023,PRESTON,32.0,16.7,,,,,,,,
+Preston Reservoir ACE,52482.0,2014,RESERVOIR,,,,,,,,,,
+Preston Reservoir ACE,52482.0,2015,RESERVOIR,,,,,,,,,,
+Preston Reservoir ACE,52482.0,2016,RESERVOIR,,,,,,,,,,
+Preston Reservoir ACE,52482.0,2017,RESERVOIR,,,,,,Independent,Special,48.0,-37.698622,145.009236
+Preston Reservoir ACE,52482.0,2018,RESERVOIR,,,,,,Independent,Special,51.0,-37.698622,145.009236
+Preston Reservoir ACE,52482.0,2019,RESERVOIR,,,,,,Independent,Special,54.0,-37.698622,145.009236
+Preston Reservoir ACE,52482.0,2020,RESERVOIR,,,,,,Independent,Special,47.0,-37.698622,145.009236
+Preston Reservoir ACE,52482.0,2021,RESERVOIR,,,,,956.0,Independent,Special,44.0,-37.698622,145.009236
+Preston Reservoir ACE,52482.0,2022,RESERVOIR,,,,,932.0,Independent,Special,77.0,-37.698622,145.009236
+Preston Reservoir ACE,52482.0,2023,RESERVOIR,,,,,,,,,,
 Princes Hill Sec College,45454.0,2014,PRINCES HILL,32.0,14.2,96.0,96.0,1143.0,Government,Secondary,867.0,-37.783481,144.96503
 Princes Hill Sec College,45454.0,2015,PRINCES HILL,31.0,7.7,93.0,98.0,1151.0,Government,Secondary,868.0,-37.783481,144.96503
 Princes Hill Sec College,45454.0,2016,PRINCES HILL,31.0,7.8,90.0,98.0,1149.0,Government,Secondary,886.0,-37.783481,144.96503
@@ -4011,8 +4130,16 @@ Princes Hill Sec College,45454.0,2019,PRINCES HILL,32.0,9.9,85.7,98.0,1150.0,Gov
 Princes Hill Sec College,45454.0,2020,PRINCES HILL,32.0,7.4,92.9,99.0,1150.0,Government,Secondary,870.0,-37.783481,144.96503
 Princes Hill Sec College,45454.0,2021,PRINCES HILL,32.0,8.5,80.9,100.0,1148.0,Government,Secondary,863.0,-37.783481,144.96503
 Princes Hill Sec College,45454.0,2022,PRINCES HILL,32.0,9.1,89.7,97.0,1149.0,Government,Secondary,853.0,-37.783481,144.96503
-Princes Hill Sec College,,2023,PRINCES HILL,31.0,7.5,95.6,100.0,,,,,,
-Pyramid Hill College,,2023,PYRAMID HILL,,,,,,,,,,
+Princes Hill Sec College,45454.0,2023,PRINCES HILL,31.0,7.5,95.6,100.0,,,,,,
+Pyramid Hill College,44346.0,2023,PYRAMID HILL,,,,,,,,,,
+RMIT TAFE,,2014,CARLTON,27.0,1.1,64.0,82.0,,,,,,
+RMIT TAFE,,2015,CARLTON,26.0,2.7,57.0,73.0,,,,,,
+RMIT TAFE,,2016,CARLTON,25.0,3.1,52.0,73.0,,,,,,
+RMIT TAFE,,2017,CARLTON,25.0,1.7,52.0,70.0,,,,,,
+RMIT TAFE,,2018,MELBOURNE,26.0,2.2,51.8,69.0,,,,,,
+RMIT TAFE,,2019,MELBOURNE,25.0,2.3,57.5,81.0,,,,,,
+RMIT TAFE,,2020,MELBOURNE,25.0,2.7,57.7,69.0,,,,,,
+RMIT TAFE,,2021,MELBOURNE,26.0,1.9,62.4,78.0,,,,,,
 Rainbow P-12 College,51482.0,2015,RAINBOW,26.0,0.0,71.0,71.0,1034.0,Government,Combined,119.0,-35.89446757,141.99669972
 Rainbow P-12 College,51482.0,2016,RAINBOW,28.0,2.9,75.0,88.0,1016.0,Government,Combined,135.0,-35.89446757,141.99669972
 Rainbow P-12 College,51482.0,2017,RAINBOW,28.0,2.5,71.0,100.0,999.0,Government,Combined,134.0,-35.89446757,141.99669972
@@ -4021,8 +4148,8 @@ Rainbow P-12 College,51482.0,2019,RAINBOW,29.0,4.9,83.3,100.0,991.0,Government,C
 Rainbow P-12 College,51482.0,2020,RAINBOW,28.0,0.0,62.5,100.0,999.0,Government,Combined,109.0,-35.89446757,141.99669972
 Rainbow P-12 College,51482.0,2021,RAINBOW,27.0,0.0,71.4,100.0,999.0,Government,Combined,112.0,-35.89446757,141.99669972
 Rainbow P-12 College,51482.0,2022,RAINBOW,23.0,0.0,40.0,100.0,999.0,Government,Combined,106.0,-35.89446757,141.99669972
-Rainbow P-12 College,,2023,RAINBOW,23.0,,33.3,100.0,,,,,,
-Rainbow Secondary College,45459.0,2014,RAINBOW,28.0,0.0,50.0,83.0,1038.0,Government,Secondary,1450.0,-37.816606,145.239147
+Rainbow P-12 College,51482.0,2023,RAINBOW,23.0,,33.3,100.0,,,,,,
+Rainbow Secondary College,51482.0,2014,RAINBOW,28.0,0.0,50.0,83.0,,,,,,
 Red Cliffs Secondary College,45458.0,2014,RED CLIFFS,25.0,2.4,50.0,98.0,951.0,Government,Secondary,725.0,-34.298804,142.195452
 Red Cliffs Secondary College,45458.0,2015,RED CLIFFS,25.0,0.8,67.0,99.0,943.0,Government,Secondary,740.0,-34.298804,142.195452
 Red Cliffs Secondary College,45458.0,2016,RED CLIFFS,25.0,1.0,59.0,92.0,947.0,Government,Secondary,776.0,-34.298804,142.195452
@@ -4032,10 +4159,10 @@ Red Cliffs Secondary College,45458.0,2019,RED CLIFFS,22.0,0.0,63.2,100.0,938.0,G
 Red Cliffs Secondary College,45458.0,2020,RED CLIFFS,24.0,0.6,60.6,97.0,937.0,Government,Secondary,518.0,-34.298804,142.195452
 Red Cliffs Secondary College,45458.0,2021,RED CLIFFS,25.0,0.0,31.0,93.0,935.0,Government,Secondary,474.0,-34.298804,142.195452
 Red Cliffs Secondary College,45458.0,2022,RED CLIFFS,20.0,1.0,41.7,83.0,922.0,Government,Secondary,428.0,-34.298804,142.195452
-Red Cliffs Secondary College,,2023,RED CLIFFS,22.0,,47.6,90.0,,,,,,
+Red Cliffs Secondary College,45458.0,2023,RED CLIFFS,22.0,,47.6,90.0,,,,,,
 Red Rock Christian College,46342.0,2021,SUNBURY,29.0,0.0,,,1067.0,Independent,Combined,178.0,-37.5191,144.706
 Red Rock Christian College,46342.0,2022,SUNBURY,29.0,7.7,28.6,71.0,1066.0,Independent,Combined,180.0,-37.5191,144.706
-Red Rock Christian College,,2023,SUNBURY,23.0,7.1,25.0,100.0,,,,,,
+Red Rock Christian College,46342.0,2023,SUNBURY,23.0,7.1,25.0,100.0,,,,,,
 Reservoir High School,45498.0,2014,RESERVOIR,24.0,2.1,92.0,99.0,930.0,Government,Secondary,558.0,-37.722259,145.029772
 Reservoir High School,45498.0,2015,RESERVOIR,24.0,1.5,88.0,97.0,944.0,Government,Secondary,563.0,-37.722259,145.029772
 Reservoir High School,45498.0,2016,RESERVOIR,26.0,2.7,71.0,92.0,950.0,Government,Secondary,586.0,-37.722259,145.029772
@@ -4045,9 +4172,9 @@ Reservoir High School,45498.0,2019,RESERVOIR,27.0,3.3,85.7,100.0,972.0,Governmen
 Reservoir High School,45498.0,2020,RESERVOIR,28.0,2.7,75.0,96.0,976.0,Government,Secondary,690.0,-37.722259,145.029772
 Reservoir High School,45498.0,2021,RESERVOIR,28.0,3.9,78.8,96.0,977.0,Government,Secondary,682.0,-37.722259,145.029772
 Reservoir High School,45498.0,2022,RESERVOIR,27.0,4.6,77.9,95.0,976.0,Government,Secondary,691.0,-37.722259,145.029772
-Reservoir High School,,2023,RESERVOIR,26.0,1.1,55.4,91.0,,,,,,
+Reservoir High School,45498.0,2023,RESERVOIR,26.0,1.1,55.4,91.0,,,,,,
 Richmond High School,52703.0,2022,RICHMOND,29.0,10.0,,,1076.0,Government,Secondary,507.0,-37.817503,145.002623
-Richmond High School,,2023,RICHMOND,28.0,7.8,78.4,95.0,,,,,,
+Richmond High School,52703.0,2023,RICHMOND,28.0,7.8,78.4,95.0,,,,,,
 Ringwood Secondary College,45459.0,2014,RINGWOOD,30.0,9.7,91.0,99.0,1038.0,Government,Secondary,1450.0,-37.816606,145.239147
 Ringwood Secondary College,45459.0,2015,RINGWOOD,31.0,9.1,93.0,97.0,1040.0,Government,Secondary,1490.0,-37.816606,145.239147
 Ringwood Secondary College,45459.0,2016,RINGWOOD,30.0,7.9,92.0,97.0,1038.0,Government,Secondary,1523.0,-37.816606,145.239147
@@ -4057,14 +4184,14 @@ Ringwood Secondary College,45459.0,2019,RINGWOOD,30.0,7.0,78.9,99.0,1046.0,Gover
 Ringwood Secondary College,45459.0,2020,RINGWOOD,30.0,9.9,83.8,98.0,1045.0,Government,Secondary,1581.0,-37.816606,145.239147
 Ringwood Secondary College,45459.0,2021,RINGWOOD,30.0,7.0,85.3,98.0,1045.0,Government,Secondary,1572.0,-37.816606,145.239147
 Ringwood Secondary College,45459.0,2022,RINGWOOD,30.0,9.0,74.4,96.0,1045.0,Government,Secondary,1545.0,-37.816606,145.239147
-Ringwood Secondary College,,2023,RINGWOOD,30.0,7.3,69.4,94.0,,,,,,
+Ringwood Secondary College,45459.0,2023,RINGWOOD,30.0,7.3,69.4,94.0,,,,,,
 River Nile School,52480.0,2017,NORTH MELBOURNE,,,,,,Independent,Special,34.0,-37.805092,144.955013
 River Nile School,52480.0,2018,NORTH MELBOURNE,,,,,,Independent,Special,42.0,-37.805092,144.955013
 River Nile School,52480.0,2019,NORTH MELBOURNE,,,,,844.0,Independent,Special,74.0,-37.805092,144.955013
 River Nile School,52480.0,2020,NORTH MELBOURNE,,,,,822.0,Independent,Special,103.0,-37.805092,144.955013
 River Nile School,52480.0,2021,NORTH MELBOURNE,,,,,810.0,Independent,Special,99.0,-37.805092,144.955013
 River Nile School,52480.0,2022,NORTH MELBOURNE,,,,,775.0,Independent,Special,100.0,-37.805092,144.955013
-River Nile School,,2023,NORTH MELBOURNE,,,7.1,79.0,,,,,,
+River Nile School,52480.0,2023,NORTH MELBOURNE,,,7.1,79.0,,,,,,
 Robinvale College,52377.0,2016,ROBINVALE,25.0,1.6,24.0,94.0,867.0,Government,Combined,433.0,-34.58888676,142.78154505
 Robinvale College,52377.0,2017,ROBINVALE,24.0,1.0,46.0,95.0,876.0,Government,Combined,397.0,-34.58888676,142.78154505
 Robinvale College,52377.0,2018,ROBINVALE,21.0,1.5,75.0,94.0,870.0,Government,Combined,387.0,-34.58888676,142.78154505
@@ -4072,9 +4199,9 @@ Robinvale College,52377.0,2019,ROBINVALE,26.0,0.0,20.0,100.0,871.0,Government,Co
 Robinvale College,52377.0,2020,ROBINVALE,27.0,0.0,40.0,90.0,861.0,Government,Combined,333.0,-34.58888676,142.78154505
 Robinvale College,52377.0,2021,ROBINVALE,27.0,2.6,60.0,100.0,863.0,Government,Combined,304.0,-34.58888676,142.78154505
 Robinvale College,52377.0,2022,ROBINVALE,25.0,7.1,45.5,100.0,848.0,Government,Combined,283.0,-34.58888676,142.78154505
-Robinvale College,,2023,ROBINVALE,22.0,,33.3,92.0,,,,,,
-Robinvale P-12 College,,2014,ROBINVALE,25.0,1.2,60.0,95.0,,,,,,
-Robinvale P-12 College,,2015,ROBINVALE,23.0,0.0,50.0,100.0,,,,,,
+Robinvale College,52377.0,2023,ROBINVALE,22.0,,33.3,92.0,,,,,,
+Robinvale P-12 College,52377.0,2014,ROBINVALE,25.0,1.2,60.0,95.0,,,,,,
+Robinvale P-12 College,52377.0,2015,ROBINVALE,23.0,0.0,50.0,100.0,,,,,,
 Rochester Secondary College,45460.0,2014,ROCHESTER,29.0,4.3,88.0,100.0,979.0,Government,Secondary,448.0,-36.35277863,144.69869634
 Rochester Secondary College,45460.0,2015,ROCHESTER,28.0,2.3,86.0,100.0,977.0,Government,Secondary,413.0,-36.35277863,144.69869634
 Rochester Secondary College,45460.0,2016,ROCHESTER,27.0,1.3,83.0,98.0,974.0,Government,Secondary,397.0,-36.35277863,144.69869634
@@ -4084,7 +4211,7 @@ Rochester Secondary College,45460.0,2019,ROCHESTER,27.0,2.2,69.0,100.0,972.0,Gov
 Rochester Secondary College,45460.0,2020,ROCHESTER,31.0,4.2,50.0,97.0,967.0,Government,Secondary,297.0,-36.35277863,144.69869634
 Rochester Secondary College,45460.0,2021,ROCHESTER,28.0,1.4,83.3,100.0,966.0,Government,Secondary,308.0,-36.35277863,144.69869634
 Rochester Secondary College,45460.0,2022,ROCHESTER,29.0,0.8,78.6,100.0,952.0,Government,Secondary,313.0,-36.35277863,144.69869634
-Rochester Secondary College,,2023,ROCHESTER,27.0,2.0,45.7,91.0,,,,,,
+Rochester Secondary College,45460.0,2023,ROCHESTER,27.0,2.0,45.7,91.0,,,,,,
 Rosebud Secondary College,45461.0,2014,ROSEBUD,30.0,4.7,82.0,97.0,990.0,Government,Secondary,1161.0,-38.367615,144.887447
 Rosebud Secondary College,45461.0,2015,ROSEBUD,29.0,4.4,70.0,99.0,989.0,Government,Secondary,1144.0,-38.367615,144.887447
 Rosebud Secondary College,45461.0,2016,ROSEBUD,28.0,2.8,72.0,100.0,988.0,Government,Secondary,1054.0,-38.367615,144.887447
@@ -4094,7 +4221,7 @@ Rosebud Secondary College,45461.0,2019,ROSEBUD,28.0,2.4,75.3,99.0,986.0,Governme
 Rosebud Secondary College,45461.0,2020,ROSEBUD,27.0,2.3,68.2,99.0,985.0,Government,Secondary,855.0,-38.367615,144.887447
 Rosebud Secondary College,45461.0,2021,ROSEBUD,28.0,5.1,83.3,100.0,987.0,Government,Secondary,867.0,-38.367615,144.887447
 Rosebud Secondary College,45461.0,2022,ROSEBUD,28.0,3.9,68.2,97.0,982.0,Government,Secondary,856.0,-38.367615,144.887447
-Rosebud Secondary College,,2023,ROSEBUD,28.0,0.6,43.6,93.0,,,,,,
+Rosebud Secondary College,45461.0,2023,ROSEBUD,28.0,0.6,43.6,93.0,,,,,,
 Rosehill Secondary College,45340.0,2014,NIDDRIE,30.0,5.9,81.0,93.0,997.0,Government,Secondary,1145.0,-37.7473,144.886
 Rosehill Secondary College,45340.0,2015,NIDDRIE,30.0,3.9,76.0,96.0,1001.0,Government,Secondary,1159.0,-37.7473,144.886
 Rosehill Secondary College,45340.0,2016,NIDDRIE,29.0,2.2,75.0,96.0,999.0,Government,Secondary,1151.0,-37.7473,144.886
@@ -4104,7 +4231,7 @@ Rosehill Secondary College,45340.0,2019,NIDDRIE,29.0,2.7,86.5,98.0,1013.0,Govern
 Rosehill Secondary College,45340.0,2020,NIDDRIE,29.0,2.8,93.6,99.0,1013.0,Government,Secondary,1115.0,-37.7473,144.886
 Rosehill Secondary College,45340.0,2021,NIDDRIE,29.0,5.4,89.9,99.0,1018.0,Government,Secondary,1106.0,-37.7473,144.886
 Rosehill Secondary College,45340.0,2022,NIDDRIE,28.0,3.7,87.2,99.0,1020.0,Government,Secondary,1113.0,-37.7473,144.886
-Rosehill Secondary College,,2023,NIDDRIE,28.0,3.7,76.1,98.0,,,,,,
+Rosehill Secondary College,45340.0,2023,NIDDRIE,28.0,3.7,76.1,98.0,,,,,,
 Rowville Secondary College,45512.0,2014,ROWVILLE,26.0,2.4,59.0,94.0,1008.0,Government,Secondary,1814.0,-37.92388682,145.23708852
 Rowville Secondary College,45512.0,2015,ROWVILLE,26.0,2.2,63.0,96.0,1007.0,Government,Secondary,1786.0,-37.92388682,145.23708852
 Rowville Secondary College,45512.0,2016,ROWVILLE,26.0,2.1,56.0,90.0,1006.0,Government,Secondary,1783.0,-37.92388682,145.23708852
@@ -4114,7 +4241,7 @@ Rowville Secondary College,45512.0,2019,ROWVILLE,26.0,1.0,55.7,94.0,1020.0,Gover
 Rowville Secondary College,45512.0,2020,ROWVILLE,25.0,1.9,66.5,96.0,1020.0,Government,Secondary,1836.0,-37.92388682,145.23708852
 Rowville Secondary College,45512.0,2021,ROWVILLE,26.0,3.1,62.1,95.0,1019.0,Government,Secondary,1803.0,-37.92388682,145.23708852
 Rowville Secondary College,45512.0,2022,ROWVILLE,26.0,2.0,55.9,96.0,1020.0,Government,Secondary,1777.0,-37.92388682,145.23708852
-Rowville Secondary College,,2023,ROWVILLE,26.0,1.6,41.3,94.0,,,,,,
+Rowville Secondary College,45512.0,2023,ROWVILLE,26.0,1.6,41.3,94.0,,,,,,
 Roxburgh College,45476.0,2014,ROXBURGH PARK,24.0,1.7,93.0,91.0,915.0,Government,Secondary,1236.0,-37.63062884,144.92945915
 Roxburgh College,45476.0,2015,ROXBURGH PARK,24.0,0.7,88.0,88.0,913.0,Government,Secondary,1305.0,-37.63062884,144.92945915
 Roxburgh College,45476.0,2016,ROXBURGH PARK,25.0,0.5,96.0,96.0,911.0,Government,Secondary,1323.0,-37.63062884,144.92945915
@@ -4124,7 +4251,7 @@ Roxburgh College,45476.0,2019,ROXBURGH PARK,26.0,0.2,86.5,88.0,923.0,Government,
 Roxburgh College,45476.0,2020,ROXBURGH PARK,24.0,1.4,90.3,90.0,921.0,Government,Secondary,1339.0,-37.63062884,144.92945915
 Roxburgh College,45476.0,2021,ROXBURGH PARK,25.0,3.0,90.8,93.0,920.0,Government,Secondary,1251.0,-37.63062884,144.92945915
 Roxburgh College,45476.0,2022,ROXBURGH PARK,24.0,1.0,92.6,97.0,915.0,Government,Secondary,1154.0,-37.63062884,144.92945915
-Roxburgh College,,2023,ROXBURGH PARK,24.0,2.5,74.4,95.0,,,,,,
+Roxburgh College,45476.0,2023,ROXBURGH PARK,24.0,2.5,74.4,95.0,,,,,,
 Rushworth P-12 College,45310.0,2014,RUSHWORTH,25.0,0.0,44.0,100.0,936.0,Government,Combined,165.0,-36.583317,145.014399
 Rushworth P-12 College,45310.0,2015,RUSHWORTH,25.0,0.0,64.0,100.0,938.0,Government,Combined,157.0,-36.583317,145.014399
 Rushworth P-12 College,45310.0,2016,RUSHWORTH,23.0,0.0,50.0,100.0,929.0,Government,Combined,158.0,-36.583317,145.014399
@@ -4134,7 +4261,7 @@ Rushworth P-12 College,45310.0,2019,RUSHWORTH,22.0,0.0,42.9,100.0,911.0,Governme
 Rushworth P-12 College,45310.0,2020,RUSHWORTH,25.0,2.2,85.7,100.0,911.0,Government,Combined,155.0,-36.583317,145.014399
 Rushworth P-12 College,45310.0,2021,RUSHWORTH,25.0,0.0,100.0,100.0,907.0,Government,Combined,140.0,-36.583317,145.014399
 Rushworth P-12 College,45310.0,2022,RUSHWORTH,27.0,3.3,71.4,86.0,896.0,Government,Combined,132.0,-36.583317,145.014399
-Rushworth P-12 College,,2023,RUSHWORTH,24.0,,57.1,100.0,,,,,,
+Rushworth P-12 College,45310.0,2023,RUSHWORTH,24.0,,57.1,100.0,,,,,,
 Rutherglen High School,45462.0,2014,RUTHERGLEN,26.0,0.7,24.0,94.0,948.0,Government,Secondary,285.0,-36.062564,146.452103
 Rutherglen High School,45462.0,2015,RUTHERGLEN,26.0,1.4,62.0,100.0,951.0,Government,Secondary,283.0,-36.062564,146.452103
 Rutherglen High School,45462.0,2016,RUTHERGLEN,25.0,4.0,40.0,96.0,951.0,Government,Secondary,267.0,-36.062564,146.452103
@@ -4144,7 +4271,7 @@ Rutherglen High School,45462.0,2019,RUTHERGLEN,26.0,1.8,22.7,100.0,965.0,Governm
 Rutherglen High School,45462.0,2020,RUTHERGLEN,25.0,1.1,31.8,95.0,964.0,Government,Secondary,290.0,-36.062564,146.452103
 Rutherglen High School,45462.0,2021,RUTHERGLEN,24.0,0.9,33.3,95.0,972.0,Government,Secondary,272.0,-36.062564,146.452103
 Rutherglen High School,45462.0,2022,RUTHERGLEN,23.0,0.0,26.1,91.0,967.0,Government,Secondary,294.0,-36.062564,146.452103
-Rutherglen High School,,2023,RUTHERGLEN,24.0,,16.7,94.0,,,,,,
+Rutherglen High School,45462.0,2023,RUTHERGLEN,24.0,,16.7,94.0,,,,,,
 Ruyton Girls' School,46138.0,2014,KEW,38.0,37.7,100.0,100.0,,Independent,Combined,752.0,-37.81119789,145.0388602
 Ruyton Girls' School,46138.0,2015,KEW,35.0,21.2,100.0,100.0,1176.0,Independent,Combined,800.0,-37.81119789,145.0388602
 Ruyton Girls' School,46138.0,2016,KEW,37.0,30.3,100.0,100.0,1182.0,Independent,Combined,820.0,-37.81119789,145.0388602
@@ -4154,14 +4281,15 @@ Ruyton Girls' School,46138.0,2019,KEW,36.0,32.2,100.0,100.0,1185.0,Independent,C
 Ruyton Girls' School,46138.0,2020,KEW,36.0,27.1,100.0,100.0,1185.0,Independent,Combined,885.0,-37.81119789,145.0388602
 Ruyton Girls' School,46138.0,2021,KEW,36.0,27.1,97.8,99.0,1185.0,Independent,Combined,870.0,-37.81119789,145.0388602
 Ruyton Girls' School,46138.0,2022,KEW,36.0,28.3,100.0,100.0,1193.0,Independent,Combined,851.0,-37.81119789,145.0388602
-Ruyton Girls' School,,2023,KEW,37.0,31.4,100.0,100.0,,,,,,
-SEDA College,40835.0,2017,HAWTHORN EAST,,,,,,Independent,Special,117.0,-38.178231,145.926224
-SEDA College,40835.0,2018,HAWTHORN EAST,,,,,,Independent,Special,102.0,-38.178231,145.926224
-SEDA College,40835.0,2019,HAWTHORN EAST,,,,,,Independent,Special,128.0,-38.178231,145.926224
-SEDA College,40835.0,2020,HAWTHORN EAST,,,,,,Independent,Special,151.0,-38.178231,145.926224
-SEDA College,40835.0,2021,HAWTHORN EAST,,,,,965.0,Independent,Special,166.0,-38.178231,145.926224
-SEDA College,40835.0,2022,HAWTHORN EAST,,,,,957.0,Independent,Special,167.0,-38.178231,145.926224
-SEDA College,,2023,HAWTHORN EAST,,,4.9,100.0,,,,,,
+Ruyton Girls' School,46138.0,2023,KEW,37.0,31.4,100.0,100.0,,,,,,
+SEDA College,52527.0,2017,HAWTHORN EAST,,,,,,Independent,Secondary,794.0,-37.83088,145.05387
+SEDA College,52527.0,2018,HAWTHORN EAST,,,,,,Independent,Secondary,725.0,-37.83088,145.05387
+SEDA College,52527.0,2019,HAWTHORN EAST,,,,,,Independent,Secondary,723.0,-37.83088,145.05387
+SEDA College,52527.0,2020,HAWTHORN EAST,,,,,1020.0,Independent,Secondary,785.0,-37.83088,145.05387
+SEDA College,52527.0,2021,HAWTHORN EAST,,,,,1024.0,Independent,Secondary,723.0,-37.83088,145.05387
+SEDA College,52527.0,2022,HAWTHORN EAST,,,,,1022.0,Independent,Secondary,644.0,-37.83088,145.05387
+SEDA College,52527.0,2023,HAWTHORN EAST,,,4.9,100.0,,,,,,
+SEDA Group,,2016,HAWTHORN EAST,,,,,,,,,,
 Sacre Coeur,45654.0,2014,GLEN IRIS,36.0,24.9,100.0,100.0,1176.0,Catholic,Combined,730.0,-37.86151677,145.05261988
 Sacre Coeur,45654.0,2015,GLEN IRIS,35.0,23.9,100.0,100.0,1181.0,Catholic,Combined,726.0,-37.86151677,145.05261988
 Sacre Coeur,45654.0,2016,GLEN IRIS,36.0,27.1,100.0,100.0,1179.0,Catholic,Combined,731.0,-37.86151677,145.05261988
@@ -4171,91 +4299,37 @@ Sacre Coeur,45654.0,2019,GLEN IRIS,35.0,23.0,100.0,100.0,1178.0,Catholic,Combine
 Sacre Coeur,45654.0,2020,GLEN IRIS,35.0,20.8,98.8,100.0,1175.0,Catholic,Combined,710.0,-37.86151677,145.05261988
 Sacre Coeur,45654.0,2021,GLEN IRIS,35.0,18.6,100.0,100.0,1174.0,Catholic,Combined,709.0,-37.86151677,145.05261988
 Sacre Coeur,45654.0,2022,GLEN IRIS,36.0,20.6,98.9,100.0,1181.0,Catholic,Combined,681.0,-37.86151677,145.05261988
-Sacre Coeur,,2023,GLEN IRIS,36.0,27.0,98.9,100.0,,,,,,
+Sacre Coeur,45654.0,2023,GLEN IRIS,36.0,27.0,98.9,100.0,,,,,,
 Sacred Heart College,45672.0,2014,YARRAWONGA,28.0,1.3,66.0,100.0,1083.0,Catholic,Secondary,1369.0,-38.14949635,144.34014532
-Sacred Heart College,45682.0,2014,YARRAWONGA,28.0,1.3,66.0,100.0,1064.0,Catholic,Secondary,819.0,-37.252887,144.458821
-Sacred Heart College,45717.0,2014,YARRAWONGA,28.0,1.3,66.0,100.0,1007.0,Catholic,Secondary,279.0,-36.008887,146.009947
 Sacred Heart College,45672.0,2015,YARRAWONGA,29.0,2.5,81.0,100.0,1084.0,Catholic,Secondary,1379.0,-38.14949635,144.34014532
-Sacred Heart College,45682.0,2015,YARRAWONGA,29.0,2.5,81.0,100.0,1063.0,Catholic,Secondary,831.0,-37.252887,144.458821
-Sacred Heart College,45717.0,2015,YARRAWONGA,29.0,2.5,81.0,100.0,1015.0,Catholic,Secondary,259.0,-36.008887,146.009947
 Sacred Heart College,45672.0,2016,YARRAWONGA,28.0,1.7,79.0,100.0,1084.0,Catholic,Secondary,1414.0,-38.14949635,144.34014532
-Sacred Heart College,45682.0,2016,YARRAWONGA,28.0,1.7,79.0,100.0,1062.0,Catholic,Secondary,828.0,-37.252887,144.458821
-Sacred Heart College,45717.0,2016,YARRAWONGA,28.0,1.7,79.0,100.0,1013.0,Catholic,Secondary,245.0,-36.008887,146.009947
 Sacred Heart College,45672.0,2017,YARRAWONGA,28.0,1.0,100.0,100.0,1087.0,Catholic,Secondary,1426.0,-38.14949635,144.34014532
-Sacred Heart College,45682.0,2017,YARRAWONGA,28.0,1.0,100.0,100.0,1062.0,Catholic,Secondary,805.0,-37.252887,144.458821
-Sacred Heart College,45717.0,2017,YARRAWONGA,28.0,1.0,100.0,100.0,1016.0,Catholic,Secondary,265.0,-36.008887,146.009947
 Sacred Heart College,45672.0,2018,YARRAWONGA,28.0,4.9,72.2,100.0,1083.0,Catholic,Secondary,1455.0,-38.14949635,144.34014532
-Sacred Heart College,45682.0,2018,YARRAWONGA,28.0,4.9,72.2,100.0,1059.0,Catholic,Secondary,801.0,-37.252887,144.458821
-Sacred Heart College,45717.0,2018,YARRAWONGA,28.0,4.9,72.2,100.0,1018.0,Catholic,Secondary,269.0,-36.008887,146.009947
 Sacred Heart College,45672.0,2019,YARRAWONGA,28.0,4.3,86.2,100.0,1087.0,Catholic,Secondary,1484.0,-38.14949635,144.34014532
-Sacred Heart College,45682.0,2019,YARRAWONGA,28.0,4.3,86.2,100.0,1062.0,Catholic,Secondary,759.0,-37.252887,144.458821
-Sacred Heart College,45717.0,2019,YARRAWONGA,28.0,4.3,86.2,100.0,1021.0,Catholic,Secondary,275.0,-36.008887,146.009947
 Sacred Heart College,45672.0,2020,YARRAWONGA,28.0,3.4,80.6,100.0,1089.0,Catholic,Secondary,1502.0,-38.14949635,144.34014532
-Sacred Heart College,45682.0,2020,YARRAWONGA,28.0,3.4,80.6,100.0,1065.0,Catholic,Secondary,791.0,-37.252887,144.458821
-Sacred Heart College,45717.0,2020,YARRAWONGA,28.0,3.4,80.6,100.0,1017.0,Catholic,Secondary,259.0,-36.008887,146.009947
 Sacred Heart College,45672.0,2021,YARRAWONGA,29.0,4.5,80.0,100.0,1091.0,Catholic,Secondary,1488.0,-38.14949635,144.34014532
-Sacred Heart College,45682.0,2021,YARRAWONGA,29.0,4.5,80.0,100.0,1068.0,Catholic,Secondary,788.0,-37.252887,144.458821
-Sacred Heart College,45717.0,2021,YARRAWONGA,29.0,4.5,80.0,100.0,1017.0,Catholic,Secondary,250.0,-36.008887,146.009947
 Sacred Heart College,45672.0,2022,YARRAWONGA,30.0,12.7,90.5,100.0,1094.0,Catholic,Secondary,1451.0,-38.14949635,144.34014532
-Sacred Heart College,45682.0,2022,YARRAWONGA,30.0,12.7,90.5,100.0,1071.0,Catholic,Secondary,791.0,-37.252887,144.458821
-Sacred Heart College,45717.0,2022,YARRAWONGA,30.0,12.7,90.5,100.0,1018.0,Catholic,Secondary,227.0,-36.008887,146.009947
-Sacred Heart College,,2023,YARRAWONGA,27.0,,81.3,100.0,,,,,,
+Sacred Heart College,45672.0,2023,YARRAWONGA,27.0,,81.3,100.0,,,,,,
 Sacred Heart College Geelong,45672.0,2014,NEWTOWN,33.0,15.0,92.0,99.0,1083.0,Catholic,Secondary,1369.0,-38.14949635,144.34014532
-Sacred Heart College Geelong,45682.0,2014,NEWTOWN,33.0,15.0,92.0,99.0,1064.0,Catholic,Secondary,819.0,-37.252887,144.458821
-Sacred Heart College Geelong,45717.0,2014,NEWTOWN,33.0,15.0,92.0,99.0,1007.0,Catholic,Secondary,279.0,-36.008887,146.009947
 Sacred Heart College Geelong,45672.0,2015,NEWTOWN,33.0,13.8,95.0,99.0,1084.0,Catholic,Secondary,1379.0,-38.14949635,144.34014532
-Sacred Heart College Geelong,45682.0,2015,NEWTOWN,33.0,13.8,95.0,99.0,1063.0,Catholic,Secondary,831.0,-37.252887,144.458821
-Sacred Heart College Geelong,45717.0,2015,NEWTOWN,33.0,13.8,95.0,99.0,1015.0,Catholic,Secondary,259.0,-36.008887,146.009947
 Sacred Heart College Geelong,45672.0,2016,NEWTOWN,33.0,13.5,92.0,100.0,1084.0,Catholic,Secondary,1414.0,-38.14949635,144.34014532
-Sacred Heart College Geelong,45682.0,2016,NEWTOWN,33.0,13.5,92.0,100.0,1062.0,Catholic,Secondary,828.0,-37.252887,144.458821
-Sacred Heart College Geelong,45717.0,2016,NEWTOWN,33.0,13.5,92.0,100.0,1013.0,Catholic,Secondary,245.0,-36.008887,146.009947
 Sacred Heart College Geelong,45672.0,2017,NEWTOWN,34.0,13.6,91.0,100.0,1087.0,Catholic,Secondary,1426.0,-38.14949635,144.34014532
-Sacred Heart College Geelong,45682.0,2017,NEWTOWN,34.0,13.6,91.0,100.0,1062.0,Catholic,Secondary,805.0,-37.252887,144.458821
-Sacred Heart College Geelong,45717.0,2017,NEWTOWN,34.0,13.6,91.0,100.0,1016.0,Catholic,Secondary,265.0,-36.008887,146.009947
 Sacred Heart College Geelong,45672.0,2018,NEWTOWN,31.0,8.0,87.8,100.0,1083.0,Catholic,Secondary,1455.0,-38.14949635,144.34014532
-Sacred Heart College Geelong,45682.0,2018,NEWTOWN,31.0,8.0,87.8,100.0,1059.0,Catholic,Secondary,801.0,-37.252887,144.458821
-Sacred Heart College Geelong,45717.0,2018,NEWTOWN,31.0,8.0,87.8,100.0,1018.0,Catholic,Secondary,269.0,-36.008887,146.009947
 Sacred Heart College Geelong,45672.0,2019,NEWTOWN,32.0,11.6,85.0,100.0,1087.0,Catholic,Secondary,1484.0,-38.14949635,144.34014532
-Sacred Heart College Geelong,45682.0,2019,NEWTOWN,32.0,11.6,85.0,100.0,1062.0,Catholic,Secondary,759.0,-37.252887,144.458821
-Sacred Heart College Geelong,45717.0,2019,NEWTOWN,32.0,11.6,85.0,100.0,1021.0,Catholic,Secondary,275.0,-36.008887,146.009947
 Sacred Heart College Geelong,45672.0,2020,NEWTOWN,32.0,11.2,89.2,100.0,1089.0,Catholic,Secondary,1502.0,-38.14949635,144.34014532
-Sacred Heart College Geelong,45682.0,2020,NEWTOWN,32.0,11.2,89.2,100.0,1065.0,Catholic,Secondary,791.0,-37.252887,144.458821
-Sacred Heart College Geelong,45717.0,2020,NEWTOWN,32.0,11.2,89.2,100.0,1017.0,Catholic,Secondary,259.0,-36.008887,146.009947
 Sacred Heart College Geelong,45672.0,2021,NEWTOWN,32.0,12.8,90.3,100.0,1091.0,Catholic,Secondary,1488.0,-38.14949635,144.34014532
-Sacred Heart College Geelong,45682.0,2021,NEWTOWN,32.0,12.8,90.3,100.0,1068.0,Catholic,Secondary,788.0,-37.252887,144.458821
-Sacred Heart College Geelong,45717.0,2021,NEWTOWN,32.0,12.8,90.3,100.0,1017.0,Catholic,Secondary,250.0,-36.008887,146.009947
 Sacred Heart College Geelong,45672.0,2022,NEWTOWN,31.0,7.3,87.0,100.0,1094.0,Catholic,Secondary,1451.0,-38.14949635,144.34014532
-Sacred Heart College Geelong,45682.0,2022,NEWTOWN,31.0,7.3,87.0,100.0,1071.0,Catholic,Secondary,791.0,-37.252887,144.458821
-Sacred Heart College Geelong,45717.0,2022,NEWTOWN,31.0,7.3,87.0,100.0,1018.0,Catholic,Secondary,227.0,-36.008887,146.009947
-Sacred Heart College Geelong,,2023,NEWTOWN,32.0,10.7,79.4,100.0,,,,,,
-Sacred Heart College Kyneton,45672.0,2014,KYNETON,28.0,2.0,90.0,100.0,1083.0,Catholic,Secondary,1369.0,-38.14949635,144.34014532
+Sacred Heart College Geelong,45672.0,2023,NEWTOWN,32.0,10.7,79.4,100.0,,,,,,
 Sacred Heart College Kyneton,45682.0,2014,KYNETON,28.0,2.0,90.0,100.0,1064.0,Catholic,Secondary,819.0,-37.252887,144.458821
-Sacred Heart College Kyneton,45717.0,2014,KYNETON,28.0,2.0,90.0,100.0,1007.0,Catholic,Secondary,279.0,-36.008887,146.009947
-Sacred Heart College Kyneton,45672.0,2015,KYNETON,30.0,2.2,85.0,99.0,1084.0,Catholic,Secondary,1379.0,-38.14949635,144.34014532
 Sacred Heart College Kyneton,45682.0,2015,KYNETON,30.0,2.2,85.0,99.0,1063.0,Catholic,Secondary,831.0,-37.252887,144.458821
-Sacred Heart College Kyneton,45717.0,2015,KYNETON,30.0,2.2,85.0,99.0,1015.0,Catholic,Secondary,259.0,-36.008887,146.009947
-Sacred Heart College Kyneton,45672.0,2016,KYNETON,29.0,3.6,92.0,100.0,1084.0,Catholic,Secondary,1414.0,-38.14949635,144.34014532
 Sacred Heart College Kyneton,45682.0,2016,KYNETON,29.0,3.6,92.0,100.0,1062.0,Catholic,Secondary,828.0,-37.252887,144.458821
-Sacred Heart College Kyneton,45717.0,2016,KYNETON,29.0,3.6,92.0,100.0,1013.0,Catholic,Secondary,245.0,-36.008887,146.009947
-Sacred Heart College Kyneton,45672.0,2017,KYNETON,31.0,9.4,87.0,100.0,1087.0,Catholic,Secondary,1426.0,-38.14949635,144.34014532
 Sacred Heart College Kyneton,45682.0,2017,KYNETON,31.0,9.4,87.0,100.0,1062.0,Catholic,Secondary,805.0,-37.252887,144.458821
-Sacred Heart College Kyneton,45717.0,2017,KYNETON,31.0,9.4,87.0,100.0,1016.0,Catholic,Secondary,265.0,-36.008887,146.009947
-Sacred Heart College Kyneton,45672.0,2018,KYNETON,31.0,6.6,89.6,100.0,1083.0,Catholic,Secondary,1455.0,-38.14949635,144.34014532
 Sacred Heart College Kyneton,45682.0,2018,KYNETON,31.0,6.6,89.6,100.0,1059.0,Catholic,Secondary,801.0,-37.252887,144.458821
-Sacred Heart College Kyneton,45717.0,2018,KYNETON,31.0,6.6,89.6,100.0,1018.0,Catholic,Secondary,269.0,-36.008887,146.009947
-Sacred Heart College Kyneton,45672.0,2019,KYNETON,30.0,5.1,89.5,100.0,1087.0,Catholic,Secondary,1484.0,-38.14949635,144.34014532
 Sacred Heart College Kyneton,45682.0,2019,KYNETON,30.0,5.1,89.5,100.0,1062.0,Catholic,Secondary,759.0,-37.252887,144.458821
-Sacred Heart College Kyneton,45717.0,2019,KYNETON,30.0,5.1,89.5,100.0,1021.0,Catholic,Secondary,275.0,-36.008887,146.009947
-Sacred Heart College Kyneton,45672.0,2020,KYNETON,29.0,4.7,96.8,100.0,1089.0,Catholic,Secondary,1502.0,-38.14949635,144.34014532
 Sacred Heart College Kyneton,45682.0,2020,KYNETON,29.0,4.7,96.8,100.0,1065.0,Catholic,Secondary,791.0,-37.252887,144.458821
-Sacred Heart College Kyneton,45717.0,2020,KYNETON,29.0,4.7,96.8,100.0,1017.0,Catholic,Secondary,259.0,-36.008887,146.009947
-Sacred Heart College Kyneton,45672.0,2021,KYNETON,30.0,3.7,81.1,100.0,1091.0,Catholic,Secondary,1488.0,-38.14949635,144.34014532
 Sacred Heart College Kyneton,45682.0,2021,KYNETON,30.0,3.7,81.1,100.0,1068.0,Catholic,Secondary,788.0,-37.252887,144.458821
-Sacred Heart College Kyneton,45717.0,2021,KYNETON,30.0,3.7,81.1,100.0,1017.0,Catholic,Secondary,250.0,-36.008887,146.009947
-Sacred Heart College Kyneton,45672.0,2022,KYNETON,30.0,4.4,83.1,98.0,1094.0,Catholic,Secondary,1451.0,-38.14949635,144.34014532
 Sacred Heart College Kyneton,45682.0,2022,KYNETON,30.0,4.4,83.1,98.0,1071.0,Catholic,Secondary,791.0,-37.252887,144.458821
-Sacred Heart College Kyneton,45717.0,2022,KYNETON,30.0,4.4,83.1,98.0,1018.0,Catholic,Secondary,227.0,-36.008887,146.009947
-Sacred Heart College Kyneton,,2023,KYNETON,29.0,3.3,82.5,100.0,,,,,,
+Sacred Heart College Kyneton,45682.0,2023,KYNETON,29.0,3.3,82.5,100.0,,,,,,
 Sacred Heart Girls' College,45922.0,2014,HUGHESDALE,33.0,14.5,95.0,99.0,1079.0,Catholic,Secondary,1029.0,-37.902163,145.086083
 Sacred Heart Girls' College,45922.0,2015,HUGHESDALE,33.0,12.8,96.0,100.0,1083.0,Catholic,Secondary,1021.0,-37.902163,145.086083
 Sacred Heart Girls' College,45922.0,2016,HUGHESDALE,33.0,13.8,100.0,100.0,1082.0,Catholic,Secondary,1020.0,-37.902163,145.086083
@@ -4265,7 +4339,7 @@ Sacred Heart Girls' College,45922.0,2019,HUGHESDALE,32.0,12.2,97.5,100.0,1096.0,
 Sacred Heart Girls' College,45922.0,2020,HUGHESDALE,34.0,12.9,97.0,100.0,1099.0,Catholic,Secondary,986.0,-37.902163,145.086083
 Sacred Heart Girls' College,45922.0,2021,HUGHESDALE,32.0,8.8,96.5,99.0,1102.0,Catholic,Secondary,959.0,-37.902163,145.086083
 Sacred Heart Girls' College,45922.0,2022,HUGHESDALE,32.0,12.5,92.9,100.0,1102.0,Catholic,Secondary,961.0,-37.902163,145.086083
-Sacred Heart Girls' College,,2023,HUGHESDALE,32.0,8.2,97.1,100.0,,,,,,
+Sacred Heart Girls' College,45922.0,2023,HUGHESDALE,32.0,8.2,97.1,100.0,,,,,,
 Saint Ignatius College,45721.0,2014,DRYSDALE,31.0,7.7,85.0,100.0,1012.0,Catholic,Secondary,1084.0,-38.18870264,144.55789753
 Saint Ignatius College,45721.0,2015,DRYSDALE,31.0,8.5,76.0,98.0,1048.0,Catholic,Secondary,1137.0,-38.18870264,144.55789753
 Saint Ignatius College,45721.0,2016,DRYSDALE,30.0,8.5,76.0,100.0,1050.0,Catholic,Secondary,1197.0,-38.18870264,144.55789753
@@ -4275,7 +4349,7 @@ Saint Ignatius College,45721.0,2019,DRYSDALE,30.0,5.9,68.8,99.0,1063.0,Catholic,
 Saint Ignatius College,45721.0,2020,DRYSDALE,30.0,5.5,73.8,99.0,1064.0,Catholic,Secondary,1321.0,-38.18870264,144.55789753
 Saint Ignatius College,45721.0,2021,DRYSDALE,31.0,6.9,78.3,100.0,1069.0,Catholic,Secondary,1343.0,-38.18870264,144.55789753
 Saint Ignatius College,45721.0,2022,DRYSDALE,30.0,6.5,71.4,99.0,1070.0,Catholic,Secondary,1363.0,-38.18870264,144.55789753
-Saint Ignatius College,,2023,DRYSDALE,30.0,6.3,67.4,100.0,,,,,,
+Saint Ignatius College,45721.0,2023,DRYSDALE,30.0,6.3,67.4,100.0,,,,,,
 Sale College,40726.0,2014,SALE,27.0,2.2,66.0,90.0,932.0,Government,Secondary,704.0,-38.108921,147.068006
 Sale College,40726.0,2015,SALE,26.0,2.9,70.0,91.0,931.0,Government,Secondary,756.0,-38.108921,147.068006
 Sale College,40726.0,2016,SALE,26.0,2.5,61.0,94.0,941.0,Government,Secondary,744.0,-38.108921,147.068006
@@ -4285,17 +4359,17 @@ Sale College,40726.0,2019,SALE,26.0,1.6,60.3,97.0,946.0,Government,Secondary,798
 Sale College,40726.0,2020,SALE,25.0,0.4,59.7,98.0,946.0,Government,Secondary,843.0,-38.108921,147.068006
 Sale College,40726.0,2021,SALE,26.0,0.0,46.0,94.0,944.0,Government,Secondary,802.0,-38.108921,147.068006
 Sale College,40726.0,2022,SALE,24.0,0.4,64.2,98.0,938.0,Government,Secondary,789.0,-38.108921,147.068006
-Sale College,,2023,SALE,26.0,2.7,54.8,95.0,,,,,,
-Salesian College,40726.0,2014,CHADSTONE,31.0,11.4,91.0,100.0,932.0,Government,Secondary,704.0,-38.108921,147.068006
-Salesian College,40726.0,2015,CHADSTONE,31.0,8.7,93.0,100.0,931.0,Government,Secondary,756.0,-38.108921,147.068006
-Salesian College,40726.0,2016,CHADSTONE,31.0,9.1,88.0,100.0,941.0,Government,Secondary,744.0,-38.108921,147.068006
-Salesian College,40726.0,2017,CHADSTONE,31.0,5.0,91.0,100.0,932.0,Government,Secondary,757.0,-38.108921,147.068006
-Salesian College,40726.0,2018,CHADSTONE,31.0,6.4,89.2,99.0,942.0,Government,Secondary,768.0,-38.108921,147.068006
-Salesian College,40726.0,2019,CHADSTONE,31.0,8.0,89.6,98.0,946.0,Government,Secondary,798.0,-38.108921,147.068006
-Salesian College,40726.0,2020,CHADSTONE,30.0,4.0,91.6,99.0,946.0,Government,Secondary,843.0,-38.108921,147.068006
-Salesian College,40726.0,2021,CHADSTONE,31.0,8.5,83.2,99.0,944.0,Government,Secondary,802.0,-38.108921,147.068006
-Salesian College,40726.0,2022,CHADSTONE,31.0,8.9,87.3,100.0,938.0,Government,Secondary,789.0,-38.108921,147.068006
-Salesian College,,2023,CHADSTONE,32.0,11.7,80.9,99.0,,,,,,
+Sale College,40726.0,2023,SALE,26.0,2.7,54.8,95.0,,,,,,
+Salesian College,45870.0,2014,CHADSTONE,31.0,11.4,91.0,100.0,1060.0,Catholic,Secondary,933.0,-37.882735,145.100257
+Salesian College,45870.0,2015,CHADSTONE,31.0,8.7,93.0,100.0,1064.0,Catholic,Secondary,957.0,-37.882735,145.100257
+Salesian College,45870.0,2016,CHADSTONE,31.0,9.1,88.0,100.0,1066.0,Catholic,Secondary,965.0,-37.882735,145.100257
+Salesian College,45870.0,2017,CHADSTONE,31.0,5.0,91.0,100.0,1071.0,Catholic,Secondary,1024.0,-37.882735,145.100257
+Salesian College,45870.0,2018,CHADSTONE,31.0,6.4,89.2,99.0,1081.0,Catholic,Secondary,1057.0,-37.882735,145.100257
+Salesian College,45870.0,2019,CHADSTONE,31.0,8.0,89.6,98.0,1078.0,Catholic,Secondary,1060.0,-37.882735,145.100257
+Salesian College,45870.0,2020,CHADSTONE,30.0,4.0,91.6,99.0,1080.0,Catholic,Secondary,1133.0,-37.882735,145.100257
+Salesian College,45870.0,2021,CHADSTONE,31.0,8.5,83.2,99.0,1082.0,Catholic,Secondary,1114.0,-37.882735,145.100257
+Salesian College,45870.0,2022,CHADSTONE,31.0,8.9,87.3,100.0,1083.0,Catholic,Secondary,1104.0,-37.882735,145.100257
+Salesian College,45870.0,2023,CHADSTONE,32.0,11.7,80.9,99.0,,,,,,
 Salesian College Sunbury,45827.0,2014,SUNBURY,30.0,5.9,97.0,99.0,1056.0,Catholic,Secondary,1141.0,-37.572644000000025,144.73903
 Salesian College Sunbury,45827.0,2015,SUNBURY,30.0,3.8,97.0,99.0,1055.0,Catholic,Secondary,1209.0,-37.572644000000025,144.73903
 Salesian College Sunbury,45827.0,2016,SUNBURY,29.0,3.8,96.0,99.0,1053.0,Catholic,Secondary,1219.0,-37.572644,144.73903
@@ -4305,7 +4379,7 @@ Salesian College Sunbury,45827.0,2019,SUNBURY,29.0,3.9,90.1,100.0,1053.0,Catholi
 Salesian College Sunbury,45827.0,2020,SUNBURY,30.0,4.7,89.9,100.0,1052.0,Catholic,Secondary,1332.0,-37.572644,144.73903
 Salesian College Sunbury,45827.0,2021,SUNBURY,28.0,3.1,71.7,99.0,1052.0,Catholic,Secondary,1395.0,-37.572644,144.73903
 Salesian College Sunbury,45827.0,2022,SUNBURY,28.0,2.4,75.2,99.0,1053.0,Catholic,Secondary,1469.0,-37.572644,144.73903
-Salesian College Sunbury,,2023,SUNBURY,28.0,2.4,65.7,100.0,,,,,,
+Salesian College Sunbury,45827.0,2023,SUNBURY,28.0,2.4,65.7,100.0,,,,,,
 Sandringham College,40620.0,2014,SANDRINGHAM,28.0,1.6,65.0,97.0,1054.0,Government,Secondary,1013.0,-37.9566838,145.02334835
 Sandringham College,40620.0,2015,SANDRINGHAM,28.0,3.9,71.0,97.0,1069.0,Government,Secondary,982.0,-37.9566838,145.02334835
 Sandringham College,40620.0,2016,SANDRINGHAM,28.0,5.1,73.0,97.0,1061.0,Government,Secondary,933.0,-37.9566838,145.02334835
@@ -4315,7 +4389,7 @@ Sandringham College,40620.0,2019,SANDRINGHAM,30.0,5.8,75.5,96.0,1071.0,Governmen
 Sandringham College,40620.0,2020,SANDRINGHAM,30.0,7.9,80.3,97.0,1082.0,Government,Secondary,933.0,-37.9566838,145.02334835
 Sandringham College,40620.0,2021,SANDRINGHAM,30.0,5.9,77.9,94.0,1085.0,Government,Secondary,947.0,-37.9566838,145.02334835
 Sandringham College,40620.0,2022,SANDRINGHAM,30.0,4.8,81.5,95.0,1093.0,Government,Secondary,977.0,-37.9566838,145.02334835
-Sandringham College,,2023,SANDRINGHAM,30.0,7.3,70.2,95.0,,,,,,
+Sandringham College,40620.0,2023,SANDRINGHAM,30.0,7.3,70.2,95.0,,,,,,
 Santa Maria College,45841.0,2014,NORTHCOTE,32.0,8.3,98.0,100.0,1062.0,Catholic,Secondary,909.0,-37.770356,145.00248
 Santa Maria College,45841.0,2015,NORTHCOTE,31.0,11.0,99.0,100.0,1066.0,Catholic,Secondary,911.0,-37.770356,145.00248
 Santa Maria College,45841.0,2016,NORTHCOTE,31.0,8.0,98.0,100.0,1077.0,Catholic,Secondary,905.0,-37.770356,145.00248
@@ -4325,7 +4399,7 @@ Santa Maria College,45841.0,2019,NORTHCOTE,31.0,9.6,93.1,100.0,1091.0,Catholic,S
 Santa Maria College,45841.0,2020,NORTHCOTE,31.0,9.7,95.4,100.0,1095.0,Catholic,Secondary,890.0,-37.770356,145.00248
 Santa Maria College,45841.0,2021,NORTHCOTE,32.0,10.8,96.8,100.0,1098.0,Catholic,Secondary,888.0,-37.770356,145.00248
 Santa Maria College,45841.0,2022,NORTHCOTE,30.0,6.3,94.4,100.0,1101.0,Catholic,Secondary,856.0,-37.770356,145.00248
-Santa Maria College,,2023,NORTHCOTE,30.0,6.8,96.4,100.0,,,,,,
+Santa Maria College,45841.0,2023,NORTHCOTE,30.0,6.8,96.4,100.0,,,,,,
 Scoresby Secondary College,45463.0,2014,SCORESBY,26.0,1.0,82.0,98.0,979.0,Government,Secondary,398.0,-37.888642,145.2362
 Scoresby Secondary College,45463.0,2015,SCORESBY,23.0,0.0,77.0,94.0,977.0,Government,Secondary,346.0,-37.888642,145.2362
 Scoresby Secondary College,45463.0,2016,SCORESBY,23.0,1.5,78.0,98.0,990.0,Government,Secondary,288.0,-37.888642,145.2362
@@ -4335,7 +4409,7 @@ Scoresby Secondary College,45463.0,2019,SCORESBY,27.0,1.0,86.4,100.0,994.0,Gover
 Scoresby Secondary College,45463.0,2020,SCORESBY,25.0,1.1,60.0,100.0,991.0,Government,Secondary,277.0,-37.888642,145.2362
 Scoresby Secondary College,45463.0,2021,SCORESBY,27.0,1.4,52.9,100.0,988.0,Government,Secondary,256.0,-37.888642,145.2362
 Scoresby Secondary College,45463.0,2022,SCORESBY,27.0,2.0,75.0,100.0,983.0,Government,Secondary,251.0,-37.888642,145.2362
-Scoresby Secondary College,,2023,SCORESBY,27.0,1.4,48.3,90.0,,,,,,
+Scoresby Secondary College,45463.0,2023,SCORESBY,27.0,1.4,48.3,90.0,,,,,,
 Scotch College,46172.0,2014,HAWTHORN,36.0,26.6,96.0,100.0,1203.0,Independent,Combined,1886.0,-37.833922,145.032288
 Scotch College,46172.0,2015,HAWTHORN,35.0,22.3,99.0,100.0,1201.0,Independent,Combined,1871.0,-37.833922,145.032288
 Scotch College,46172.0,2016,HAWTHORN,35.0,23.9,96.0,100.0,1196.0,Independent,Combined,1862.0,-37.833922,145.032288
@@ -4345,7 +4419,7 @@ Scotch College,46172.0,2019,HAWTHORN,35.0,27.2,99.6,100.0,1191.0,Independent,Com
 Scotch College,46172.0,2020,HAWTHORN,35.0,23.4,96.5,100.0,1191.0,Independent,Combined,1879.0,-37.833922,145.032288
 Scotch College,46172.0,2021,HAWTHORN,34.0,20.9,96.6,100.0,1188.0,Independent,Combined,1879.0,-37.833922,145.032288
 Scotch College,46172.0,2022,HAWTHORN,35.0,23.2,99.2,100.0,1191.0,Independent,Combined,1882.0,-37.833922,145.032288
-Scotch College,,2023,HAWTHORN,34.0,18.4,97.0,100.0,,,,,,
+Scotch College,46172.0,2023,HAWTHORN,34.0,18.4,97.0,100.0,,,,,,
 Seymour College,40851.0,2014,SEYMOUR,25.0,0.0,66.0,92.0,935.0,Government,Combined,886.0,-37.02984234,145.1411167
 Seymour College,40851.0,2015,SEYMOUR,26.0,1.1,64.0,95.0,931.0,Government,Combined,802.0,-37.02984234,145.1411167
 Seymour College,40851.0,2016,SEYMOUR,27.0,1.5,85.0,90.0,929.0,Government,Combined,784.0,-37.02984234,145.1411167
@@ -4355,7 +4429,7 @@ Seymour College,40851.0,2019,SEYMOUR,27.0,3.0,56.6,94.0,940.0,Government,Combine
 Seymour College,40851.0,2020,SEYMOUR,26.0,2.6,64.8,100.0,937.0,Government,Combined,692.0,-37.02984234,145.1411167
 Seymour College,40851.0,2021,SEYMOUR,27.0,2.8,67.3,100.0,940.0,Government,Combined,744.0,-37.02984234,145.1411167
 Seymour College,40851.0,2022,SEYMOUR,25.0,2.6,70.5,93.0,933.0,Government,Combined,732.0,-37.02984234,145.1411167
-Seymour College,,2023,SEYMOUR,25.0,1.8,68.5,100.0,,,,,,
+Seymour College,40851.0,2023,SEYMOUR,25.0,1.8,68.5,100.0,,,,,,
 Shelford Girls' Grammar,46183.0,2014,CAULFIELD,38.0,37.5,100.0,100.0,1169.0,Independent,Combined,434.0,-37.877908,145.011318
 Shelford Girls' Grammar,46183.0,2015,CAULFIELD,37.0,32.6,98.0,100.0,1172.0,Independent,Combined,435.0,-37.877908,145.011318
 Shelford Girls' Grammar,46183.0,2016,CAULFIELD,37.0,30.7,100.0,100.0,1166.0,Independent,Combined,499.0,-37.877908,145.011318
@@ -4365,7 +4439,7 @@ Shelford Girls' Grammar,46183.0,2019,CAULFIELD,36.0,25.0,95.5,100.0,1162.0,Indep
 Shelford Girls' Grammar,46183.0,2020,CAULFIELD,35.0,18.2,98.5,100.0,1162.0,Independent,Combined,511.0,-37.877908,145.011318
 Shelford Girls' Grammar,46183.0,2021,CAULFIELD NORTH,35.0,23.0,98.2,100.0,1153.0,Independent,Combined,467.0,-37.877908,145.011318
 Shelford Girls' Grammar,46183.0,2022,CAULFIELD NORTH,36.0,27.1,97.0,100.0,1147.0,Independent,Combined,447.0,-37.877908,145.011318
-Shelford Girls' Grammar,,2023,CAULFIELD NORTH,34.0,16.1,98.4,100.0,,,,,,
+Shelford Girls' Grammar,46183.0,2023,CAULFIELD NORTH,34.0,16.1,98.4,100.0,,,,,,
 Shepparton ACE College,40848.0,2014,SHEPPARTON,,,,,,Independent,Secondary,37.0,-36.38413232,145.41164522
 Shepparton ACE College,40848.0,2015,SHEPPARTON,,,,,,Independent,Secondary,53.0,-36.38413232,145.41164522
 Shepparton ACE College,40848.0,2016,SHEPPARTON,,,,,,Independent,Secondary,44.0,-36.38413232,145.41164522
@@ -4375,7 +4449,7 @@ Shepparton ACE College,40848.0,2019,SHEPPARTON,,,,,887.0,Independent,Secondary,8
 Shepparton ACE College,40848.0,2020,SHEPPARTON,,,,,921.0,Independent,Secondary,86.0,-36.38413232,145.41164522
 Shepparton ACE College,40848.0,2021,SHEPPARTON,,,,,906.0,Independent,Secondary,82.0,-36.3776363800323,145.401748339538
 Shepparton ACE Sec College,40848.0,2022,SHEPPARTON,,,,,899.0,Independent,Secondary,85.0,-36.3776363800323,145.401748339538
-Shepparton ACE Sec College,,2023,SHEPPARTON,,,,60.0,,,,,,
+Shepparton ACE Sec College,40848.0,2023,SHEPPARTON,,,,60.0,,,,,,
 Shepparton Christian College,46344.0,2014,SHEPPARTON,29.0,3.3,80.0,100.0,1040.0,Independent,Combined,210.0,-36.35375591,145.41625825
 Shepparton Christian College,46344.0,2015,SHEPPARTON,30.0,2.8,88.0,100.0,1042.0,Independent,Combined,222.0,-36.35375591,145.41625825
 Shepparton Christian College,46344.0,2016,SHEPPARTON,28.0,1.6,83.0,92.0,1047.0,Independent,Combined,207.0,-36.35375591,145.41625825
@@ -4385,33 +4459,33 @@ Shepparton Christian College,46344.0,2019,SHEPPARTON,27.0,7.0,20.0,100.0,1049.0,
 Shepparton Christian College,46344.0,2020,SHEPPARTON,27.0,3.7,72.7,100.0,1049.0,Independent,Combined,235.0,-36.35375591,145.41625825
 Shepparton Christian College,46344.0,2021,SHEPPARTON,29.0,0.0,58.3,100.0,1030.0,Independent,Combined,259.0,-36.35375591,145.41625825
 Shepparton Christian College,46344.0,2022,SHEPPARTON,29.0,1.7,71.4,100.0,1039.0,Independent,Combined,286.0,-36.35375591,145.41625825
-Shepparton Christian College,,2023,SHEPPARTON,26.0,7.1,50.0,100.0,,,,,,
-Shepparton High School,45445.0,2014,SHEPPARTON,25.0,0.9,58.0,87.0,1004.0,Government,Secondary,687.0,-38.18665,144.337409
-Shepparton High School,45445.0,2015,SHEPPARTON,25.0,0.7,68.0,93.0,1000.0,Government,Secondary,634.0,-38.18665,144.337409
-Shepparton High School,45445.0,2016,SHEPPARTON,27.0,1.7,61.0,89.0,1011.0,Government,Secondary,565.0,-38.18665,144.337409
-Shepparton High School,45445.0,2017,SHEPPARTON,24.0,2.0,73.0,84.0,1010.0,Government,Secondary,560.0,-38.18665,144.337409
-Shepparton High School,45445.0,2018,SHEPPARTON,24.0,0.5,61.7,87.0,1015.0,Government,Secondary,563.0,-38.18665,144.337409
-Shepparton High School,45445.0,2019,SHEPPARTON,23.0,0.0,53.5,86.0,1022.0,Government,Secondary,656.0,-38.18665,144.337409
-Sherbrooke Community School,45316.0,2014,SASSAFRAS,25.0,5.4,30.0,70.0,1007.0,Government,Combined,138.0,-37.868244,145.349444
-Sherbrooke Community School,45316.0,2015,SASSAFRAS,27.0,0.0,89.0,100.0,1016.0,Government,Combined,153.0,-37.868244,145.349444
-Sherbrooke Community School,45316.0,2016,SASSAFRAS,26.0,0.0,80.0,100.0,1004.0,Government,Combined,146.0,-37.868244,145.349444
-Sherbrooke Community School,45316.0,2017,SASSAFRAS,25.0,2.6,40.0,80.0,1002.0,Government,Combined,157.0,-37.868244,145.349444
-Sherbrooke Community School,45316.0,2018,SASSAFRAS,26.0,0.0,57.9,100.0,1017.0,Government,Combined,131.0,-37.868244,145.349444
-Sherbrooke Community School,45316.0,2019,SASSAFRAS,26.0,0.0,80.0,90.0,1035.0,Government,Combined,131.0,-37.868244,145.349444
-Sherbrooke Community School,45316.0,2020,SASSAFRAS,28.0,3.3,45.5,100.0,1035.0,Government,Combined,148.0,-37.868244,145.349444
-Sherbrooke Community School,45316.0,2021,SASSAFRAS,30.0,20.0,50.0,100.0,1027.0,Government,Combined,138.0,-37.868244,145.349444
-Sherbrooke Community School,45316.0,2022,SASSAFRAS,30.0,0.0,57.1,100.0,1015.0,Government,Combined,123.0,-37.868244,145.349444
-Sherbrooke Community School,,2023,SASSAFRAS,26.0,,40.0,100.0,,,,,,
-Siena College,45857.0,2014,CAMBERWELL,34.0,18.5,99.0,99.0,1134.0,Catholic,Secondary,712.0,-37.833662,145.082575
-Siena College,45857.0,2015,CAMBERWELL,34.0,14.4,96.0,100.0,1130.0,Catholic,Secondary,741.0,-37.833662,145.082575
-Siena College,45857.0,2016,CAMBERWELL,34.0,16.0,98.0,100.0,1126.0,Catholic,Secondary,739.0,-37.833662,145.082575
-Siena College,45857.0,2017,CAMBERWELL,34.0,14.3,100.0,100.0,1132.0,Catholic,Secondary,742.0,-37.833662,145.082575
-Siena College,45857.0,2018,CAMBERWELL,34.0,17.5,99.2,99.0,1132.0,Catholic,Secondary,784.0,-37.833662,145.082575
-Siena College,45857.0,2019,CAMBERWELL,33.0,13.7,96.6,100.0,1143.0,Catholic,Secondary,791.0,-37.833662,145.082575
-Siena College,45857.0,2020,CAMBERWELL,33.0,16.5,98.3,100.0,1142.0,Catholic,Secondary,799.0,-37.833662,145.082575
-Siena College,45857.0,2021,CAMBERWELL,34.0,16.8,99.2,100.0,1145.0,Catholic,Secondary,823.0,-37.833662,145.082575
-Siena College,45857.0,2022,CAMBERWELL,34.0,20.2,98.3,100.0,1151.0,Catholic,Secondary,782.0,-37.833662,145.082575
-Siena College,,2023,CAMBERWELL,34.0,20.4,100.0,100.0,,,,,,
+Shepparton Christian College,46344.0,2023,SHEPPARTON,26.0,7.1,50.0,100.0,,,,,,
+Shepparton High School,45316.0,2014,SHEPPARTON,25.0,0.9,58.0,87.0,1007.0,Government,Combined,138.0,-37.868244,145.349444
+Shepparton High School,45316.0,2015,SHEPPARTON,25.0,0.7,68.0,93.0,1016.0,Government,Combined,153.0,-37.868244,145.349444
+Shepparton High School,45316.0,2016,SHEPPARTON,27.0,1.7,61.0,89.0,1004.0,Government,Combined,146.0,-37.868244,145.349444
+Shepparton High School,45316.0,2017,SHEPPARTON,24.0,2.0,73.0,84.0,1002.0,Government,Combined,157.0,-37.868244,145.349444
+Shepparton High School,45316.0,2018,SHEPPARTON,24.0,0.5,61.7,87.0,1017.0,Government,Combined,131.0,-37.868244,145.349444
+Shepparton High School,45316.0,2019,SHEPPARTON,23.0,0.0,53.5,86.0,1035.0,Government,Combined,131.0,-37.868244,145.349444
+Sherbrooke Community School,45857.0,2014,SASSAFRAS,25.0,5.4,30.0,70.0,1134.0,Catholic,Secondary,712.0,-37.833662,145.082575
+Sherbrooke Community School,45857.0,2015,SASSAFRAS,27.0,0.0,89.0,100.0,1130.0,Catholic,Secondary,741.0,-37.833662,145.082575
+Sherbrooke Community School,45857.0,2016,SASSAFRAS,26.0,0.0,80.0,100.0,1126.0,Catholic,Secondary,739.0,-37.833662,145.082575
+Sherbrooke Community School,45857.0,2017,SASSAFRAS,25.0,2.6,40.0,80.0,1132.0,Catholic,Secondary,742.0,-37.833662,145.082575
+Sherbrooke Community School,45857.0,2018,SASSAFRAS,26.0,0.0,57.9,100.0,1132.0,Catholic,Secondary,784.0,-37.833662,145.082575
+Sherbrooke Community School,45857.0,2019,SASSAFRAS,26.0,0.0,80.0,90.0,1143.0,Catholic,Secondary,791.0,-37.833662,145.082575
+Sherbrooke Community School,45857.0,2020,SASSAFRAS,28.0,3.3,45.5,100.0,1142.0,Catholic,Secondary,799.0,-37.833662,145.082575
+Sherbrooke Community School,45857.0,2021,SASSAFRAS,30.0,20.0,50.0,100.0,1145.0,Catholic,Secondary,823.0,-37.833662,145.082575
+Sherbrooke Community School,45857.0,2022,SASSAFRAS,30.0,0.0,57.1,100.0,1151.0,Catholic,Secondary,782.0,-37.833662,145.082575
+Sherbrooke Community School,45857.0,2023,SASSAFRAS,26.0,,40.0,100.0,,,,,,
+Siena College,45631.0,2014,CAMBERWELL,34.0,18.5,99.0,99.0,944.0,Catholic,Secondary,474.0,-37.805971,144.952883
+Siena College,45631.0,2015,CAMBERWELL,34.0,14.4,96.0,100.0,1008.0,Catholic,Secondary,484.0,-37.805971,144.952883
+Siena College,45631.0,2016,CAMBERWELL,34.0,16.0,98.0,100.0,989.0,Catholic,Secondary,455.0,-37.805971,144.952883
+Siena College,45631.0,2017,CAMBERWELL,34.0,14.3,100.0,100.0,1009.0,Catholic,Secondary,460.0,-37.805971,144.952883
+Siena College,45631.0,2018,CAMBERWELL,34.0,17.5,99.2,99.0,1000.0,Catholic,Secondary,435.0,-37.805971,144.952883
+Siena College,45631.0,2019,CAMBERWELL,33.0,13.7,96.6,100.0,1015.0,Catholic,Secondary,426.0,-37.805971,144.952883
+Siena College,45631.0,2020,CAMBERWELL,33.0,16.5,98.3,100.0,1019.0,Catholic,Secondary,416.0,-37.805971,144.952883
+Siena College,45631.0,2021,CAMBERWELL,34.0,16.8,99.2,100.0,1020.0,Catholic,Secondary,411.0,-37.805971,144.952883
+Siena College,45631.0,2022,CAMBERWELL,34.0,20.2,98.3,100.0,1029.0,Catholic,Secondary,410.0,-37.805971,144.952883
+Siena College,45631.0,2023,CAMBERWELL,34.0,20.4,100.0,100.0,,,,,,
 Simonds Catholic College,45631.0,2014,FITZROY NORTH,29.0,7.8,95.0,97.0,944.0,Catholic,Secondary,474.0,-37.805971,144.952883
 Simonds Catholic College,45631.0,2015,FITZROY NORTH,29.0,2.6,94.0,99.0,1008.0,Catholic,Secondary,484.0,-37.805971,144.952883
 Simonds Catholic College,45631.0,2016,FITZROY NORTH,28.0,3.0,94.0,98.0,989.0,Catholic,Secondary,455.0,-37.805971,144.952883
@@ -4421,7 +4495,7 @@ Simonds Catholic College,45631.0,2019,FITZROY NORTH,30.0,5.8,86.3,98.0,1015.0,Ca
 Simonds Catholic College,45631.0,2020,FITZROY NORTH,31.0,9.0,83.9,100.0,1019.0,Catholic,Secondary,416.0,-37.805971,144.952883
 Simonds Catholic College,45631.0,2021,FITZROY NORTH,30.0,7.3,93.0,100.0,1020.0,Catholic,Secondary,411.0,-37.805971,144.952883
 Simonds Catholic College,45631.0,2022,FITZROY NORTH,29.0,1.0,89.7,98.0,1029.0,Catholic,Secondary,410.0,-37.805971,144.952883
-Simonds Catholic College,,2023,WEST MELBOURNE,28.0,1.7,92.3,87.0,,,,,,
+Simonds Catholic College,45631.0,2023,WEST MELBOURNE,28.0,1.7,92.3,87.0,,,,,,
 Sirius College - Eastmeadows,46335.0,2014,BROADMEADOWS,32.0,11.1,93.0,96.0,1014.0,Independent,Combined,2221.0,-37.684291,144.934966
 Sirius College - Eastmeadows,46335.0,2015,BROADMEADOWS,31.0,10.1,100.0,100.0,1026.0,Independent,Combined,2250.0,-37.684291,144.934966
 Sirius College - Eastmeadows,46335.0,2016,BROADMEADOWS,29.0,7.2,100.0,100.0,1019.0,Independent,Combined,2373.0,-37.684291,144.934966
@@ -4431,9 +4505,9 @@ Sirius College - Eastmeadows,46335.0,2019,BROADMEADOWS,31.0,8.2,97.6,99.0,1053.0
 Sirius College - Eastmeadows,46335.0,2020,BROADMEADOWS,32.0,11.6,98.8,100.0,1053.0,Independent,Combined,2914.0,-37.684291,144.934966
 Sirius College - Eastmeadows,46335.0,2021,BROADMEADOWS,31.0,5.9,98.6,100.0,1054.0,Independent,Combined,2971.0,-37.684291,144.934966
 Sirius College - Eastmeadows,46335.0,2022,BROADMEADOWS,29.0,7.0,98.9,100.0,1054.0,Independent,Combined,3033.0,-37.684291,144.934966
-Sirius College - Eastmeadows,,2023,BROADMEADOWS,31.0,11.1,96.7,99.0,,,,,,
+Sirius College - Eastmeadows,46335.0,2023,BROADMEADOWS,31.0,11.1,96.7,99.0,,,,,,
 Sirius College - Ibrahim Dellal,46335.0,2022,SUNSHINE WEST,32.0,9.8,,,1054.0,Independent,Combined,3033.0,-37.684291,144.934966
-Sirius College - Ibrahim Dellal,,2023,SUNSHINE WEST,31.0,4.9,94.3,97.0,,,,,,
+Sirius College - Ibrahim Dellal,46335.0,2023,SUNSHINE WEST,31.0,4.9,94.3,97.0,,,,,,
 Sirius College - Keysborough,46335.0,2014,KEYSBOROUGH,29.0,5.2,100.0,100.0,1014.0,Independent,Combined,2221.0,-37.684291,144.934966
 Sirius College - Keysborough,46335.0,2015,KEYSBOROUGH,30.0,5.2,97.0,97.0,1026.0,Independent,Combined,2250.0,-37.684291,144.934966
 Sirius College - Keysborough,46335.0,2016,KEYSBOROUGH,26.0,3.1,100.0,100.0,1019.0,Independent,Combined,2373.0,-37.684291,144.934966
@@ -4443,7 +4517,7 @@ Sirius College - Keysborough,46335.0,2019,KEYSBOROUGH,30.0,11.2,100.0,100.0,1053
 Sirius College - Keysborough,46335.0,2020,KEYSBOROUGH,30.0,4.1,100.0,100.0,1053.0,Independent,Combined,2914.0,-37.684291,144.934966
 Sirius College - Keysborough,46335.0,2021,KEYSBOROUGH,29.0,4.0,90.9,100.0,1054.0,Independent,Combined,2971.0,-37.684291,144.934966
 Sirius College - Keysborough,46335.0,2022,KEYSBOROUGH,30.0,5.0,100.0,100.0,1054.0,Independent,Combined,3033.0,-37.684291,144.934966
-Sirius College - Keysborough,,2023,KEYSBOROUGH,30.0,4.6,94.9,97.0,,,,,,
+Sirius College - Keysborough,46335.0,2023,KEYSBOROUGH,30.0,4.6,94.9,97.0,,,,,,
 Sirius College - Meadow Fair,46335.0,2014,BROADMEADOWS,28.0,7.2,94.0,100.0,1014.0,Independent,Combined,2221.0,-37.684291,144.934966
 Sirius College - Meadow Fair,46335.0,2015,BROADMEADOWS,28.0,10.3,94.0,100.0,1026.0,Independent,Combined,2250.0,-37.684291,144.934966
 Sirius College - Meadow Fair,46335.0,2016,BROADMEADOWS,31.0,11.4,90.0,100.0,1019.0,Independent,Combined,2373.0,-37.684291,144.934966
@@ -4453,7 +4527,14 @@ Sirius College - Meadow Fair,46335.0,2019,BROADMEADOWS,32.0,9.4,96.4,98.0,1053.0
 Sirius College - Meadow Fair,46335.0,2020,BROADMEADOWS,31.0,13.6,91.7,100.0,1053.0,Independent,Combined,2914.0,-37.684291,144.934966
 Sirius College - Meadow Fair,46335.0,2021,BROADMEADOWS,31.0,8.0,94.9,100.0,1054.0,Independent,Combined,2971.0,-37.684291,144.934966
 Sirius College - Meadow Fair,46335.0,2022,BROADMEADOWS,29.0,7.4,97.3,100.0,1054.0,Independent,Combined,3033.0,-37.684291,144.934966
-Sirius College - Meadow Fair,,2023,BROADMEADOWS,30.0,8.5,95.5,98.0,,,,,,
+Sirius College - Meadow Fair,46335.0,2023,BROADMEADOWS,30.0,8.5,95.5,98.0,,,,,,
+SkillsPlus,,2019,FRANKSTON,,,,,,,,,,
+SkillsPlus,,2020,FRANKSTON,,,,,,,,,,
+Skillsplus,,2014,FRANKSTON,,,,,,,,,,
+Skillsplus,,2015,FRANKSTON,,,,,,,,,,
+Skillsplus,,2016,FRANKSTON,,,,,,,,,,
+Skillsplus,,2017,FRANKSTON,,,,,,,,,,
+Skillsplus,,2018,FRANKSTON,,,,,,,,,,
 Somerville Secondary College,45605.0,2014,SOMERVILLE,26.0,0.7,55.0,93.0,956.0,Government,Secondary,334.0,-38.22721827,145.16822738
 Somerville Secondary College,45605.0,2015,SOMERVILLE,22.0,0.7,64.0,89.0,968.0,Government,Secondary,337.0,-38.22721827,145.16822738
 Somerville Secondary College,45605.0,2016,SOMERVILLE,23.0,0.8,64.0,100.0,962.0,Government,Secondary,304.0,-38.22721827,145.16822738
@@ -4463,10 +4544,10 @@ Somerville Secondary College,45605.0,2019,SOMERVILLE,24.0,2.5,75.0,81.0,975.0,Go
 Somerville Secondary College,45605.0,2020,SOMERVILLE,25.0,0.0,81.8,95.0,975.0,Government,Secondary,239.0,-38.22721827,145.16822738
 Somerville Secondary College,45605.0,2021,SOMERVILLE,27.0,0.0,100.0,100.0,977.0,Government,Secondary,242.0,-38.22721827,145.16822738
 Somerville Secondary College,45605.0,2022,SOMERVILLE,28.0,0.0,57.1,93.0,968.0,Government,Secondary,325.0,-38.22721827,145.16822738
-Somerville Secondary College,,2023,SOMERVILLE,28.0,,50.0,94.0,,,,,,
-South Gippsland Sec College,45259.0,2014,FOSTER,29.0,4.6,75.0,93.0,,Government,Special,42.0,-38.47819065,145.95728943
-South Gippsland Sec College,45259.0,2015,FOSTER,29.0,5.2,75.0,95.0,,Government,Special,36.0,-38.47819065,145.95728943
-South Gippsland Sec College,45259.0,2016,FOSTER,26.0,3.5,68.0,84.0,,Government,Special,44.0,-38.47819065,145.95728943
+Somerville Secondary College,45605.0,2023,SOMERVILLE,28.0,,50.0,94.0,,,,,,
+South Gippsland Sec College,45389.0,2014,FOSTER,29.0,4.6,75.0,93.0,979.0,Government,Secondary,298.0,-38.651737,146.197413
+South Gippsland Sec College,45389.0,2015,FOSTER,29.0,5.2,75.0,95.0,990.0,Government,Secondary,293.0,-38.651737,146.197413
+South Gippsland Sec College,45389.0,2016,FOSTER,26.0,3.5,68.0,84.0,1002.0,Government,Secondary,277.0,-38.651737,146.197413
 South Oakleigh Sec College,45539.0,2014,OAKLEIGH SOUTH,28.0,1.9,89.0,96.0,1007.0,Government,Secondary,418.0,-37.92232068,145.08976799
 South Oakleigh Sec College,45539.0,2015,OAKLEIGH SOUTH,28.0,2.6,96.0,98.0,1001.0,Government,Secondary,395.0,-37.92232068,145.08976799
 South Oakleigh Sec College,45539.0,2016,OAKLEIGH SOUTH,29.0,1.1,96.0,98.0,1008.0,Government,Secondary,443.0,-37.92232068,145.08976799
@@ -4476,19 +4557,35 @@ South Oakleigh Sec College,45539.0,2019,OAKLEIGH SOUTH,28.0,7.6,68.9,89.0,1026.0
 South Oakleigh Sec College,45539.0,2020,OAKLEIGH SOUTH,29.0,2.7,78.9,96.0,1028.0,Government,Secondary,588.0,-37.92232068,145.08976799
 South Oakleigh Sec College,45539.0,2021,OAKLEIGH SOUTH,28.0,1.8,77.5,99.0,1033.0,Government,Secondary,669.0,-37.92232068,145.08976799
 South Oakleigh Sec College,45539.0,2022,OAKLEIGH SOUTH,30.0,4.8,69.8,98.0,1039.0,Government,Secondary,698.0,-37.92232068,145.08976799
-South Oakleigh Sec College,,2023,OAKLEIGH SOUTH,29.0,3.3,80.6,100.0,,,,,,
+South Oakleigh Sec College,45539.0,2023,OAKLEIGH SOUTH,29.0,3.3,80.6,100.0,,,,,,
+South West Institute of TAFE,,2014,WARRNAMBOOL,21.0,0.0,11.0,61.0,,,,,,
+South West Institute of TAFE,,2015,WARRNAMBOOL,19.0,0.0,23.0,82.0,,,,,,
+South West Institute of TAFE,,2016,WARRNAMBOOL,18.0,0.0,30.0,80.0,,,,,,
+South West Institute of TAFE,,2017,WARRNAMBOOL,,,0.0,0.0,,,,,,
+South West Institute of TAFE,,2018,WARRNAMBOOL,,,,,,,,,,
+South West Institute of TAFE,,2019,WARRNAMBOOL,,,,,,,,,,
+South West Institute of TAFE,,2020,WARRNAMBOOL,,,,,,,,,,
+South West Institute of TAFE,,2021,WARRNAMBOOL,,,,,,,,,,
+South West Institute of TAFE,,2022,WARRNAMBOOL,,,,,,,,,,
+South West Institute of TAFE,,2023,WARRNAMBOOL,,,,57.0,,,,,,
 Southern Cross Grammar,50394.0,2017,CAROLINE SPRINGS,34.0,8.3,,,1119.0,Independent,Combined,532.0,-37.71396413,144.73960237
 Southern Cross Grammar,50394.0,2018,CAROLINE SPRINGS,31.0,4.6,100.0,100.0,1128.0,Independent,Combined,634.0,-37.71396413,144.73960237
 Southern Cross Grammar,50394.0,2019,CAROLINE SPRINGS,32.0,4.1,80.0,100.0,1122.0,Independent,Combined,681.0,-37.71396413,144.73960237
 Southern Cross Grammar,50394.0,2020,CAROLINE SPRINGS,29.0,6.4,81.6,100.0,1122.0,Independent,Combined,723.0,-37.71396413,144.73960237
 Southern Cross Grammar,50394.0,2021,CAROLINE SPRINGS,31.0,9.6,91.4,100.0,1130.0,Independent,Combined,768.0,-37.71396413,144.73960237
 Southern Cross Grammar,50394.0,2022,CAROLINE SPRINGS,31.0,7.5,82.0,100.0,1132.0,Independent,Combined,803.0,-37.71396413,144.73960237
-Southern Cross Grammar,,2023,CAROLINE SPRINGS,31.0,7.0,92.6,100.0,,,,,,
+Southern Cross Grammar,50394.0,2023,CAROLINE SPRINGS,31.0,7.0,92.6,100.0,,,,,,
+Southern Grampians Adult Edu,,2014,HAMILTON,,,,,,,,,,
+Southern Grampians Adult Edu,,2015,HAMILTON,,,,,,,,,,
+Southern Grampians Adult Edu,,2016,HAMILTON,,,,,,,,,,
+Southern Grampians Adult Edu,,2017,HAMILTON,,,,,,,,,,
+Southern Grampians Adult Edu,,2018,HAMILTON,,,,,,,,,,
+Southern Grampians Adult Edu,,2019,HAMILTON,,,,,,,,,,
 Springside West Sec College,52594.0,2019,FRASER RISE,26.0,0.0,,,1014.0,Government,Secondary,426.0,-37.71514,144.727262
 Springside West Sec College,52594.0,2020,FRASER RISE,26.0,0.0,94.7,100.0,1026.0,Government,Secondary,755.0,-37.71514,144.727262
 Springside West Sec College,52594.0,2021,FRASER RISE,28.0,3.3,95.1,95.0,1028.0,Government,Secondary,976.0,-37.71514,144.727262
 Springside West Sec College,52594.0,2022,FRASER RISE,30.0,3.4,79.2,96.0,1026.0,Government,Secondary,1209.0,-37.71514,144.727262
-Springside West Sec College,,2023,FRASER RISE,27.0,2.7,87.1,98.0,,,,,,
+Springside West Sec College,52594.0,2023,FRASER RISE,27.0,2.7,87.1,98.0,,,,,,
 St Albans Secondary College,45466.0,2014,ST ALBANS,29.0,4.8,85.0,95.0,940.0,Government,Secondary,1161.0,-37.745308,144.807009
 St Albans Secondary College,45466.0,2015,ST ALBANS,30.0,6.3,95.0,98.0,940.0,Government,Secondary,1227.0,-37.745308,144.807009
 St Albans Secondary College,45466.0,2016,ST ALBANS,30.0,7.3,92.0,94.0,943.0,Government,Secondary,1367.0,-37.745308,144.807009
@@ -4498,7 +4595,7 @@ St Albans Secondary College,45466.0,2019,ST ALBANS,29.0,4.3,94.1,90.0,957.0,Gove
 St Albans Secondary College,45466.0,2020,ST ALBANS,30.0,7.7,93.0,99.0,956.0,Government,Secondary,1569.0,-37.745308,144.807009
 St Albans Secondary College,45466.0,2021,ST ALBANS,30.0,8.2,92.4,97.0,960.0,Government,Secondary,1599.0,-37.745308,144.807009
 St Albans Secondary College,45466.0,2022,ST ALBANS,31.0,8.8,93.4,98.0,955.0,Government,Secondary,1656.0,-37.745308,144.807009
-St Albans Secondary College,,2023,ST ALBANS,31.0,7.8,85.2,94.0,,,,,,
+St Albans Secondary College,45466.0,2023,ST ALBANS,31.0,7.8,85.2,94.0,,,,,,
 St Aloysius College,45735.0,2014,NORTH MELBOURNE,31.0,5.0,97.0,100.0,1025.0,Catholic,Secondary,474.0,-37.792892,144.942875
 St Aloysius College,45735.0,2015,NORTH MELBOURNE,30.0,5.1,99.0,100.0,1040.0,Catholic,Secondary,503.0,-37.792892,144.942875
 St Aloysius College,45735.0,2016,NORTH MELBOURNE,30.0,5.8,93.0,100.0,1044.0,Catholic,Secondary,533.0,-37.792892,144.942875
@@ -4508,7 +4605,7 @@ St Aloysius College,45735.0,2019,NORTH MELBOURNE,32.0,11.0,93.8,100.0,1079.0,Cat
 St Aloysius College,45735.0,2020,NORTH MELBOURNE,32.0,8.8,100.0,100.0,1082.0,Catholic,Secondary,445.0,-37.792892,144.942875
 St Aloysius College,45735.0,2021,NORTH MELBOURNE,32.0,10.8,100.0,100.0,1081.0,Catholic,Secondary,427.0,-37.792892,144.942875
 St Aloysius College,45735.0,2022,NORTH MELBOURNE,31.0,6.1,95.1,100.0,1092.0,Catholic,Secondary,409.0,-37.792892,144.942875
-St Aloysius College,,2023,NORTH MELBOURNE,30.0,8.5,83.6,100.0,,,,,,
+St Aloysius College,45735.0,2023,NORTH MELBOURNE,30.0,8.5,83.6,100.0,,,,,,
 St Andrews Christian College,46293.0,2014,WANTIRNA SOUTH,29.0,6.0,94.0,100.0,1186.0,Independent,Combined,515.0,-37.8741927,145.2442752
 St Andrews Christian College,46293.0,2015,WANTIRNA SOUTH,31.0,10.0,93.0,100.0,1179.0,Independent,Combined,538.0,-37.8741927,145.2442752
 St Andrews Christian College,46293.0,2016,WANTIRNA SOUTH,31.0,6.6,94.0,100.0,1160.0,Independent,Combined,554.0,-37.8741927,145.2442752
@@ -4518,8 +4615,8 @@ St Andrews Christian College,46293.0,2019,WANTIRNA SOUTH,31.0,10.0,94.9,100.0,11
 St Andrews Christian College,46293.0,2020,WANTIRNA SOUTH,33.0,13.9,100.0,100.0,1159.0,Independent,Combined,657.0,-37.8741927,145.2442752
 St Andrews Christian College,46293.0,2021,WANTIRNA SOUTH,33.0,12.3,90.5,98.0,1166.0,Independent,Combined,676.0,-37.8741927,145.2442752
 St Andrews Christian College,46293.0,2022,WANTIRNA SOUTH,33.0,18.0,85.1,100.0,1166.0,Independent,Combined,669.0,-37.8741927,145.2442752
-St Andrews Christian College,,2023,WANTIRNA SOUTH,32.0,9.7,94.9,100.0,,,,,,
-St Anne's College,,2023,KIALLA,26.0,,,,,,,,,
+St Andrews Christian College,46293.0,2023,WANTIRNA SOUTH,32.0,9.7,94.9,100.0,,,,,,
+St Anne's College,52735.0,2023,KIALLA,26.0,,,,,,,,,
 St Arnaud Secondary College,45467.0,2014,ST ARNAUD,29.0,1.2,88.0,94.0,953.0,Government,Secondary,213.0,-36.609547,143.250936
 St Arnaud Secondary College,45467.0,2015,ST ARNAUD,27.0,2.9,59.0,91.0,947.0,Government,Secondary,204.0,-36.609547,143.250936
 St Arnaud Secondary College,45467.0,2016,ST ARNAUD,23.0,0.0,75.0,88.0,942.0,Government,Secondary,191.0,-36.609547,143.250936
@@ -4529,7 +4626,7 @@ St Arnaud Secondary College,45467.0,2019,ST ARNAUD,25.0,2.6,14.3,100.0,956.0,Gov
 St Arnaud Secondary College,45467.0,2020,ST ARNAUD,29.0,0.0,61.5,100.0,968.0,Government,Secondary,132.0,-36.609547,143.250936
 St Arnaud Secondary College,45467.0,2021,ST ARNAUD,28.0,0.0,100.0,100.0,978.0,Government,Secondary,125.0,-36.609547,143.250936
 St Arnaud Secondary College,45467.0,2022,ST ARNAUD,25.0,0.0,66.7,89.0,973.0,Government,Secondary,136.0,-36.609547,143.250936
-St Arnaud Secondary College,,2023,ST ARNAUD,28.0,2.4,61.5,100.0,,,,,,
+St Arnaud Secondary College,45467.0,2023,ST ARNAUD,28.0,2.4,61.5,100.0,,,,,,
 St Augustine's College,45739.0,2014,KYABRAM,29.0,2.2,91.0,100.0,1011.0,Catholic,Combined,688.0,-36.30955,145.044713
 St Augustine's College,45739.0,2015,KYABRAM,29.0,2.5,81.0,100.0,1012.0,Catholic,Combined,692.0,-36.30955,145.044713
 St Augustine's College,45739.0,2016,KYABRAM,26.0,3.9,100.0,100.0,1014.0,Catholic,Combined,677.0,-36.30955,145.044713
@@ -4539,7 +4636,7 @@ St Augustine's College,45739.0,2019,KYABRAM,25.0,0.0,58.5,100.0,1002.0,Catholic,
 St Augustine's College,45739.0,2020,KYABRAM,26.0,1.2,80.6,100.0,1002.0,Catholic,Combined,704.0,-36.30955,145.044713
 St Augustine's College,45739.0,2021,KYABRAM,26.0,2.9,78.8,100.0,1001.0,Catholic,Combined,712.0,-36.30955,145.044713
 St Augustine's College,45739.0,2022,KYABRAM,30.0,3.8,76.7,100.0,1008.0,Catholic,Combined,697.0,-36.30955,145.044713
-St Augustine's College,,2023,KYABRAM,29.0,3.9,61.5,100.0,,,,,,
+St Augustine's College,45739.0,2023,KYABRAM,29.0,3.9,61.5,100.0,,,,,,
 St Bede's College,45855.0,2014,MENTONE,31.0,7.9,86.0,99.0,1062.0,Catholic,Secondary,1425.0,-37.991161,145.068214
 St Bede's College,45855.0,2015,MENTONE,31.0,7.6,87.0,100.0,1073.0,Catholic,Secondary,1504.0,-37.991161,145.068214
 St Bede's College,45855.0,2016,MENTONE,31.0,9.9,90.0,100.0,1080.0,Catholic,Secondary,1527.0,-37.991161,145.068214
@@ -4549,7 +4646,7 @@ St Bede's College,45855.0,2019,MENTONE,30.0,6.3,79.0,100.0,1095.0,Catholic,Secon
 St Bede's College,45855.0,2020,MENTONE,30.0,5.9,81.1,100.0,1096.0,Catholic,Secondary,1566.0,-37.991161,145.068214
 St Bede's College,45855.0,2021,MENTONE,30.0,6.4,80.0,100.0,1091.0,Catholic,Secondary,1908.0,-37.991161,145.068214
 St Bede's College,45855.0,2022,MENTONE,29.0,4.2,78.4,100.0,1093.0,Catholic,Secondary,1891.0,-37.991161,145.068214
-St Bede's College,,2023,MENTONE,31.0,8.3,71.3,100.0,,,,,,
+St Bede's College,45855.0,2023,MENTONE,31.0,8.3,71.3,100.0,,,,,,
 St Bernard's College,45864.0,2014,ESSENDON,32.0,8.7,93.0,99.0,1077.0,Catholic,Secondary,1410.0,-37.74942324,144.88352628
 St Bernard's College,45864.0,2015,ESSENDON,32.0,10.5,86.0,99.0,1069.0,Catholic,Secondary,1435.0,-37.74942324,144.88352628
 St Bernard's College,45864.0,2016,ESSENDON,32.0,10.2,89.0,100.0,1068.0,Catholic,Secondary,1441.0,-37.74942324,144.88352628
@@ -4559,7 +4656,7 @@ St Bernard's College,45864.0,2019,ESSENDON,30.0,7.5,91.8,100.0,1077.0,Catholic,S
 St Bernard's College,45864.0,2020,ESSENDON,30.0,6.0,93.3,100.0,1082.0,Catholic,Secondary,1532.0,-37.74942324,144.88352628
 St Bernard's College,45864.0,2021,ESSENDON,30.0,5.3,82.7,100.0,1084.0,Catholic,Secondary,1568.0,-37.74942324,144.88352628
 St Bernard's College,45864.0,2022,ESSENDON,31.0,6.3,80.1,100.0,1089.0,Catholic,Secondary,1577.0,-37.74942324,144.88352628
-St Bernard's College,,2023,ESSENDON,30.0,5.6,76.8,100.0,,,,,,
+St Bernard's College,45864.0,2023,ESSENDON,30.0,5.6,76.8,100.0,,,,,,
 St Brigid's College,45793.0,2014,HORSHAM,28.0,5.1,60.0,100.0,966.0,Catholic,Secondary,470.0,-36.717313,142.207946
 St Brigid's College,45793.0,2015,HORSHAM,30.0,4.4,74.0,100.0,998.0,Catholic,Secondary,440.0,-36.717313,142.207946
 St Brigid's College,45793.0,2016,HORSHAM,28.0,3.9,71.0,98.0,998.0,Catholic,Secondary,421.0,-36.717313,142.207946
@@ -4569,7 +4666,7 @@ St Brigid's College,45793.0,2019,HORSHAM,29.0,5.2,67.6,100.0,998.0,Catholic,Seco
 St Brigid's College,45793.0,2020,HORSHAM,27.0,4.8,80.0,100.0,996.0,Catholic,Secondary,265.0,-36.717313,142.207946
 St Brigid's College,45793.0,2021,HORSHAM,28.0,0.0,70.8,100.0,998.0,Catholic,Secondary,219.0,-36.717313,142.207946
 St Brigid's College,45793.0,2022,HORSHAM,26.0,0.0,48.1,96.0,1008.0,Catholic,Secondary,218.0,-36.717313,142.207946
-St Brigid's College,,2023,HORSHAM,27.0,1.6,42.1,100.0,,,,,,
+St Brigid's College,45793.0,2023,HORSHAM,27.0,1.6,42.1,100.0,,,,,,
 St Catherine's School,46178.0,2014,TOORAK,35.0,23.7,100.0,100.0,1161.0,Independent,Combined,636.0,-37.838296,145.021269
 St Catherine's School,46178.0,2015,TOORAK,36.0,26.0,99.0,100.0,1164.0,Independent,Combined,672.0,-37.838296,145.021269
 St Catherine's School,46178.0,2016,TOORAK,35.0,18.0,100.0,100.0,1162.0,Independent,Combined,656.0,-37.838296,145.021269
@@ -4579,7 +4676,7 @@ St Catherine's School,46178.0,2019,TOORAK,35.0,20.2,98.7,100.0,1162.0,Independen
 St Catherine's School,46178.0,2020,TOORAK,35.0,25.0,98.8,100.0,1162.0,Independent,Combined,656.0,-37.838296,145.021269
 St Catherine's School,46178.0,2021,TOORAK,37.0,32.2,97.5,100.0,1159.0,Independent,Combined,587.0,-37.838296,145.021269
 St Catherine's School,46178.0,2022,TOORAK,37.0,32.9,98.7,100.0,1169.0,Independent,Combined,630.0,-37.838296,145.021269
-St Catherine's School,,2023,TOORAK,36.0,28.9,100.0,100.0,,,,,,
+St Catherine's School,46178.0,2023,TOORAK,36.0,28.9,100.0,100.0,,,,,,
 St Columba's College,45748.0,2014,ESSENDON,32.0,10.9,99.0,99.0,1090.0,Catholic,Secondary,1002.0,-37.757202,144.91429
 St Columba's College,45748.0,2015,ESSENDON,32.0,9.4,100.0,100.0,1088.0,Catholic,Secondary,1003.0,-37.757202,144.91429
 St Columba's College,45748.0,2016,ESSENDON,32.0,10.3,100.0,100.0,1090.0,Catholic,Secondary,1025.0,-37.757202,144.91429
@@ -4589,7 +4686,7 @@ St Columba's College,45748.0,2019,ESSENDON,32.0,10.5,95.8,100.0,1095.0,Catholic,
 St Columba's College,45748.0,2020,ESSENDON,33.0,13.1,98.7,100.0,1096.0,Catholic,Secondary,1032.0,-37.757202,144.91429
 St Columba's College,45748.0,2021,ESSENDON,32.0,12.7,96.6,100.0,1098.0,Catholic,Secondary,1031.0,-37.757202,144.91429
 St Columba's College,45748.0,2022,ESSENDON,32.0,10.4,96.5,100.0,1106.0,Catholic,Secondary,1001.0,-37.757202,144.91429
-St Columba's College,,2023,ESSENDON,31.0,7.5,90.7,100.0,,,,,,
+St Columba's College,45748.0,2023,ESSENDON,31.0,7.5,90.7,100.0,,,,,,
 St Francis Xavier College,40621.0,2014,BEACONSFIELD,30.0,4.7,87.0,99.0,1027.0,Catholic,Combined,2402.0,-38.051525,145.373328
 St Francis Xavier College,40621.0,2015,BEACONSFIELD,31.0,5.8,89.0,100.0,1032.0,Catholic,Combined,2547.0,-38.051525,145.373328
 St Francis Xavier College,40621.0,2016,BEACONSFIELD,30.0,5.9,83.0,99.0,1026.0,Catholic,Secondary,2791.0,-38.051525,145.373328
@@ -4599,7 +4696,7 @@ St Francis Xavier College,40621.0,2019,BEACONSFIELD,29.0,6.1,80.7,99.0,1039.0,Ca
 St Francis Xavier College,40621.0,2020,BEACONSFIELD,29.0,5.9,76.1,99.0,1040.0,Catholic,Secondary,3296.0,-38.051525,145.373328
 St Francis Xavier College,40621.0,2021,BEACONSFIELD,29.0,4.3,71.2,99.0,1038.0,Catholic,Secondary,3306.0,-38.051525,145.373328
 St Francis Xavier College,40621.0,2022,BEACONSFIELD,29.0,3.9,71.6,96.0,1042.0,Catholic,Secondary,3278.0,-38.051525,145.373328
-St Francis Xavier College,,2023,BEACONSFIELD,28.0,2.8,71.4,97.0,,,,,,
+St Francis Xavier College,40621.0,2023,BEACONSFIELD,28.0,2.8,71.4,97.0,,,,,,
 St Helena Secondary College,45510.0,2014,ELTHAM,31.0,6.3,89.0,99.0,1050.0,Government,Secondary,1512.0,-37.686582,145.139842
 St Helena Secondary College,45510.0,2015,ELTHAM,30.0,5.0,91.0,98.0,1054.0,Government,Secondary,1537.0,-37.686582,145.139842
 St Helena Secondary College,45510.0,2016,ELTHAM,30.0,5.6,93.0,98.0,1057.0,Government,Secondary,1582.0,-37.686582,145.139842
@@ -4609,17 +4706,17 @@ St Helena Secondary College,45510.0,2019,ELTHAM,29.0,3.8,71.9,96.0,1059.0,Govern
 St Helena Secondary College,45510.0,2020,ELTHAM,29.0,5.8,73.3,96.0,1061.0,Government,Secondary,1585.0,-37.686582,145.139842
 St Helena Secondary College,45510.0,2021,ELTHAM,29.0,3.5,76.6,99.0,1061.0,Government,Secondary,1570.0,-37.686582,145.139842
 St Helena Secondary College,45510.0,2022,ELTHAM,29.0,4.8,80.2,98.0,1062.0,Government,Secondary,1510.0,-37.686582,145.139842
-St Helena Secondary College,,2023,ELTHAM,29.0,6.0,68.1,92.0,,,,,,
-St John's Greek Orth College,45932.0,2014,PRESTON,30.0,12.5,85.0,100.0,1005.0,Catholic,Secondary,1076.0,-37.990229,145.226256
-St John's Greek Orth College,45932.0,2015,PRESTON,33.0,15.0,83.0,92.0,1004.0,Catholic,Secondary,988.0,-37.990229,145.226256
-St John's Greek Orth College,45932.0,2016,PRESTON,32.0,5.9,80.0,93.0,1000.0,Catholic,Secondary,924.0,-37.990229,145.226256
-St John's Greek Orth College,45932.0,2017,PRESTON,26.0,3.4,67.0,100.0,1006.0,Catholic,Secondary,856.0,-37.990229,145.226256
-St John's Greek Orth College,45932.0,2018,PRESTON,29.0,4.3,62.5,94.0,998.0,Catholic,Secondary,800.0,-37.990229,145.226256
-St John's Greek Orth College,45932.0,2019,PRESTON,27.0,4.7,84.2,100.0,997.0,Catholic,Secondary,717.0,-37.990229,145.226256
-St John's Greek Orth College,45932.0,2020,PRESTON,34.0,15.0,50.0,90.0,1002.0,Catholic,Secondary,694.0,-37.990229,145.226256
-St John's Greek Orth College,45932.0,2021,PRESTON,29.0,0.0,82.4,100.0,997.0,Catholic,Secondary,642.0,-37.990229,145.226256
-St John's Greek Orth College,45932.0,2022,PRESTON,30.0,6.1,100.0,100.0,995.0,Catholic,Secondary,612.0,-37.990229,145.226256
-St John's Greek Orth College,,2023,PRESTON,28.0,1.1,86.4,100.0,,,,,,
+St Helena Secondary College,45510.0,2023,ELTHAM,29.0,6.0,68.1,92.0,,,,,,
+St John's Greek Orth College,46252.0,2014,PRESTON,30.0,12.5,85.0,100.0,1048.0,Independent,Combined,217.0,-37.748167,144.999274
+St John's Greek Orth College,46252.0,2015,PRESTON,33.0,15.0,83.0,92.0,1045.0,Independent,Combined,217.0,-37.748167,144.999274
+St John's Greek Orth College,46252.0,2016,PRESTON,32.0,5.9,80.0,93.0,1036.0,Independent,Combined,237.0,-37.748167,144.999274
+St John's Greek Orth College,46252.0,2017,PRESTON,26.0,3.4,67.0,100.0,1024.0,Independent,Combined,249.0,-37.748167,144.999274
+St John's Greek Orth College,46252.0,2018,PRESTON,29.0,4.3,62.5,94.0,1048.0,Independent,Combined,255.0,-37.748167,144.999274
+St John's Greek Orth College,46252.0,2019,PRESTON,27.0,4.7,84.2,100.0,1052.0,Independent,Combined,240.0,-37.748167,144.999274
+St John's Greek Orth College,46252.0,2020,PRESTON,34.0,15.0,50.0,90.0,1052.0,Independent,Combined,255.0,-37.748167,144.999274
+St John's Greek Orth College,46252.0,2021,PRESTON,29.0,0.0,82.4,100.0,1052.0,Independent,Combined,259.0,-37.7458484141014,144.999550764193
+St John's Greek Orth College,46252.0,2022,PRESTON,30.0,6.1,100.0,100.0,1059.0,Independent,Combined,286.0,-37.7458484141014,144.999550764193
+St John's Greek Orth College,46252.0,2023,PRESTON,28.0,1.1,86.4,100.0,,,,,,
 St John's Regional College,45932.0,2014,DANDENONG,28.0,2.0,93.0,100.0,1005.0,Catholic,Secondary,1076.0,-37.990229,145.226256
 St John's Regional College,45932.0,2015,DANDENONG,27.0,2.5,86.0,99.0,1004.0,Catholic,Secondary,988.0,-37.990229,145.226256
 St John's Regional College,45932.0,2016,DANDENONG,25.0,1.8,95.0,99.0,1000.0,Catholic,Secondary,924.0,-37.990229,145.226256
@@ -4629,83 +4726,47 @@ St John's Regional College,45932.0,2019,DANDENONG,25.0,0.7,82.6,99.0,997.0,Catho
 St John's Regional College,45932.0,2020,DANDENONG,25.0,1.3,87.6,98.0,1002.0,Catholic,Secondary,694.0,-37.990229,145.226256
 St John's Regional College,45932.0,2021,DANDENONG,26.0,3.0,77.9,97.0,997.0,Catholic,Secondary,642.0,-37.990229,145.226256
 St John's Regional College,45932.0,2022,DANDENONG,25.0,2.5,72.2,97.0,995.0,Catholic,Secondary,612.0,-37.990229,145.226256
-St John's Regional College,,2023,DANDENONG,26.0,2.0,78.9,100.0,,,,,,
+St John's Regional College,45932.0,2023,DANDENONG,26.0,2.0,78.9,100.0,,,,,,
 St Joseph's College,45732.0,2014,ECHUCA,27.0,2.8,74.0,99.0,996.0,Catholic,Secondary,848.0,-36.118067,144.743373
-St Joseph's College,45972.0,2014,ECHUCA,27.0,2.8,74.0,99.0,999.0,Catholic,Secondary,1046.0,-37.89049,145.295093
 St Joseph's College,45732.0,2014,FERNTREE GULLY,31.0,7.2,90.0,100.0,996.0,Catholic,Secondary,848.0,-36.118067,144.743373
-St Joseph's College,45972.0,2014,FERNTREE GULLY,31.0,7.2,90.0,100.0,999.0,Catholic,Secondary,1046.0,-37.89049,145.295093
 St Joseph's College,45732.0,2014,MILDURA,29.0,3.7,75.0,100.0,996.0,Catholic,Secondary,848.0,-36.118067,144.743373
-St Joseph's College,45972.0,2014,MILDURA,29.0,3.7,75.0,100.0,999.0,Catholic,Secondary,1046.0,-37.89049,145.295093
 St Joseph's College,45732.0,2014,NEWTOWN,31.0,9.8,82.0,100.0,996.0,Catholic,Secondary,848.0,-36.118067,144.743373
-St Joseph's College,45972.0,2014,NEWTOWN,31.0,9.8,82.0,100.0,999.0,Catholic,Secondary,1046.0,-37.89049,145.295093
 St Joseph's College,45732.0,2015,ECHUCA,28.0,2.5,72.0,97.0,1001.0,Catholic,Secondary,889.0,-36.118067,144.743373
-St Joseph's College,45972.0,2015,ECHUCA,28.0,2.5,72.0,97.0,1018.0,Catholic,Secondary,1047.0,-37.89049,145.295093
 St Joseph's College,45732.0,2015,FERNTREE GULLY,30.0,8.1,92.0,100.0,1001.0,Catholic,Secondary,889.0,-36.118067,144.743373
-St Joseph's College,45972.0,2015,FERNTREE GULLY,30.0,8.1,92.0,100.0,1018.0,Catholic,Secondary,1047.0,-37.89049,145.295093
 St Joseph's College,45732.0,2015,MILDURA,29.0,4.4,83.0,99.0,1001.0,Catholic,Secondary,889.0,-36.118067,144.743373
-St Joseph's College,45972.0,2015,MILDURA,29.0,4.4,83.0,99.0,1018.0,Catholic,Secondary,1047.0,-37.89049,145.295093
 St Joseph's College,45732.0,2015,NEWTOWN,32.0,11.6,79.0,98.0,1001.0,Catholic,Secondary,889.0,-36.118067,144.743373
-St Joseph's College,45972.0,2015,NEWTOWN,32.0,11.6,79.0,98.0,1018.0,Catholic,Secondary,1047.0,-37.89049,145.295093
 St Joseph's College,45732.0,2016,ECHUCA,28.0,3.0,70.0,99.0,1003.0,Catholic,Secondary,899.0,-36.118067,144.743373
-St Joseph's College,45972.0,2016,ECHUCA,28.0,3.0,70.0,99.0,1021.0,Catholic,Secondary,1049.0,-37.89049,145.295093
 St Joseph's College,45732.0,2016,FERNTREE GULLY,30.0,4.3,89.0,98.0,1003.0,Catholic,Secondary,899.0,-36.118067,144.743373
-St Joseph's College,45972.0,2016,FERNTREE GULLY,30.0,4.3,89.0,98.0,1021.0,Catholic,Secondary,1049.0,-37.89049,145.295093
 St Joseph's College,45732.0,2016,MILDURA,30.0,6.1,74.0,96.0,1003.0,Catholic,Secondary,899.0,-36.118067,144.743373
-St Joseph's College,45972.0,2016,MILDURA,30.0,6.1,74.0,96.0,1021.0,Catholic,Secondary,1049.0,-37.89049,145.295093
 St Joseph's College,45732.0,2016,NEWTOWN,31.0,9.4,75.0,99.0,1003.0,Catholic,Secondary,899.0,-36.118067,144.743373
-St Joseph's College,45972.0,2016,NEWTOWN,31.0,9.4,75.0,99.0,1021.0,Catholic,Secondary,1049.0,-37.89049,145.295093
 St Joseph's College,45732.0,2017,ECHUCA,28.0,1.8,75.0,96.0,1002.0,Catholic,Secondary,900.0,-36.118067,144.743373
-St Joseph's College,45972.0,2017,ECHUCA,28.0,1.8,75.0,96.0,1022.0,Catholic,Secondary,1061.0,-37.89049,145.295093
 St Joseph's College,45732.0,2017,FERNTREE GULLY,30.0,6.4,88.0,99.0,1002.0,Catholic,Secondary,900.0,-36.118067,144.743373
-St Joseph's College,45972.0,2017,FERNTREE GULLY,30.0,6.4,88.0,99.0,1022.0,Catholic,Secondary,1061.0,-37.89049,145.295093
 St Joseph's College,45732.0,2017,MILDURA,29.0,6.3,73.0,100.0,1002.0,Catholic,Secondary,900.0,-36.118067,144.743373
-St Joseph's College,45972.0,2017,MILDURA,29.0,6.3,73.0,100.0,1022.0,Catholic,Secondary,1061.0,-37.89049,145.295093
 St Joseph's College,45732.0,2017,NEWTOWN,31.0,10.0,72.0,99.0,1002.0,Catholic,Secondary,900.0,-36.118067,144.743373
-St Joseph's College,45972.0,2017,NEWTOWN,31.0,10.0,72.0,99.0,1022.0,Catholic,Secondary,1061.0,-37.89049,145.295093
 St Joseph's College,45732.0,2018,ECHUCA,29.0,1.8,80.8,96.0,1003.0,Catholic,Secondary,892.0,-36.118067,144.743373
-St Joseph's College,45972.0,2018,ECHUCA,29.0,1.8,80.8,96.0,1029.0,Catholic,Secondary,1010.0,-37.89049,145.295093
 St Joseph's College,45732.0,2018,FERNTREE GULLY,30.0,5.7,82.5,100.0,1003.0,Catholic,Secondary,892.0,-36.118067,144.743373
-St Joseph's College,45972.0,2018,FERNTREE GULLY,30.0,5.7,82.5,100.0,1029.0,Catholic,Secondary,1010.0,-37.89049,145.295093
 St Joseph's College,45732.0,2018,MILDURA,29.0,5.6,75.4,100.0,1003.0,Catholic,Secondary,892.0,-36.118067,144.743373
-St Joseph's College,45972.0,2018,MILDURA,29.0,5.6,75.4,100.0,1029.0,Catholic,Secondary,1010.0,-37.89049,145.295093
 St Joseph's College,45732.0,2018,NEWTOWN,31.0,9.8,74.2,98.0,1003.0,Catholic,Secondary,892.0,-36.118067,144.743373
-St Joseph's College,45972.0,2018,NEWTOWN,31.0,9.8,74.2,98.0,1029.0,Catholic,Secondary,1010.0,-37.89049,145.295093
 St Joseph's College,45732.0,2019,ECHUCA,28.0,3.9,82.6,100.0,1000.0,Catholic,Secondary,902.0,-36.118067,144.743373
-St Joseph's College,45972.0,2019,ECHUCA,28.0,3.9,82.6,100.0,1038.0,Catholic,Secondary,985.0,-37.89049,145.295093
 St Joseph's College,45732.0,2019,FERNTREE GULLY,30.0,4.5,81.0,99.0,1000.0,Catholic,Secondary,902.0,-36.118067,144.743373
-St Joseph's College,45972.0,2019,FERNTREE GULLY,30.0,4.5,81.0,99.0,1038.0,Catholic,Secondary,985.0,-37.89049,145.295093
 St Joseph's College,45732.0,2019,MILDURA,30.0,7.1,76.7,100.0,1000.0,Catholic,Secondary,902.0,-36.118067,144.743373
-St Joseph's College,45972.0,2019,MILDURA,30.0,7.1,76.7,100.0,1038.0,Catholic,Secondary,985.0,-37.89049,145.295093
 St Joseph's College,45732.0,2019,NEWTOWN,31.0,11.4,69.5,100.0,1000.0,Catholic,Secondary,902.0,-36.118067,144.743373
-St Joseph's College,45972.0,2019,NEWTOWN,31.0,11.4,69.5,100.0,1038.0,Catholic,Secondary,985.0,-37.89049,145.295093
 St Joseph's College,45732.0,2020,ECHUCA,29.0,3.6,73.8,95.0,1001.0,Catholic,Secondary,933.0,-36.118067,144.743373
-St Joseph's College,45972.0,2020,ECHUCA,29.0,3.6,73.8,95.0,1044.0,Catholic,Secondary,960.0,-37.89049,145.295093
 St Joseph's College,45732.0,2020,FERNTREE GULLY,32.0,7.9,89.3,98.0,1001.0,Catholic,Secondary,933.0,-36.118067,144.743373
-St Joseph's College,45972.0,2020,FERNTREE GULLY,32.0,7.9,89.3,98.0,1044.0,Catholic,Secondary,960.0,-37.89049,145.295093
 St Joseph's College,45732.0,2020,MILDURA,29.0,4.2,78.6,100.0,1001.0,Catholic,Secondary,933.0,-36.118067,144.743373
-St Joseph's College,45972.0,2020,MILDURA,29.0,4.2,78.6,100.0,1044.0,Catholic,Secondary,960.0,-37.89049,145.295093
 St Joseph's College,45732.0,2020,NEWTOWN,31.0,8.8,73.7,99.0,1001.0,Catholic,Secondary,933.0,-36.118067,144.743373
-St Joseph's College,45972.0,2020,NEWTOWN,31.0,8.8,73.7,99.0,1044.0,Catholic,Secondary,960.0,-37.89049,145.295093
 St Joseph's College,45732.0,2021,ECHUCA,28.0,3.1,75.0,98.0,1008.0,Catholic,Secondary,917.0,-36.118067,144.743373
-St Joseph's College,45972.0,2021,ECHUCA,28.0,3.1,75.0,98.0,1043.0,Catholic,Secondary,936.0,-37.89049,145.295093
 St Joseph's College,45732.0,2021,FERNTREE GULLY,31.0,9.2,81.2,100.0,1008.0,Catholic,Secondary,917.0,-36.118067,144.743373
-St Joseph's College,45972.0,2021,FERNTREE GULLY,31.0,9.2,81.2,100.0,1043.0,Catholic,Secondary,936.0,-37.89049,145.295093
 St Joseph's College,45732.0,2021,MILDURA,28.0,1.8,66.7,100.0,1008.0,Catholic,Secondary,917.0,-36.118067,144.743373
-St Joseph's College,45972.0,2021,MILDURA,28.0,1.8,66.7,100.0,1043.0,Catholic,Secondary,936.0,-37.89049,145.295093
 St Joseph's College,45732.0,2021,NEWTOWN,31.0,8.3,64.9,99.0,1008.0,Catholic,Secondary,917.0,-36.118067,144.743373
-St Joseph's College,45972.0,2021,NEWTOWN,31.0,8.3,64.9,99.0,1043.0,Catholic,Secondary,936.0,-37.89049,145.295093
 St Joseph's College,45732.0,2022,ECHUCA,29.0,3.2,65.7,96.0,1024.0,Catholic,Secondary,960.0,-36.118067,144.743373
-St Joseph's College,45972.0,2022,ECHUCA,29.0,3.2,65.7,96.0,1043.0,Catholic,Secondary,914.0,-37.89049,145.295093
 St Joseph's College,45732.0,2022,FERNTREE GULLY,30.0,5.5,82.0,100.0,1024.0,Catholic,Secondary,960.0,-36.118067,144.743373
-St Joseph's College,45972.0,2022,FERNTREE GULLY,30.0,5.5,82.0,100.0,1043.0,Catholic,Secondary,914.0,-37.89049,145.295093
 St Joseph's College,45732.0,2022,MILDURA,28.0,3.0,75.9,100.0,1024.0,Catholic,Secondary,960.0,-36.118067,144.743373
-St Joseph's College,45972.0,2022,MILDURA,28.0,3.0,75.9,100.0,1043.0,Catholic,Secondary,914.0,-37.89049,145.295093
 St Joseph's College,45732.0,2022,NEWTOWN,30.0,7.4,68.5,99.0,1024.0,Catholic,Secondary,960.0,-36.118067,144.743373
-St Joseph's College,45972.0,2022,NEWTOWN,30.0,7.4,68.5,99.0,1043.0,Catholic,Secondary,914.0,-37.89049,145.295093
-St Joseph's College,,2023,ECHUCA,29.0,2.9,61.9,99.0,,,,,,
-St Joseph's College,,2023,FERNTREE GULLY,32.0,6.4,67.7,100.0,,,,,,
-St Joseph's College,,2023,MILDURA,29.0,5.9,57.7,98.0,,,,,,
-St Joseph's College,,2023,NEWTOWN,30.0,5.2,53.0,99.0,,,,,,
+St Joseph's College,45732.0,2023,ECHUCA,29.0,2.9,61.9,99.0,,,,,,
+St Joseph's College,45732.0,2023,FERNTREE GULLY,32.0,6.4,67.7,100.0,,,,,,
+St Joseph's College,45732.0,2023,MILDURA,29.0,5.9,57.7,98.0,,,,,,
+St Joseph's College,45732.0,2023,NEWTOWN,30.0,5.2,53.0,99.0,,,,,,
 St Kevin's College,45848.0,2014,TOORAK,35.0,22.1,98.0,100.0,1190.0,Catholic,Combined,1976.0,-37.8353971,145.02469671
 St Kevin's College,45848.0,2015,TOORAK,36.0,29.3,98.0,100.0,1185.0,Catholic,Combined,1973.0,-37.8353971,145.02469671
 St Kevin's College,45848.0,2016,TOORAK,35.0,27.1,99.0,100.0,1188.0,Catholic,Combined,1982.0,-37.8353971,145.02469671
@@ -4715,7 +4776,7 @@ St Kevin's College,45848.0,2019,TOORAK,36.0,27.5,100.0,100.0,1177.0,Catholic,Com
 St Kevin's College,45848.0,2020,TOORAK,35.0,25.9,99.6,100.0,1177.0,Catholic,Combined,2099.0,-37.8353971,145.02469671
 St Kevin's College,45848.0,2021,TOORAK,35.0,22.0,97.6,100.0,1179.0,Catholic,Combined,2114.0,-37.8353971,145.02469671
 St Kevin's College,45848.0,2022,TOORAK,35.0,24.0,99.6,100.0,1186.0,Catholic,Combined,2120.0,-37.8353971,145.02469671
-St Kevin's College,,2023,TOORAK,35.0,24.0,96.4,100.0,,,,,,
+St Kevin's College,45848.0,2023,TOORAK,35.0,24.0,96.4,100.0,,,,,,
 St Leonard's College,46173.0,2014,BRIGHTON EAST,33.0,12.4,89.0,100.0,1162.0,Independent,Combined,1341.0,-37.928631,145.007554
 St Leonard's College,46173.0,2015,BRIGHTON EAST,33.0,13.6,87.0,100.0,1176.0,Independent,Combined,1347.0,-37.928631,145.007554
 St Leonard's College,46173.0,2016,BRIGHTON EAST,33.0,14.7,93.0,100.0,1183.0,Independent,Combined,1404.0,-37.928631,145.007554
@@ -4725,17 +4786,17 @@ St Leonard's College,46173.0,2019,BRIGHTON EAST,33.0,14.4,92.9,100.0,1174.0,Inde
 St Leonard's College,46173.0,2020,BRIGHTON EAST,34.0,17.2,91.7,100.0,1174.0,Independent,Combined,1553.0,-37.928631,145.007554
 St Leonard's College,46173.0,2021,BRIGHTON EAST,34.0,16.8,96.1,99.0,1174.0,Independent,Combined,1512.0,-37.928631,145.007554
 St Leonard's College,46173.0,2022,BRIGHTON EAST,34.0,16.6,92.7,100.0,1179.0,Independent,Combined,1571.0,-37.928631,145.007554
-St Leonard's College,,2023,BRIGHTON EAST,35.0,20.7,93.7,100.0,,,,,,
-St Margaret's School,45934.0,2014,BERWICK,34.0,17.3,100.0,100.0,941.0,Catholic,Combined,216.0,-34.58470583,142.77850545
-St Margaret's School,45934.0,2015,BERWICK,35.0,24.2,100.0,100.0,970.0,Catholic,Combined,221.0,-34.58470583,142.77850545
-St Margaret's School,45934.0,2016,BERWICK,34.0,15.9,100.0,100.0,983.0,Catholic,Combined,239.0,-34.58470583,142.77850545
-St Margaret's School,45934.0,2017,BERWICK,35.0,20.4,100.0,100.0,974.0,Catholic,Combined,250.0,-34.58470583,142.77850545
-St Margaret's School,45934.0,2018,BERWICK,34.0,17.2,97.9,100.0,985.0,Catholic,Combined,245.0,-34.58470583,142.77850545
-St Margaret's School,45934.0,2019,BERWICK,34.0,16.7,98.1,100.0,983.0,Catholic,Combined,228.0,-34.58470583,142.77850545
-St Margaret's School,45934.0,2020,BERWICK,35.0,27.9,98.3,100.0,968.0,Catholic,Combined,244.0,-34.58470583,142.77850545
-St Margaret's School,45934.0,2021,BERWICK,34.0,17.8,98.2,100.0,960.0,Catholic,Combined,260.0,-34.58470583,142.77850545
-St Margaret's School,45934.0,2022,BERWICK,34.0,17.1,94.3,100.0,957.0,Catholic,Combined,279.0,-34.58470583,142.77850545
-St Margaret's School,,2023,BERWICK,33.0,18.9,97.6,100.0,,,,,,
+St Leonard's College,46173.0,2023,BRIGHTON EAST,35.0,20.7,93.7,100.0,,,,,,
+St Margaret's School,46203.0,2014,BERWICK,34.0,17.3,100.0,100.0,1128.0,Independent,Combined,925.0,-38.035346,145.346545
+St Margaret's School,46203.0,2015,BERWICK,35.0,24.2,100.0,100.0,1136.0,Independent,Combined,960.0,-38.035346,145.346545
+St Margaret's School,46203.0,2016,BERWICK,34.0,15.9,100.0,100.0,1136.0,Independent,Combined,943.0,-38.035346,145.346545
+St Margaret's School,46203.0,2017,BERWICK,35.0,20.4,100.0,100.0,1137.0,Independent,Combined,824.0,-38.035346,145.346545
+St Margaret's School,46203.0,2018,BERWICK,34.0,17.2,97.9,100.0,1135.0,Independent,Combined,764.0,-38.035346,145.346545
+St Margaret's School,46203.0,2019,BERWICK,34.0,16.7,98.1,100.0,1133.0,Independent,Combined,746.0,-38.035346,145.346545
+St Margaret's School,46203.0,2020,BERWICK,35.0,27.9,98.3,100.0,1133.0,Independent,Combined,736.0,-38.035346,145.346545
+St Margaret's School,46203.0,2021,BERWICK,34.0,17.8,98.2,100.0,1140.0,Independent,Combined,672.0,-38.035346,145.346545
+St Margaret's School,46203.0,2022,BERWICK,34.0,17.1,94.3,100.0,1147.0,Independent,Combined,739.0,-38.035346,145.346545
+St Margaret's School,46203.0,2023,BERWICK,33.0,18.9,97.6,100.0,,,,,,
 St Mary MacKillop College,46085.0,2014,SWAN HILL,30.0,4.1,91.0,100.0,988.0,Catholic,Secondary,496.0,-35.341915,143.556795
 St Mary MacKillop College,46085.0,2015,SWAN HILL,31.0,7.7,94.0,100.0,1025.0,Catholic,Secondary,475.0,-35.341915,143.556795
 St Mary MacKillop College,46085.0,2016,SWAN HILL,31.0,7.3,83.0,98.0,1026.0,Catholic,Secondary,475.0,-35.341915,143.556795
@@ -4745,7 +4806,7 @@ St Mary MacKillop College,46085.0,2019,SWAN HILL,29.0,5.0,89.8,100.0,1041.0,Cath
 St Mary MacKillop College,46085.0,2020,SWAN HILL,28.0,2.8,74.5,98.0,1027.0,Catholic,Secondary,433.0,-35.341915,143.556795
 St Mary MacKillop College,46085.0,2021,SWAN HILL,28.0,4.2,84.0,100.0,1024.0,Catholic,Secondary,427.0,-35.341915,143.556795
 St Mary MacKillop College,46085.0,2022,SWAN HILL,29.0,5.5,88.1,95.0,1033.0,Catholic,Secondary,439.0,-35.341915,143.556795
-St Mary MacKillop College,,2023,SWAN HILL,30.0,5.8,65.2,93.0,,,,,,
+St Mary MacKillop College,46085.0,2023,SWAN HILL,30.0,5.8,65.2,93.0,,,,,,
 St Mary of the Angels School,45945.0,2014,NATHALIA,28.0,4.0,75.0,98.0,1011.0,Catholic,Secondary,502.0,-36.057656,145.208748
 St Mary of the Angels School,45945.0,2015,NATHALIA,29.0,1.7,85.0,100.0,1011.0,Catholic,Secondary,515.0,-36.057656,145.208748
 St Mary of the Angels School,45945.0,2016,NATHALIA,29.0,3.5,92.0,100.0,1007.0,Catholic,Secondary,547.0,-36.057656,145.208748
@@ -4755,11 +4816,11 @@ St Mary of the Angels School,45945.0,2019,NATHALIA,29.0,0.7,90.6,98.0,1006.0,Cat
 St Mary of the Angels School,45945.0,2020,NATHALIA,28.0,3.3,78.1,100.0,1006.0,Catholic,Secondary,619.0,-36.057656,145.208748
 St Mary of the Angels School,45945.0,2021,NATHALIA,27.0,2.2,72.9,100.0,1007.0,Catholic,Secondary,638.0,-36.057656,145.208748
 St Mary of the Angels School,45945.0,2022,NATHALIA,29.0,4.1,63.8,97.0,1014.0,Catholic,Secondary,669.0,-36.057656,145.208748
-St Mary of the Angels School,,2023,NATHALIA,27.0,2.1,62.1,97.0,,,,,,
-St Mary's College,,2023,SEYMOUR,,,,,,,,,,
+St Mary of the Angels School,45945.0,2023,NATHALIA,27.0,2.1,62.1,97.0,,,,,,
+St Mary's College,45660.0,2023,SEYMOUR,,,,,,,,,,
 St Mary's College Melbourne,45632.0,2021,ST KILDA EAST,29.0,3.6,88.8,100.0,1075.0,Catholic,Secondary,526.0,-37.859365,144.997001
 St Mary's College Melbourne,45632.0,2022,ST KILDA EAST,30.0,4.4,77.7,99.0,1081.0,Catholic,Secondary,512.0,-37.859365,144.997001
-St Mary's College Melbourne,,2023,ST KILDA EAST,31.0,6.4,70.7,99.0,,,,,,
+St Mary's College Melbourne,45632.0,2023,ST KILDA EAST,31.0,6.4,70.7,99.0,,,,,,
 St Mary's Coptic Orth College,46320.0,2014,COOLAROO,27.0,3.4,98.0,100.0,1004.0,Independent,Combined,730.0,-37.65583,144.931212
 St Mary's Coptic Orth College,46320.0,2015,COOLAROO,27.0,4.2,98.0,100.0,,Independent,Combined,769.0,-37.65583,144.931212
 St Mary's Coptic Orth College,46320.0,2016,COOLAROO,27.0,8.4,85.0,96.0,1001.0,Independent,Combined,782.0,-37.65583,144.931212
@@ -4769,7 +4830,7 @@ St Mary's Coptic Orth College,46320.0,2019,COOLAROO,29.0,5.3,88.9,100.0,1014.0,I
 St Mary's Coptic Orth College,46320.0,2020,COOLAROO,27.0,2.8,93.7,100.0,1017.0,Independent,Combined,826.0,-37.65583,144.931212
 St Mary's Coptic Orth College,46320.0,2021,COOLAROO,28.0,5.5,83.3,93.0,1010.0,Independent,Combined,839.0,-37.65583,144.931212
 St Mary's Coptic Orth College,46320.0,2022,COOLAROO,27.0,6.5,89.8,98.0,1006.0,Independent,Combined,880.0,-37.65583,144.931212
-St Mary's Coptic Orth College,,2023,COOLAROO,30.0,14.2,88.1,100.0,,,,,,
+St Mary's Coptic Orth College,46320.0,2023,COOLAROO,30.0,14.2,88.1,100.0,,,,,,
 St Michael's Grammar School,46163.0,2014,ST KILDA,34.0,14.3,94.0,100.0,1164.0,Independent,Combined,1235.0,-37.85955,144.991742
 St Michael's Grammar School,46163.0,2015,ST KILDA,34.0,19.0,94.0,100.0,1165.0,Independent,Combined,1223.0,-37.85955,144.991742
 St Michael's Grammar School,46163.0,2016,ST KILDA,34.0,16.0,91.0,100.0,1162.0,Independent,Combined,1220.0,-37.85955,144.991742
@@ -4779,7 +4840,7 @@ St Michael's Grammar School,46163.0,2019,ST KILDA,32.0,13.7,88.1,100.0,1152.0,In
 St Michael's Grammar School,46163.0,2020,ST KILDA,32.0,12.7,95.5,100.0,1152.0,Independent,Combined,1134.0,-37.85955,144.991742
 St Michael's Grammar School,46163.0,2021,ST KILDA,34.0,13.8,92.9,100.0,1157.0,Independent,Combined,1106.0,-37.85955,144.991742
 St Michael's Grammar School,46163.0,2022,ST KILDA,33.0,17.2,95.7,100.0,1162.0,Independent,Combined,1126.0,-37.85955,144.991742
-St Michael's Grammar School,,2023,ST KILDA,34.0,17.6,94.2,99.0,,,,,,
+St Michael's Grammar School,46163.0,2023,ST KILDA,34.0,17.6,94.2,99.0,,,,,,
 St Monica's College,40615.0,2014,EPPING,29.0,5.2,86.0,99.0,1027.0,Catholic,Secondary,1864.0,-37.6507081,145.0302857
 St Monica's College,40615.0,2015,EPPING,30.0,7.4,84.0,99.0,1031.0,Catholic,Secondary,1893.0,-37.6507081,145.0302857
 St Monica's College,40615.0,2016,EPPING,31.0,8.6,84.0,100.0,1031.0,Catholic,Secondary,1910.0,-37.6507081,145.0302857
@@ -4789,7 +4850,7 @@ St Monica's College,40615.0,2019,EPPING,30.0,4.9,83.1,100.0,1043.0,Catholic,Seco
 St Monica's College,40615.0,2020,EPPING,28.0,3.5,88.0,100.0,1047.0,Catholic,Secondary,1977.0,-37.655706,145.032058
 St Monica's College,40615.0,2021,EPPING,29.0,4.5,86.4,100.0,1049.0,Catholic,Secondary,2005.0,-37.655706,145.032058
 St Monica's College,40615.0,2022,EPPING,29.0,4.7,85.8,100.0,1055.0,Catholic,Secondary,2018.0,-37.655706,145.032058
-St Monica's College,,2023,EPPING,28.0,4.2,74.3,100.0,,,,,,
+St Monica's College,40615.0,2023,EPPING,28.0,4.2,74.3,100.0,,,,,,
 St Patrick's College,45634.0,2014,BALLARAT,30.0,5.9,86.0,99.0,1047.0,Catholic,Secondary,1361.0,-37.559711,143.831558
 St Patrick's College,45634.0,2015,BALLARAT,30.0,6.0,67.0,99.0,1048.0,Catholic,Secondary,1406.0,-37.559711,143.831558
 St Patrick's College,45634.0,2016,BALLARAT,29.0,4.9,72.0,100.0,1049.0,Catholic,Secondary,1376.0,-37.559711,143.831558
@@ -4799,7 +4860,7 @@ St Patrick's College,45634.0,2019,BALLARAT,29.0,5.7,65.9,98.0,1045.0,Catholic,Se
 St Patrick's College,45634.0,2020,BALLARAT,28.0,4.7,65.5,99.0,1047.0,Catholic,Secondary,1305.0,-37.559711,143.831558
 St Patrick's College,45634.0,2021,BALLARAT,28.0,5.5,68.1,99.0,1053.0,Catholic,Secondary,1273.0,-37.559711,143.831558
 St Patrick's College,45634.0,2022,BALLARAT,29.0,3.6,69.6,99.0,1050.0,Catholic,Secondary,1266.0,-37.559711,143.831558
-St Patrick's College,,2023,BALLARAT,28.0,3.8,57.9,100.0,,,,,,
+St Patrick's College,45634.0,2023,BALLARAT,28.0,3.8,57.9,100.0,,,,,,
 St Paul's Anglican Grammar Schl,46277.0,2014,WARRAGUL,31.0,8.0,96.0,100.0,1109.0,Independent,Combined,1354.0,-38.147811,145.930417
 St Paul's Anglican Grammar Schl,46277.0,2015,WARRAGUL,32.0,8.7,96.0,100.0,1102.0,Independent,Combined,1285.0,-38.147811,145.930417
 St Paul's Anglican Grammar Schl,46277.0,2016,WARRAGUL,31.0,7.5,94.0,100.0,1104.0,Independent,Combined,1293.0,-38.147811,145.930417
@@ -4809,7 +4870,7 @@ St Paul's Anglican Grammar Schl,46277.0,2019,WARRAGUL,32.0,13.6,85.8,100.0,1099.
 St Paul's Anglican Grammar Schl,46277.0,2020,WARRAGUL,34.0,18.1,95.9,98.0,1099.0,Independent,Combined,1330.0,-38.147811,145.930417
 St Paul's Anglican Grammar Schl,46277.0,2021,WARRAGUL,31.0,8.3,90.3,100.0,1102.0,Independent,Combined,1370.0,-38.147811,145.930417
 St Paul's Anglican Grammar Schl,46277.0,2022,WARRAGUL,32.0,10.8,84.1,99.0,1102.0,Independent,Combined,1443.0,-38.147811,145.930417
-St Paul's Anglican Grammar Schl,,2023,WARRAGUL,31.0,6.9,79.8,99.0,,,,,,
+St Paul's Anglican Grammar Schl,46277.0,2023,WARRAGUL,31.0,6.9,79.8,99.0,,,,,,
 St Peter's College,46087.0,2014,CRANBOURNE,27.0,1.5,88.0,100.0,1020.0,Catholic,Secondary,1174.0,-38.108411,145.256866
 St Peter's College,46087.0,2015,CRANBOURNE,28.0,4.0,84.0,98.0,1021.0,Catholic,Secondary,1253.0,-38.108411,145.256866
 St Peter's College,46087.0,2016,CRANBOURNE,27.0,2.1,76.0,98.0,1016.0,Catholic,Secondary,1354.0,-38.108411,145.256866
@@ -4819,7 +4880,7 @@ St Peter's College,46087.0,2019,CRANBOURNE,27.0,0.8,83.9,100.0,1027.0,Catholic,S
 St Peter's College,46087.0,2020,CRANBOURNE,27.0,0.8,92.1,98.0,1031.0,Catholic,Secondary,1637.0,-38.108411,145.256866
 St Peter's College,46087.0,2021,CRANBOURNE,25.0,1.3,83.5,97.0,1031.0,Catholic,Secondary,1736.0,-38.108411,145.256866
 St Peter's College,46087.0,2022,CRANBOURNE,27.0,2.8,83.7,99.0,1036.0,Catholic,Secondary,1790.0,-38.108411,145.256866
-St Peter's College,,2023,CRANBOURNE,26.0,1.7,67.0,96.0,,,,,,
+St Peter's College,46087.0,2023,CRANBOURNE,26.0,1.7,67.0,96.0,,,,,,
 St Thomas Aquinas College,46346.0,2014,TYNONG,27.0,2.1,72.0,100.0,1036.0,Independent,Combined,318.0,-38.0829561,145.62279301
 St Thomas Aquinas College,46346.0,2015,TYNONG,29.0,2.9,100.0,100.0,1036.0,Independent,Combined,305.0,-38.0829561,145.62279301
 St Thomas Aquinas College,46346.0,2016,TYNONG,28.0,3.9,77.0,100.0,1035.0,Independent,Combined,297.0,-38.0829561,145.62279301
@@ -4829,7 +4890,7 @@ St Thomas Aquinas College,46346.0,2019,TYNONG,24.0,1.3,57.1,100.0,1048.0,Indepen
 St Thomas Aquinas College,46346.0,2020,TYNONG,27.0,2.0,73.7,100.0,1052.0,Independent,Combined,281.0,-38.0829561,145.62279301
 St Thomas Aquinas College,46346.0,2021,TYNONG,28.0,0.0,47.1,100.0,1047.0,Independent,Combined,265.0,-38.0829561,145.62279301
 St Thomas Aquinas College,46346.0,2022,TYNONG,26.0,0.0,45.5,91.0,1041.0,Independent,Combined,233.0,-38.0829561,145.62279301
-St Thomas Aquinas College,,2023,TYNONG,27.0,1.9,58.3,100.0,,,,,,
+St Thomas Aquinas College,46346.0,2023,TYNONG,27.0,1.9,58.3,100.0,,,,,,
 Star of the Sea College,45675.0,2014,GARDENVALE,33.0,9.4,98.0,100.0,1125.0,Catholic,Secondary,1093.0,-37.896734,144.99678
 Star of the Sea College,45675.0,2015,GARDENVALE,33.0,8.8,97.0,100.0,1122.0,Catholic,Secondary,1109.0,-37.896734,144.99678
 Star of the Sea College,45675.0,2016,BRIGHTON,34.0,15.0,99.0,99.0,1125.0,Catholic,Secondary,1103.0,-37.896734,144.99678
@@ -4839,7 +4900,7 @@ Star of the Sea College,45675.0,2019,BRIGHTON,35.0,16.9,100.0,100.0,1124.0,Catho
 Star of the Sea College,45675.0,2020,BRIGHTON,34.0,16.9,99.4,100.0,1126.0,Catholic,Secondary,1187.0,-37.896734,144.99678
 Star of the Sea College,45675.0,2021,BRIGHTON,33.0,17.6,100.0,100.0,1129.0,Catholic,Secondary,1202.0,-37.896734,144.99678
 Star of the Sea College,45675.0,2022,BRIGHTON,34.0,15.2,100.0,100.0,1125.0,Catholic,Secondary,1194.0,-37.896734,144.99678
-Star of the Sea College,,2023,BRIGHTON,34.0,13.5,97.6,100.0,,,,,,
+Star of the Sea College,45675.0,2023,BRIGHTON,34.0,13.5,97.6,100.0,,,,,,
 Staughton College,45336.0,2014,MELTON SOUTH,23.0,0.9,55.0,93.0,945.0,Government,Secondary,965.0,-37.708271,144.567745
 Staughton College,45336.0,2015,MELTON SOUTH,24.0,0.3,56.0,93.0,950.0,Government,Secondary,989.0,-37.708271,144.567745
 Staughton College,45336.0,2016,MELTON SOUTH,25.0,0.2,60.0,95.0,948.0,Government,Secondary,988.0,-37.708271,144.567745
@@ -4849,7 +4910,7 @@ Staughton College,45336.0,2019,MELTON SOUTH,27.0,3.0,70.9,96.0,952.0,Government,
 Staughton College,45336.0,2020,MELTON SOUTH,27.0,3.1,66.7,96.0,959.0,Government,Secondary,1150.0,-37.708271,144.567745
 Staughton College,45336.0,2021,MELTON SOUTH,26.0,1.3,59.8,95.0,961.0,Government,Secondary,1205.0,-37.708271,144.567745
 Staughton College,45336.0,2022,MELTON SOUTH,25.0,0.6,74.6,99.0,958.0,Government,Secondary,1295.0,-37.708271,144.567745
-Staughton College,,2023,MELTON SOUTH,23.0,1.4,34.9,90.0,,,,,,
+Staughton College,45336.0,2023,MELTON SOUTH,23.0,1.4,34.9,90.0,,,,,,
 Stawell Secondary College,45511.0,2014,STAWELL,26.0,0.7,73.0,92.0,956.0,Government,Secondary,429.0,-37.061954,142.789787
 Stawell Secondary College,45511.0,2015,STAWELL,28.0,4.7,62.0,100.0,966.0,Government,Secondary,423.0,-37.061954,142.789787
 Stawell Secondary College,45511.0,2016,STAWELL,26.0,2.1,80.0,98.0,962.0,Government,Secondary,429.0,-37.061954,142.789787
@@ -4859,7 +4920,7 @@ Stawell Secondary College,45511.0,2019,STAWELL,23.0,0.0,44.4,97.0,967.0,Governme
 Stawell Secondary College,45511.0,2020,STAWELL,25.0,2.4,58.1,94.0,970.0,Government,Secondary,374.0,-37.061954,142.789787
 Stawell Secondary College,45511.0,2021,STAWELL,24.0,1.9,50.0,96.0,967.0,Government,Secondary,378.0,-37.061954,142.789787
 Stawell Secondary College,45511.0,2022,STAWELL,25.0,0.7,41.2,94.0,952.0,Government,Secondary,363.0,-37.061954,142.789787
-Stawell Secondary College,,2023,STAWELL,23.0,,42.4,100.0,,,,,,
+Stawell Secondary College,45511.0,2023,STAWELL,23.0,,42.4,100.0,,,,,,
 Stott's College,50313.0,2014,CARLTON,26.0,5.0,67.0,67.0,,Independent,Secondary,,-37.80142573738283,144.9671616337538
 Stott's College,50313.0,2015,CARLTON,21.0,0.0,86.0,95.0,,Independent,Secondary,,-37.80142573738283,144.9671616337538
 Stott's College,50313.0,2016,CARLTON,24.0,5.6,73.0,100.0,,Independent,Secondary,,-37.80142574,144.96716163
@@ -4877,7 +4938,7 @@ Strathcona Baptist Girls GS,46192.0,2019,CANTERBURY,36.0,27.9,94.9,100.0,1143.0,
 Strathcona Baptist Girls GS,46192.0,2020,CANTERBURY,36.0,28.2,97.6,100.0,1143.0,Independent,Combined,752.0,-37.829176,145.080366
 Strathcona Baptist Girls GS,46192.0,2021,CANTERBURY,35.0,20.5,96.5,100.0,1153.0,Independent,Combined,750.0,-37.829176,145.080366
 Strathcona Baptist Girls GS,46192.0,2022,CANTERBURY,36.0,25.1,98.1,100.0,1145.0,Independent,Combined,780.0,-37.829176,145.080366
-Strathcona Baptist Girls GS,,2023,CANTERBURY,35.0,23.7,98.9,100.0,,,,,,
+Strathcona Baptist Girls GS,46192.0,2023,CANTERBURY,35.0,23.7,98.9,100.0,,,,,,
 Strathmore Secondary College,45469.0,2014,STRATHMORE,31.0,8.9,94.0,99.0,1076.0,Government,Secondary,1539.0,-37.73695,144.926643
 Strathmore Secondary College,45469.0,2015,STRATHMORE,31.0,8.4,96.0,99.0,1074.0,Government,Secondary,1591.0,-37.73695,144.926643
 Strathmore Secondary College,45469.0,2016,STRATHMORE,31.0,9.6,97.0,99.0,1074.0,Government,Secondary,1629.0,-37.73695,144.926643
@@ -4887,7 +4948,7 @@ Strathmore Secondary College,45469.0,2019,STRATHMORE,31.0,6.4,92.1,98.0,1080.0,G
 Strathmore Secondary College,45469.0,2020,STRATHMORE,30.0,5.3,83.1,98.0,1078.0,Government,Secondary,1911.0,-37.73695,144.926643
 Strathmore Secondary College,45469.0,2021,STRATHMORE,30.0,7.2,82.9,97.0,1078.0,Government,Secondary,1903.0,-37.73695,144.926643
 Strathmore Secondary College,45469.0,2022,STRATHMORE,31.0,7.4,74.7,98.0,1080.0,Government,Secondary,1912.0,-37.73695,144.926643
-Strathmore Secondary College,,2023,STRATHMORE,30.0,6.9,86.7,99.0,,,,,,
+Strathmore Secondary College,45469.0,2023,STRATHMORE,30.0,6.9,86.7,99.0,,,,,,
 Sunbury College,45470.0,2014,SUNBURY,26.0,2.6,76.0,97.0,986.0,Government,Secondary,1021.0,-37.574206,144.728687
 Sunbury College,45470.0,2015,SUNBURY,27.0,2.5,77.0,96.0,973.0,Government,Secondary,975.0,-37.574206,144.728687
 Sunbury College,45470.0,2016,SUNBURY,27.0,3.2,66.0,99.0,969.0,Government,Secondary,952.0,-37.574206,144.728687
@@ -4897,7 +4958,7 @@ Sunbury College,45470.0,2019,SUNBURY,26.0,1.7,53.7,96.0,978.0,Government,Seconda
 Sunbury College,45470.0,2020,SUNBURY,25.0,1.7,69.6,96.0,982.0,Government,Secondary,1101.0,-37.574206,144.728687
 Sunbury College,45470.0,2021,SUNBURY,26.0,3.2,60.2,92.0,987.0,Government,Secondary,1080.0,-37.574206,144.728687
 Sunbury College,45470.0,2022,SUNBURY,28.0,2.2,79.3,99.0,988.0,Government,Secondary,1067.0,-37.574206,144.728687
-Sunbury College,,2023,SUNBURY,27.0,1.3,50.4,97.0,,,,,,
+Sunbury College,45470.0,2023,SUNBURY,27.0,1.3,50.4,97.0,,,,,,
 Sunbury Downs Sec College,45507.0,2014,SUNBURY,31.0,6.3,76.0,95.0,990.0,Government,Secondary,710.0,-37.583811,144.705353
 Sunbury Downs Sec College,45507.0,2015,SUNBURY,30.0,4.3,73.0,92.0,998.0,Government,Secondary,740.0,-37.583811,144.705353
 Sunbury Downs Sec College,45507.0,2016,SUNBURY,30.0,1.7,80.0,100.0,999.0,Government,Secondary,769.0,-37.583811,144.705353
@@ -4907,7 +4968,17 @@ Sunbury Downs Sec College,45507.0,2019,SUNBURY,30.0,4.2,54.9,99.0,1002.0,Governm
 Sunbury Downs Sec College,45507.0,2020,SUNBURY,28.0,5.6,67.1,92.0,1002.0,Government,Secondary,656.0,-37.583811,144.705353
 Sunbury Downs Sec College,45507.0,2021,SUNBURY,30.0,2.7,61.4,99.0,1001.0,Government,Secondary,625.0,-37.583811,144.705353
 Sunbury Downs Sec College,45507.0,2022,SUNBURY,29.0,2.9,65.3,98.0,996.0,Government,Secondary,592.0,-37.583811,144.705353
-Sunbury Downs Sec College,,2023,SUNBURY,29.0,4.2,71.2,93.0,,,,,,
+Sunbury Downs Sec College,45507.0,2023,SUNBURY,29.0,4.2,71.2,93.0,,,,,,
+Sunraysia Institute of TAFE,,2014,MILDURA,,,,,,,,,,
+Sunraysia Institute of TAFE,,2015,MILDURA,,,,,,,,,,
+Sunraysia Institute of TAFE,,2016,MILDURA,,,,,,,,,,
+Sunraysia Institute of TAFE,,2017,MILDURA,,,,,,,,,,
+Sunraysia Institute of TAFE,,2018,MILDURA,,,,,,,,,,
+Sunraysia Institute of TAFE,,2019,MILDURA,,,,,,,,,,
+Sunraysia Institute of TAFE,,2020,MILDURA,,,,,,,,,,
+Sunraysia Institute of TAFE,,2021,MILDURA,,,,,,,,,,
+Sunraysia Institute of TAFE,,2022,MILDURA,,,,,,,,,,
+Sunraysia Institute of TAFE,,2023,MILDURA,,,,80.0,,,,,,
 Sunshine College,45529.0,2014,SUNSHINE,27.0,1.4,95.0,97.0,921.0,Government,Secondary,1003.0,-37.79274078,144.81359292
 Sunshine College,45529.0,2015,SUNSHINE,26.0,1.6,98.0,99.0,922.0,Government,Secondary,937.0,-37.79274078,144.81359292
 Sunshine College,45529.0,2016,SUNSHINE,28.0,2.0,94.0,97.0,917.0,Government,Secondary,929.0,-37.79274078,144.81359292
@@ -4917,7 +4988,7 @@ Sunshine College,45529.0,2019,SUNSHINE,29.0,2.8,98.3,97.0,937.0,Government,Secon
 Sunshine College,45529.0,2020,SUNSHINE WEST,27.0,2.0,74.0,95.0,939.0,Government,Secondary,1153.0,-37.79274078,144.81359292
 Sunshine College,45529.0,2021,SUNSHINE WEST,27.0,2.1,62.4,94.0,963.0,Government,Secondary,1108.0,-37.79274078,144.8135929
 Sunshine College,45529.0,2022,SUNSHINE WEST,26.0,0.9,63.3,94.0,938.0,Government,Secondary,1068.0,-37.79274078,144.8135929
-Sunshine College,,2023,SUNSHINE WEST,25.0,1.0,69.8,98.0,,,,,,
+Sunshine College,45529.0,2023,SUNSHINE WEST,25.0,1.0,69.8,98.0,,,,,,
 Surf Coast Sec College,50460.0,2014,TORQUAY,23.0,0.8,67.0,96.0,1017.0,Government,Secondary,412.0,-38.321778,144.314127
 Surf Coast Sec College,50460.0,2015,TORQUAY,26.0,7.5,67.0,95.0,1030.0,Government,Secondary,534.0,-38.30419186,144.32385516
 Surf Coast Sec College,50460.0,2016,TORQUAY,25.0,1.7,61.0,90.0,1028.0,Government,Secondary,651.0,-38.30419186,144.32385516
@@ -4927,7 +4998,7 @@ Surf Coast Sec College,50460.0,2019,TORQUAY,28.0,2.2,53.2,99.0,1042.0,Government
 Surf Coast Sec College,50460.0,2020,TORQUAY,28.0,2.5,60.6,100.0,1044.0,Government,Secondary,966.0,-38.30419186,144.32385516
 Surf Coast Sec College,50460.0,2021,TORQUAY,27.0,2.4,60.6,98.0,1049.0,Government,Secondary,958.0,-38.30419186,144.32385516
 Surf Coast Sec College,50460.0,2022,TORQUAY,29.0,2.7,66.3,98.0,1049.0,Government,Secondary,931.0,-38.30419186,144.32385516
-Surf Coast Sec College,,2023,TORQUAY,29.0,3.9,50.0,98.0,,,,,,
+Surf Coast Sec College,50460.0,2023,TORQUAY,29.0,3.9,50.0,98.0,,,,,,
 Suzanne Cory High School,50301.0,2014,WERRIBEE,34.0,15.3,96.0,100.0,1102.0,Government,Secondary,797.0,-37.8939,144.701
 Suzanne Cory High School,50301.0,2015,WERRIBEE,34.0,17.1,99.0,100.0,1110.0,Government,Secondary,799.0,-37.8939,144.701
 Suzanne Cory High School,50301.0,2016,WERRIBEE,34.0,15.5,97.0,100.0,1106.0,Government,Secondary,823.0,-37.8939,144.701
@@ -4937,7 +5008,7 @@ Suzanne Cory High School,50301.0,2019,WERRIBEE,34.0,14.6,99.1,100.0,1130.0,Gover
 Suzanne Cory High School,50301.0,2020,WERRIBEE,34.0,19.0,99.6,100.0,1136.0,Government,Secondary,901.0,-37.8939,144.701
 Suzanne Cory High School,50301.0,2021,WERRIBEE,34.0,17.2,97.8,100.0,1141.0,Government,Secondary,907.0,-37.8939,144.701
 Suzanne Cory High School,50301.0,2022,WERRIBEE,34.0,16.5,98.7,100.0,1151.0,Government,Secondary,906.0,-37.8939,144.701
-Suzanne Cory High School,,2023,WERRIBEE,35.0,19.0,99.1,99.0,,,,,,
+Suzanne Cory High School,50301.0,2023,WERRIBEE,35.0,19.0,99.1,99.0,,,,,,
 Swan Hill College,45540.0,2014,SWAN HILL,27.0,1.3,87.0,100.0,932.0,Government,Secondary,906.0,-35.33522773,143.55285194
 Swan Hill College,45540.0,2015,SWAN HILL,26.0,2.6,94.0,100.0,933.0,Government,Secondary,893.0,-35.33522773,143.55285194
 Swan Hill College,45540.0,2016,SWAN HILL,27.0,1.4,87.0,95.0,932.0,Government,Secondary,885.0,-35.33522773,143.55285194
@@ -4947,7 +5018,7 @@ Swan Hill College,45540.0,2019,SWAN HILL,26.0,4.4,72.4,98.0,943.0,Government,Sec
 Swan Hill College,45540.0,2020,SWAN HILL,27.0,1.4,68.9,98.0,949.0,Government,Secondary,740.0,-35.33522773,143.55285194
 Swan Hill College,45540.0,2021,SWAN HILL,26.0,1.4,83.3,98.0,950.0,Government,Secondary,741.0,-35.33522773,143.55285194
 Swan Hill College,45540.0,2022,SWAN HILL,28.0,4.1,73.8,98.0,948.0,Government,Secondary,712.0,-35.33522773,143.55285194
-Swan Hill College,,2023,SWAN HILL,28.0,3.5,46.7,96.0,,,,,,
+Swan Hill College,45540.0,2023,SWAN HILL,28.0,3.5,46.7,96.0,,,,,,
 Swifts Creek P-12 School,45623.0,2015,SWIFTS CREEK,31.0,0.0,67.0,100.0,979.0,Government,Combined,132.0,-37.26684449,147.7240342
 Swifts Creek P-12 School,45623.0,2016,SWIFTS CREEK,28.0,3.6,33.0,100.0,985.0,Government,Combined,146.0,-37.26684449,147.7240342
 Swifts Creek P-12 School,45623.0,2017,SWIFTS CREEK,29.0,15.8,100.0,100.0,963.0,Government,Combined,125.0,-37.26684449,147.7240342
@@ -4956,7 +5027,7 @@ Swifts Creek P-12 School,45623.0,2019,SWIFTS CREEK,22.0,0.0,50.0,75.0,971.0,Gove
 Swifts Creek P-12 School,45623.0,2020,SWIFTS CREEK,24.0,3.8,27.3,91.0,962.0,Government,Combined,120.0,-37.26684449,147.7240342
 Swifts Creek P-12 School,45623.0,2021,SWIFTS CREEK,30.0,6.3,85.7,100.0,966.0,Government,Combined,101.0,-37.26684449,147.7240342
 Swifts Creek P-12 School,45623.0,2022,SWIFTS CREEK,29.0,5.9,75.0,100.0,952.0,Government,Combined,102.0,-37.26684449,147.7240342
-Swifts Creek P-12 School,,2023,SWIFTS CREEK,31.0,4.0,71.4,100.0,,,,,,
+Swifts Creek P-12 School,45623.0,2023,SWIFTS CREEK,31.0,4.0,71.4,100.0,,,,,,
 Swifts Creek School,45623.0,2014,SWIFTS CREEK,32.0,7.4,100.0,100.0,1001.0,Government,Combined,131.0,-37.26684449,147.7240342
 Swinburne Senior Sec College,40430.0,2014,HAWTHORN,29.0,2.6,80.0,90.0,,Government,Secondary,403.0,-37.823135,145.040821
 Swinburne Senior Sec College,40430.0,2015,HAWTHORN,27.0,1.0,75.0,92.0,,Government,Secondary,422.0,-37.823135,145.040821
@@ -4967,7 +5038,17 @@ Swinburne Senior Sec College,40430.0,2019,HAWTHORN,27.0,3.0,81.4,96.0,1084.0,Gov
 Swinburne Senior Sec College,40430.0,2020,HAWTHORN,29.0,3.2,78.7,98.0,1092.0,Government,Secondary,413.0,-37.823135,145.040821
 Swinburne Senior Sec College,40430.0,2021,HAWTHORN,28.0,2.8,73.8,96.0,1089.0,Government,Secondary,390.0,-37.823135,145.040821
 Swinburne Senior Sec College,40430.0,2022,HAWTHORN,28.0,4.1,64.5,96.0,1094.0,Government,Secondary,396.0,-37.823135,145.040821
-Swinburne Senior Sec College,,2023,HAWTHORN,27.0,3.2,63.6,95.0,,,,,,
+Swinburne Senior Sec College,40430.0,2023,HAWTHORN,27.0,3.2,63.6,95.0,,,,,,
+Swinburne Uni of Tech - TAFE,,2014,CROYDON,,,,,,,,,,
+Swinburne Uni of Tech - TAFE,,2015,CROYDON,,,,,,,,,,
+Swinburne Uni of Tech - TAFE,,2016,CROYDON,,,,,,,,,,
+Swinburne Uni of Tech - TAFE,,2017,CROYDON,,,,,,,,,,
+Swinburne Uni of Tech - TAFE,,2018,CROYDON,,,,,,,,,,
+Swinburne Uni of Tech - TAFE,,2019,CROYDON,24.0,1.1,36.0,88.0,,,,,,
+Swinburne Uni of Tech - TAFE,,2020,CROYDON,23.0,0.0,51.4,83.0,,,,,,
+Swinburne Uni of Tech - TAFE,,2021,CROYDON,25.0,1.3,45.5,88.0,,,,,,
+Swinburne Uni of Tech - TAFE,,2022,CROYDON,20.0,0.0,52.6,74.0,,,,,,
+Swinburne Uni of Tech - TAFE,,2023,CROYDON,,,3.8,46.0,,,,,,
 Sydney Road Community School,45471.0,2014,BRUNSWICK,22.0,0.0,67.0,67.0,994.0,Government,Secondary,85.0,-37.769524,144.961715
 Sydney Road Community School,45471.0,2015,BRUNSWICK,24.0,0.0,67.0,50.0,1005.0,Government,Secondary,87.0,-37.769524,144.961715
 Sydney Road Community School,45471.0,2016,BRUNSWICK,26.0,0.0,50.0,50.0,980.0,Government,Secondary,100.0,-37.769524,144.961715
@@ -4977,7 +5058,11 @@ Sydney Road Community School,45471.0,2019,BRUNSWICK,20.0,0.0,33.3,100.0,1025.0,G
 Sydney Road Community School,45471.0,2020,BRUNSWICK,25.0,0.0,50.0,67.0,1041.0,Government,Secondary,102.0,-37.769524,144.961715
 Sydney Road Community School,45471.0,2021,BRUNSWICK,27.0,0.0,28.6,100.0,1029.0,Government,Secondary,96.0,-37.769524,144.961715
 Sydney Road Community School,45471.0,2022,BRUNSWICK,23.0,0.0,62.5,100.0,1026.0,Government,Secondary,96.0,-37.7718349990803,144.962330426194
-Sydney Road Community School,,2023,BRUNSWICK,,,27.3,91.0,,,,,,
+Sydney Road Community School,45471.0,2023,BRUNSWICK,,,27.3,91.0,,,,,,
+TAFE Gippsland,,2020,NEWBOROUGH,28.0,7.7,0.0,83.0,,,,,,
+TAFE Gippsland,,2021,NEWBOROUGH,30.0,0.0,9.1,73.0,,,,,,
+TAFE Gippsland,,2022,SALE,28.0,0.0,7.1,79.0,,,,,,
+TAFE Gippsland,,2023,SALE,26.0,,6.7,60.0,,,,,,
 Tallangatta Secondary College,45472.0,2014,TALLANGATTA,30.0,2.8,82.0,100.0,994.0,Government,Secondary,425.0,-36.220441,147.172667
 Tallangatta Secondary College,45472.0,2015,TALLANGATTA,28.0,6.6,51.0,95.0,987.0,Government,Secondary,442.0,-36.220441,147.172667
 Tallangatta Secondary College,45472.0,2016,TALLANGATTA,27.0,4.7,60.0,100.0,990.0,Government,Secondary,440.0,-36.220441,147.172667
@@ -4987,7 +5072,7 @@ Tallangatta Secondary College,45472.0,2019,TALLANGATTA,27.0,3.3,47.4,100.0,986.0
 Tallangatta Secondary College,45472.0,2020,TALLANGATTA,26.0,0.5,78.9,100.0,987.0,Government,Secondary,351.0,-36.220441,147.172667
 Tallangatta Secondary College,45472.0,2021,TALLANGATTA,26.0,0.0,50.0,100.0,988.0,Government,Secondary,347.0,-36.220441,147.172667
 Tallangatta Secondary College,45472.0,2022,TALLANGATTA,25.0,2.6,45.2,100.0,988.0,Government,Secondary,329.0,-36.220441,147.172667
-Tallangatta Secondary College,,2023,TALLANGATTA,26.0,0.9,35.3,97.0,,,,,,
+Tallangatta Secondary College,45472.0,2023,TALLANGATTA,26.0,0.9,35.3,97.0,,,,,,
 Tarneit Senior College,50459.0,2014,TARNEIT,23.0,0.6,91.0,100.0,,Government,Secondary,306.0,-37.83330658,144.6794225
 Tarneit Senior College,50459.0,2015,TARNEIT,24.0,1.0,81.0,97.0,,Government,Secondary,386.0,-37.83330658,144.6794225
 Tarneit Senior College,50459.0,2016,TARNEIT,25.0,1.3,65.0,98.0,,Government,Secondary,425.0,-37.83330658,144.6794225
@@ -4997,8 +5082,8 @@ Tarneit Senior College,50459.0,2019,TARNEIT,24.0,0.5,93.3,98.0,997.0,Government,
 Tarneit Senior College,50459.0,2020,TARNEIT,24.0,1.3,84.0,95.0,995.0,Government,Secondary,722.0,-37.83330658,144.6794225
 Tarneit Senior College,50459.0,2021,TARNEIT,24.0,0.6,69.2,96.0,995.0,Government,Secondary,862.0,-37.83330658,144.6794225
 Tarneit Senior College,50459.0,2022,TARNEIT,24.0,1.8,75.4,95.0,989.0,Government,Secondary,969.0,-37.83330658,144.6794225
-Tarneit Senior College,,2023,TARNEIT,23.0,0.7,64.2,97.0,,,,,,
-Taylors College,46177.0,2014,MELBOURNE,31.0,8.8,95.0,95.0,1131.0,Independent,Combined,636.0,-38.17324124,145.09322974
+Tarneit Senior College,50459.0,2023,TARNEIT,23.0,0.7,64.2,97.0,,,,,,
+Taylors College,,2014,MELBOURNE,31.0,8.8,95.0,95.0,,,,,,
 Taylors Lakes Sec College,45527.0,2014,TAYLORS LAKES,28.0,3.7,92.0,100.0,984.0,Government,Secondary,1426.0,-37.7066603,144.7936498
 Taylors Lakes Sec College,45527.0,2015,TAYLORS LAKES,28.0,3.2,96.0,99.0,983.0,Government,Secondary,1453.0,-37.7066603,144.7936498
 Taylors Lakes Sec College,45527.0,2016,TAYLORS LAKES,28.0,3.2,94.0,99.0,979.0,Government,Secondary,1459.0,-37.7066603,144.7936498
@@ -5008,7 +5093,7 @@ Taylors Lakes Sec College,45527.0,2019,TAYLORS LAKES,25.0,1.9,88.9,96.0,994.0,Go
 Taylors Lakes Sec College,45527.0,2020,TAYLORS LAKES,27.0,3.9,91.8,99.0,999.0,Government,Secondary,1443.0,-37.7066603,144.7936498
 Taylors Lakes Sec College,45527.0,2021,TAYLORS LAKES,26.0,3.6,88.4,99.0,1002.0,Government,Secondary,1421.0,-37.7066603,144.7936498
 Taylors Lakes Sec College,45527.0,2022,TAYLORS LAKES,26.0,2.4,88.5,97.0,1000.0,Government,Secondary,1365.0,-37.7066603,144.7936498
-Taylors Lakes Sec College,,2023,TAYLORS LAKES,27.0,4.2,70.4,98.0,,,,,,
+Taylors Lakes Sec College,45527.0,2023,TAYLORS LAKES,27.0,4.2,70.4,98.0,,,,,,
 Templestowe College,45560.0,2014,TEMPLESTOWE LOWER,25.0,2.3,61.0,94.0,1064.0,Government,Secondary,527.0,-37.76747383,145.12182858
 Templestowe College,45560.0,2015,TEMPLESTOWE LOWER,26.0,1.7,62.0,92.0,1079.0,Government,Secondary,629.0,-37.76747383,145.12182858
 Templestowe College,45560.0,2016,TEMPLESTOWE LOWER,26.0,3.0,63.0,95.0,1091.0,Government,Secondary,796.0,-37.76747383,145.12182858
@@ -5018,7 +5103,7 @@ Templestowe College,45560.0,2019,TEMPLESTOWE LOWER,29.0,6.0,58.3,95.0,1091.0,Gov
 Templestowe College,45560.0,2020,TEMPLESTOWE LOWER,30.0,6.4,66.9,91.0,1091.0,Government,Secondary,1237.0,-37.76747383,145.12182858
 Templestowe College,45560.0,2021,TEMPLESTOWE LOWER,30.0,6.6,64.2,98.0,1092.0,Government,Secondary,1224.0,-37.76747383,145.12182858
 Templestowe College,45560.0,2022,TEMPLESTOWE LOWER,29.0,6.2,63.9,99.0,1098.0,Government,Secondary,1183.0,-37.76747383,145.12182858
-Templestowe College,,2023,TEMPLESTOWE LOWER,29.0,4.0,53.3,98.0,,,,,,
+Templestowe College,45560.0,2023,TEMPLESTOWE LOWER,29.0,4.0,53.3,98.0,,,,,,
 Terang College Sec Campus,45307.0,2014,TERANG,27.0,2.3,63.0,100.0,983.0,Government,Combined,345.0,-38.246282,142.921395
 Terang College Sec Campus,45307.0,2015,TERANG,29.0,1.0,77.0,100.0,970.0,Government,Combined,358.0,-38.246282,142.921395
 Terang College Sec Campus,45307.0,2016,TERANG,28.0,0.0,87.0,100.0,967.0,Government,Combined,360.0,-38.246282,142.921395
@@ -5028,14 +5113,21 @@ Terang College Sec Campus,45307.0,2019,TERANG,27.0,3.0,78.9,100.0,976.0,Governme
 Terang College Sec Campus,45307.0,2020,TERANG,25.0,1.1,65.0,100.0,977.0,Government,Combined,327.0,-38.246282,142.921395
 Terang College Sec Campus,45307.0,2021,TERANG,26.0,3.7,50.0,100.0,980.0,Government,Combined,289.0,-38.246282,142.921395
 Terang College Sec Campus,45307.0,2022,TERANG,29.0,4.8,66.7,93.0,971.0,Government,Combined,272.0,-38.246282,142.921395
-Terang College Sec Campus,,2023,TERANG,30.0,6.3,50.0,100.0,,,,,,
+Terang College Sec Campus,45307.0,2023,TERANG,30.0,6.3,50.0,100.0,,,,,,
+The Bendigo Kangan Institute,,2022,BROADMEADOWS,,,,,,,,,,
+The Bendigo Kangan Institute,,2023,BROADMEADOWS,,,38.6,73.0,,,,,,
+The Centre,,2014,WANGARATTA,,,,,,,,,,
+The Centre,,2015,WANGARATTA,,,,,,,,,,
+The Centre,,2016,WANGARATTA,,,,,,,,,,
+The Centre,,2017,WANGARATTA,,,,,,,,,,
+The Centre,,2019,WANGARATTA,,,,,,,,,,
 The David Scott School,52481.0,2017,FRANKSTON,,,,,,Independent,Special,48.0,-37.804676,144.97717
 The David Scott School,52481.0,2018,FRANKSTON,,,,,,Independent,Special,56.0,-37.804676,144.97717
 The David Scott School,52481.0,2019,FRANKSTON,,,,,,Independent,Special,87.0,-38.14833,145.11926
 The David Scott School,52481.0,2020,FRANKSTON,,,,,,Independent,Special,115.0,-38.14833,145.11926
 The David Scott School,52481.0,2021,FRANKSTON,,,,,965.0,Independent,Special,118.0,-38.14833,145.11926
 The David Scott School,52481.0,2022,FRANKSTON,,,,,967.0,Independent,Special,121.0,-38.14833,145.11926
-The David Scott School,,2023,FRANKSTON,,,3.8,65.0,,,,,,
+The David Scott School,52481.0,2023,FRANKSTON,,,3.8,65.0,,,,,,
 The Geelong College,46159.0,2014,NEWTOWN,34.0,15.1,99.0,100.0,1152.0,Independent,Combined,1193.0,-38.15241839,144.3400898
 The Geelong College,46159.0,2015,NEWTOWN,34.0,18.7,95.0,100.0,1148.0,Independent,Combined,1217.0,-38.15241839,144.3400898
 The Geelong College,46159.0,2016,NEWTOWN,34.0,17.8,93.0,100.0,1146.0,Independent,Combined,1238.0,-38.15241839,144.3400898
@@ -5045,7 +5137,7 @@ The Geelong College,46159.0,2019,NEWTOWN,33.0,16.3,95.1,100.0,1134.0,Independent
 The Geelong College,46159.0,2020,NEWTOWN,32.0,13.0,89.6,100.0,1134.0,Independent,Combined,1320.0,-38.15241839,144.3400898
 The Geelong College,46159.0,2021,NEWTOWN,33.0,15.6,90.8,100.0,1141.0,Independent,Combined,1372.0,-38.15241839,144.3400898
 The Geelong College,46159.0,2022,NEWTOWN,32.0,12.7,92.7,100.0,1150.0,Independent,Combined,1468.0,-38.15241839,144.3400898
-The Geelong College,,2023,NEWTOWN,33.0,13.4,89.5,100.0,,,,,,
+The Geelong College,46159.0,2023,NEWTOWN,33.0,13.4,89.5,100.0,,,,,,
 The Grange P-12 College,45526.0,2014,HOPPERS CROSSING,25.0,1.6,89.0,99.0,952.0,Government,Combined,1698.0,-37.8581346,144.67493809
 The Grange P-12 College,45526.0,2015,HOPPERS CROSSING,23.0,1.4,82.0,94.0,957.0,Government,Combined,1651.0,-37.8581346,144.67493809
 The Grange P-12 College,45526.0,2016,HOPPERS CROSSING,22.0,0.7,79.0,99.0,961.0,Government,Combined,1584.0,-37.8581346,144.67493809
@@ -5055,7 +5147,7 @@ The Grange P-12 College,45526.0,2019,HOPPERS CROSSING,26.0,0.3,88.5,100.0,973.0,
 The Grange P-12 College,45526.0,2020,HOPPERS CROSSING,24.0,1.6,84.9,100.0,968.0,Government,Combined,1827.0,-37.8581346,144.67493809
 The Grange P-12 College,45526.0,2021,HOPPERS CROSSING,22.0,1.6,64.9,91.0,970.0,Government,Combined,1839.0,-37.8581346,144.67493809
 The Grange P-12 College,45526.0,2022,HOPPERS CROSSING,22.0,1.6,82.9,93.0,963.0,Government,Combined,1859.0,-37.8581346,144.67493809
-The Grange P-12 College,,2023,HOPPERS CROSSING,25.0,1.7,59.7,94.0,,,,,,
+The Grange P-12 College,45526.0,2023,HOPPERS CROSSING,25.0,1.7,59.7,94.0,,,,,,
 The Hamilton & Alexandra Coll,46167.0,2014,HAMILTON,32.0,9.1,96.0,100.0,1110.0,Independent,Combined,477.0,-37.737198,142.024214
 The Hamilton & Alexandra Coll,46167.0,2015,HAMILTON,32.0,8.7,95.0,100.0,1095.0,Independent,Combined,477.0,-37.737198,142.024214
 The Hamilton & Alexandra Coll,46167.0,2016,HAMILTON,32.0,7.7,88.0,100.0,1101.0,Independent,Combined,456.0,-37.737198,142.024214
@@ -5065,7 +5157,7 @@ The Hamilton & Alexandra Coll,46167.0,2019,HAMILTON,31.0,8.2,87.0,100.0,1097.0,I
 The Hamilton & Alexandra Coll,46167.0,2020,HAMILTON,30.0,4.7,87.5,100.0,1097.0,Independent,Combined,469.0,-37.737198,142.024214
 The Hamilton & Alexandra Coll,46167.0,2021,HAMILTON,31.0,3.7,85.5,100.0,1106.0,Independent,Combined,468.0,-37.737198,142.024214
 The Hamilton & Alexandra Coll,46167.0,2022,HAMILTON,31.0,4.8,81.3,100.0,1103.0,Independent,Combined,451.0,-37.737198,142.024214
-The Hamilton & Alexandra Coll,,2023,HAMILTON,30.0,4.8,81.6,100.0,,,,,,
+The Hamilton & Alexandra Coll,46167.0,2023,HAMILTON,30.0,4.8,81.6,100.0,,,,,,
 The King David School,46247.0,2014,ARMADALE,35.0,28.0,94.0,100.0,1182.0,Independent,Combined,548.0,-37.858226,145.010495
 The King David School,46247.0,2015,ARMADALE,35.0,24.0,96.0,100.0,1171.0,Independent,Combined,577.0,-37.858226,145.010495
 The King David School,46247.0,2016,ARMADALE,35.0,23.2,97.0,100.0,1172.0,Independent,Combined,593.0,-37.858226,145.010495
@@ -5075,7 +5167,7 @@ The King David School,46247.0,2019,ARMADALE,36.0,21.0,100.0,100.0,1166.0,Indepen
 The King David School,46247.0,2020,ARMADALE,36.0,26.0,96.1,98.0,1171.0,Independent,Combined,607.0,-37.858226,145.010495
 The King David School,46247.0,2021,ARMADALE,36.0,26.8,100.0,100.0,1168.0,Independent,Combined,625.0,-37.858226,145.010495
 The King David School,46247.0,2022,ARMADALE,36.0,24.1,95.1,100.0,1165.0,Independent,Combined,633.0,-37.858226,145.010495
-The King David School,,2023,ARMADALE,36.0,26.5,91.9,100.0,,,,,,
+The King David School,46247.0,2023,ARMADALE,36.0,26.5,91.9,100.0,,,,,,
 The Knox School,46274.0,2014,WANTIRNA SOUTH,31.0,9.4,95.0,100.0,1126.0,Independent,Combined,735.0,-37.865467,145.219198
 The Knox School,46274.0,2015,WANTIRNA SOUTH,31.0,6.4,95.0,98.0,1134.0,Independent,Combined,680.0,-37.865467,145.219198
 The Knox School,46274.0,2016,WANTIRNA SOUTH,32.0,12.2,95.0,100.0,1124.0,Independent,Combined,602.0,-37.865467,145.219198
@@ -5085,13 +5177,13 @@ The Knox School,46274.0,2019,WANTIRNA SOUTH,32.0,7.1,90.9,100.0,1133.0,Independe
 The Knox School,46274.0,2020,WANTIRNA SOUTH,33.0,9.9,98.1,100.0,1143.0,Independent,Combined,608.0,-37.865467,145.219198
 The Knox School,46274.0,2021,WANTIRNA SOUTH,33.0,16.1,92.5,98.0,1146.0,Independent,Combined,615.0,-37.865467,145.219198
 The Knox School,46274.0,2022,WANTIRNA SOUTH,32.0,7.1,92.3,100.0,1156.0,Independent,Combined,647.0,-37.865467,145.219198
-The Knox School,,2023,WANTIRNA SOUTH,33.0,11.7,94.1,100.0,,,,,,
+The Knox School,46274.0,2023,WANTIRNA SOUTH,33.0,11.7,94.1,100.0,,,,,,
 The Lakes South Morang College,45578.0,2021,SOUTH MORANG,,,,,1001.0,Government,Combined,762.0,-37.634598,145.076703
 The Lakes South Morang College,45578.0,2022,SOUTH MORANG,23.0,0.0,75.9,86.0,993.0,Government,Combined,703.0,-37.634598,145.076703
-The Lakes South Morang College,,2023,SOUTH MORANG,24.0,1.9,41.4,76.0,,,,,,
-The Peninsula School,,2014,MOUNT ELIZA,34.0,19.7,90.0,99.0,,,,,,
-The Peninsula School,,2015,MOUNT ELIZA,33.0,13.9,96.0,100.0,,,,,,
-The Peninsula School,52235.0,2016,MOUNT ELIZA,33.0,18.1,97.0,100.0,,Government,Secondary,,-37.023335,147.245983
+The Lakes South Morang College,45578.0,2023,SOUTH MORANG,24.0,1.9,41.4,76.0,,,,,,
+The Peninsula School,46219.0,2014,MOUNT ELIZA,34.0,19.7,90.0,99.0,1121.0,Independent,Combined,1363.0,-38.198174,145.090692
+The Peninsula School,46219.0,2015,MOUNT ELIZA,33.0,13.9,96.0,100.0,1130.0,Independent,Combined,1328.0,-38.198174,145.090692
+The Peninsula School,46219.0,2016,MOUNT ELIZA,33.0,18.1,97.0,100.0,1125.0,Independent,Combined,1313.0,-38.198174,145.090692
 Thomas Carr College,46102.0,2014,TARNEIT,27.0,1.1,89.0,99.0,1022.0,Catholic,Secondary,1165.0,-37.847676,144.702055
 Thomas Carr College,46102.0,2015,TARNEIT,27.0,2.1,88.0,99.0,1019.0,Catholic,Secondary,1132.0,-37.847676,144.702055
 Thomas Carr College,46102.0,2016,TARNEIT,26.0,1.0,85.0,100.0,1020.0,Catholic,Secondary,1128.0,-37.847676,144.702055
@@ -5101,7 +5193,7 @@ Thomas Carr College,46102.0,2019,TARNEIT,27.0,1.7,90.7,99.0,1033.0,Catholic,Seco
 Thomas Carr College,46102.0,2020,TARNEIT,26.0,2.4,88.8,100.0,1037.0,Catholic,Secondary,1060.0,-37.847676,144.702055
 Thomas Carr College,46102.0,2021,TARNEIT,27.0,2.1,89.8,98.0,1040.0,Catholic,Secondary,1099.0,-37.847676,144.702055
 Thomas Carr College,46102.0,2022,TARNEIT,25.0,1.3,91.4,97.0,1049.0,Catholic,Secondary,1166.0,-37.847676,144.702055
-Thomas Carr College,,2023,TARNEIT,26.0,1.4,87.1,100.0,,,,,,
+Thomas Carr College,46102.0,2023,TARNEIT,26.0,1.4,87.1,100.0,,,,,,
 Thomastown Secondary College,45473.0,2014,THOMASTOWN,25.0,0.3,85.0,94.0,931.0,Government,Secondary,577.0,-37.679045,145.00275
 Thomastown Secondary College,45473.0,2015,THOMASTOWN,23.0,0.9,75.0,98.0,928.0,Government,Secondary,588.0,-37.679045,145.00275
 Thomastown Secondary College,45473.0,2016,THOMASTOWN,23.0,0.6,83.0,96.0,926.0,Government,Secondary,596.0,-37.679045,145.00275
@@ -5111,7 +5203,7 @@ Thomastown Secondary College,45473.0,2019,THOMASTOWN,27.0,0.7,81.4,94.0,930.0,Go
 Thomastown Secondary College,45473.0,2020,THOMASTOWN,24.0,0.7,75.3,90.0,929.0,Government,Secondary,600.0,-37.679045,145.00275
 Thomastown Secondary College,45473.0,2021,THOMASTOWN,26.0,2.9,66.0,92.0,928.0,Government,Secondary,586.0,-37.679045,145.00275
 Thomastown Secondary College,45473.0,2022,THOMASTOWN,24.0,4.4,68.8,88.0,918.0,Government,Secondary,532.0,-37.679045,145.00275
-Thomastown Secondary College,,2023,THOMASTOWN,25.0,1.0,68.3,91.0,,,,,,
+Thomastown Secondary College,45473.0,2023,THOMASTOWN,25.0,1.0,68.3,91.0,,,,,,
 Thornbury High School,45533.0,2014,THORNBURY,28.0,4.5,98.0,97.0,999.0,Government,Secondary,1192.0,-37.75649469,145.02521353
 Thornbury High School,45533.0,2015,THORNBURY,28.0,2.9,95.0,100.0,1003.0,Government,Secondary,1175.0,-37.75649469,145.02521353
 Thornbury High School,45533.0,2016,THORNBURY,29.0,4.7,87.0,98.0,1006.0,Government,Secondary,1187.0,-37.75649469,145.02521353
@@ -5121,7 +5213,7 @@ Thornbury High School,45533.0,2019,THORNBURY,31.0,6.2,93.1,98.0,1033.0,Governmen
 Thornbury High School,45533.0,2020,THORNBURY,30.0,3.6,93.3,98.0,1041.0,Government,Secondary,1077.0,-37.75649469,145.02521353
 Thornbury High School,45533.0,2021,THORNBURY,29.0,6.3,88.7,97.0,1047.0,Government,Secondary,1074.0,-37.75649469,145.02521353
 Thornbury High School,45533.0,2022,THORNBURY,31.0,8.4,87.6,100.0,1052.0,Government,Secondary,1053.0,-37.75649469,145.02521353
-Thornbury High School,,2023,THORNBURY,31.0,8.1,73.9,96.0,,,,,,
+Thornbury High School,45533.0,2023,THORNBURY,31.0,8.1,73.9,96.0,,,,,,
 Timboon P-12 School,45321.0,2014,TIMBOON,26.0,1.0,77.0,91.0,1003.0,Government,Combined,485.0,-38.48365065,142.97548307
 Timboon P-12 School,45321.0,2015,TIMBOON,25.0,0.0,68.0,96.0,999.0,Government,Combined,482.0,-38.48365065,142.97548307
 Timboon P-12 School,45321.0,2016,TIMBOON,27.0,1.3,93.0,100.0,997.0,Government,Combined,453.0,-38.48365065,142.97548307
@@ -5131,7 +5223,7 @@ Timboon P-12 School,45321.0,2019,TIMBOON,27.0,1.0,65.0,100.0,1005.0,Government,C
 Timboon P-12 School,45321.0,2020,TIMBOON,28.0,1.0,80.0,100.0,1007.0,Government,Combined,465.0,-38.48365065,142.97548307
 Timboon P-12 School,45321.0,2021,TIMBOON,28.0,3.8,76.9,100.0,1006.0,Government,Combined,460.0,-38.48365065,142.97548307
 Timboon P-12 School,45321.0,2022,TIMBOON,26.0,1.4,56.7,100.0,1008.0,Government,Combined,488.0,-38.48365065,142.97548307
-Timboon P-12 School,,2023,TIMBOON,28.0,1.1,53.8,100.0,,,,,,
+Timboon P-12 School,45321.0,2023,TIMBOON,28.0,1.1,53.8,100.0,,,,,,
 Tintern Grammar,46175.0,2016,RINGWOOD EAST,32.0,11.1,93.0,100.0,1149.0,Independent,Combined,787.0,-37.8160964,145.25646488
 Tintern Grammar,46175.0,2017,RINGWOOD EAST,31.0,8.5,94.0,100.0,1138.0,Independent,Combined,804.0,-37.8160964,145.25646488
 Tintern Grammar,46175.0,2018,RINGWOOD EAST,32.0,9.8,89.0,100.0,1143.0,Independent,Combined,804.0,-37.8160964,145.25646488
@@ -5139,9 +5231,9 @@ Tintern Grammar,46175.0,2019,RINGWOOD EAST,31.0,8.3,85.6,99.0,1150.0,Independent
 Tintern Grammar,46175.0,2020,RINGWOOD EAST,31.0,7.3,98.7,100.0,1150.0,Independent,Combined,781.0,-37.8160964,145.25646488
 Tintern Grammar,46175.0,2021,RINGWOOD EAST,30.0,7.2,92.2,100.0,1154.0,Independent,Combined,789.0,-37.8160964,145.25646488
 Tintern Grammar,46175.0,2022,RINGWOOD EAST,32.0,9.9,97.2,100.0,1157.0,Independent,Combined,797.0,-37.8160964,145.25646488
-Tintern Grammar,,2023,RINGWOOD EAST,33.0,16.2,91.7,100.0,,,,,,
-Tintern Schools,44909.0,2014,RINGWOOD EAST,32.0,9.7,93.0,100.0,,Government,Special,387.0,-37.969247,145.208041
-Tintern Schools,44909.0,2015,RINGWOOD EAST,33.0,12.2,95.0,100.0,,Government,Special,408.0,-37.969247,145.208041
+Tintern Grammar,46175.0,2023,RINGWOOD EAST,33.0,16.2,91.7,100.0,,,,,,
+Tintern Schools,46175.0,2014,RINGWOOD EAST,32.0,9.7,93.0,100.0,1142.0,Independent,Combined,803.0,-37.8160964,145.25646488
+Tintern Schools,46175.0,2015,RINGWOOD EAST,33.0,12.2,95.0,100.0,1139.0,Independent,Combined,787.0,-37.8160964,145.25646488
 Toorak College,46177.0,2014,MOUNT ELIZA,34.0,24.1,99.0,100.0,1131.0,Independent,Combined,636.0,-38.17324124,145.09322974
 Toorak College,46177.0,2015,MOUNT ELIZA,34.0,23.0,97.0,100.0,1140.0,Independent,Combined,670.0,-38.17324124,145.09322974
 Toorak College,46177.0,2016,MOUNT ELIZA,34.0,18.8,97.0,100.0,1136.0,Independent,Combined,693.0,-38.17324124,145.09322974
@@ -5151,7 +5243,7 @@ Toorak College,46177.0,2019,MOUNT ELIZA,34.0,21.8,93.7,100.0,1145.0,Independent,
 Toorak College,46177.0,2020,MOUNT ELIZA,35.0,20.3,93.3,100.0,1145.0,Independent,Combined,765.0,-38.17324124,145.09322974
 Toorak College,46177.0,2021,MOUNT ELIZA,34.0,14.3,96.0,100.0,1146.0,Independent,Combined,767.0,-38.17324124,145.09322974
 Toorak College,46177.0,2022,MOUNT ELIZA,35.0,18.7,94.7,100.0,1144.0,Independent,Combined,791.0,-38.17324124,145.09322974
-Toorak College,,2023,MOUNT ELIZA,34.0,15.6,94.3,100.0,,,,,,
+Toorak College,46177.0,2023,MOUNT ELIZA,34.0,15.6,94.3,100.0,,,,,,
 Trafalgar High School,45474.0,2014,TRAFALGAR,28.0,3.0,75.0,99.0,986.0,Government,Secondary,526.0,-38.214568,146.158302
 Trafalgar High School,45474.0,2015,TRAFALGAR,27.0,4.0,75.0,97.0,986.0,Government,Secondary,561.0,-38.214568,146.158302
 Trafalgar High School,45474.0,2016,TRAFALGAR,27.0,2.8,70.0,100.0,988.0,Government,Secondary,598.0,-38.214568,146.158302
@@ -5161,7 +5253,8 @@ Trafalgar High School,45474.0,2019,TRAFALGAR,26.0,1.4,76.5,100.0,997.0,Governmen
 Trafalgar High School,45474.0,2020,TRAFALGAR,26.0,0.9,75.0,99.0,997.0,Government,Secondary,757.0,-38.214568,146.158302
 Trafalgar High School,45474.0,2021,TRAFALGAR,28.0,2.3,63.9,95.0,995.0,Government,Secondary,731.0,-38.214568,146.158302
 Trafalgar High School,45474.0,2022,TRAFALGAR,28.0,3.1,63.1,97.0,994.0,Government,Secondary,711.0,-38.214568,146.158302
-Trafalgar High School,,2023,TRAFALGAR,27.0,7.0,58.0,100.0,,,,,,
+Trafalgar High School,45474.0,2023,TRAFALGAR,27.0,7.0,58.0,100.0,,,,,,
+Training & Edu. Programs Aust.,,2015,HAWTHORN EAST,,,,,,,,,,
 Traralgon College,40588.0,2014,TRARALGON,25.0,1.7,60.0,84.0,943.0,Government,Secondary,984.0,-38.19142459,146.51948948
 Traralgon College,40588.0,2015,TRARALGON,26.0,1.3,79.0,91.0,948.0,Government,Secondary,955.0,-38.19142459,146.51948948
 Traralgon College,40588.0,2016,TRARALGON,26.0,0.0,75.0,94.0,947.0,Government,Secondary,917.0,-38.19142459,146.51948948
@@ -5171,7 +5264,7 @@ Traralgon College,40588.0,2019,TRARALGON,26.0,1.7,51.7,98.0,953.0,Government,Sec
 Traralgon College,40588.0,2020,TRARALGON,26.0,1.7,55.7,97.0,958.0,Government,Secondary,1036.0,-38.19142459,146.51948948
 Traralgon College,40588.0,2021,TRARALGON,27.0,1.8,44.4,95.0,955.0,Government,Secondary,1037.0,-38.19142459,146.51948948
 Traralgon College,40588.0,2022,TRARALGON,27.0,3.0,55.8,98.0,941.0,Government,Secondary,1017.0,-38.19142459,146.51948948
-Traralgon College,,2023,TRARALGON,25.0,0.5,34.5,95.0,,,,,,
+Traralgon College,40588.0,2023,TRARALGON,25.0,0.5,34.5,95.0,,,,,,
 Trinity College Colac,45710.0,2014,COLAC,29.0,4.0,80.0,96.0,988.0,Catholic,Secondary,764.0,-38.35120596,143.57874347
 Trinity College Colac,45710.0,2015,COLAC,29.0,2.9,76.0,99.0,1013.0,Catholic,Secondary,747.0,-38.35120596,143.57874347
 Trinity College Colac,45710.0,2016,COLAC,28.0,6.4,76.0,100.0,1013.0,Catholic,Secondary,733.0,-38.35120596,143.57874347
@@ -5181,7 +5274,7 @@ Trinity College Colac,45710.0,2019,COLAC,28.0,3.4,70.5,99.0,1015.0,Catholic,Seco
 Trinity College Colac,45710.0,2020,COLAC,28.0,4.7,62.8,99.0,1017.0,Catholic,Secondary,730.0,-38.35120596,143.57874347
 Trinity College Colac,45710.0,2021,COLAC,29.0,1.8,65.4,100.0,1016.0,Catholic,Secondary,763.0,-38.35120596,143.57874347
 Trinity College Colac,45710.0,2022,COLAC,28.0,4.0,60.6,93.0,1018.0,Catholic,Secondary,762.0,-38.35120596,143.57874347
-Trinity College Colac,,2023,COLAC,28.0,3.9,48.9,97.0,,,,,,
+Trinity College Colac,45710.0,2023,COLAC,28.0,3.9,48.9,97.0,,,,,,
 Trinity Grammar School,46156.0,2014,KEW,36.0,26.0,99.0,100.0,1183.0,Independent,Combined,1315.0,-37.81020316,145.0355016
 Trinity Grammar School,46156.0,2015,KEW,35.0,25.0,100.0,100.0,1189.0,Independent,Combined,1357.0,-37.81020316,145.0355016
 Trinity Grammar School,46156.0,2016,KEW,36.0,29.8,99.0,100.0,1185.0,Independent,Combined,1367.0,-37.81020316,145.0355016
@@ -5191,8 +5284,8 @@ Trinity Grammar School,46156.0,2019,KEW,36.0,26.1,98.2,99.0,1182.0,Independent,C
 Trinity Grammar School,46156.0,2020,KEW,35.0,24.3,98.9,100.0,1182.0,Independent,Combined,1478.0,-37.81020316,145.0355016
 Trinity Grammar School,46156.0,2021,KEW,34.0,21.7,98.2,99.0,1176.0,Independent,Combined,1483.0,-37.81020316,145.0355016
 Trinity Grammar School,46156.0,2022,KEW,35.0,22.2,98.9,100.0,1176.0,Independent,Combined,1497.0,-37.81020316,145.0355016
-Trinity Grammar School,,2023,KEW,35.0,25.7,97.1,99.0,,,,,,
-Trinity Lutheran College,,2023,MILDURA,,,,,,,,,,
+Trinity Grammar School,46156.0,2023,KEW,35.0,25.7,97.1,99.0,,,,,,
+Trinity Lutheran College,46272.0,2023,MILDURA,,,,,,,,,,
 Tyrrell College,45203.0,2014,SEA LAKE,26.0,1.4,100.0,100.0,958.0,Government,Combined,179.0,-35.509276,142.853519
 Tyrrell College,45203.0,2015,SEA LAKE,27.0,5.5,100.0,100.0,958.0,Government,Combined,170.0,-35.509276,142.853519
 Tyrrell College,45203.0,2016,SEA LAKE,29.0,8.7,100.0,100.0,973.0,Government,Combined,166.0,-35.509276,142.853519
@@ -5202,7 +5295,7 @@ Tyrrell College,45203.0,2019,SEA LAKE,31.0,1.7,100.0,100.0,984.0,Government,Comb
 Tyrrell College,45203.0,2020,SEA LAKE,34.0,12.2,100.0,100.0,979.0,Government,Combined,162.0,-35.509276,142.853519
 Tyrrell College,45203.0,2021,SEA LAKE,30.0,3.1,100.0,100.0,990.0,Government,Combined,159.0,-35.509276,142.853519
 Tyrrell College,45203.0,2022,SEA LAKE,28.0,4.7,100.0,100.0,981.0,Government,Combined,143.0,-35.509276,142.853519
-Tyrrell College,,2023,SEA LAKE,25.0,,100.0,100.0,,,,,,
+Tyrrell College,45203.0,2023,SEA LAKE,25.0,,100.0,100.0,,,,,,
 University High School,45475.0,2014,PARKVILLE,33.0,16.7,90.0,98.0,1130.0,Government,Secondary,1303.0,-37.797009,144.955664
 University High School,45475.0,2015,PARKVILLE,32.0,11.1,91.0,99.0,1139.0,Government,Secondary,1378.0,-37.797009,144.955664
 University High School,45475.0,2016,PARKVILLE,32.0,10.1,94.0,96.0,1129.0,Government,Secondary,1425.0,-37.797009,144.955664
@@ -5212,8 +5305,8 @@ University High School,45475.0,2019,PARKVILLE,32.0,14.3,93.7,99.0,1132.0,Governm
 University High School,45475.0,2020,PARKVILLE,32.0,13.3,91.4,97.0,1129.0,Government,Secondary,1636.0,-37.797009,144.955664
 University High School,45475.0,2021,PARKVILLE,31.0,13.3,84.5,98.0,1127.0,Government,Secondary,1678.0,-37.797009,144.955664
 University High School,45475.0,2022,PARKVILLE,32.0,12.8,86.0,95.0,1124.0,Government,Secondary,1759.0,-37.797009,144.955664
-University High School,,2023,PARKVILLE,31.0,13.6,91.0,97.0,,,,,,
-Upper Yarra Community House,45477.0,2014,YARRA JUNCTION,,,,,936.0,Government,Secondary,497.0,-37.79209352,145.62393303
+University High School,45475.0,2023,PARKVILLE,31.0,13.6,91.0,97.0,,,,,,
+Upper Yarra Community House,,2014,YARRA JUNCTION,,,,,,,,,,
 Upper Yarra Secondary College,45477.0,2014,YARRA JUNCTION,24.0,1.1,97.0,97.0,936.0,Government,Secondary,497.0,-37.79209352,145.62393303
 Upper Yarra Secondary College,45477.0,2015,YARRA JUNCTION,28.0,1.9,94.0,97.0,944.0,Government,Secondary,510.0,-37.79209352,145.62393303
 Upper Yarra Secondary College,45477.0,2016,YARRA JUNCTION,27.0,0.5,89.0,100.0,942.0,Government,Secondary,506.0,-37.79209352,145.62393303
@@ -5223,7 +5316,7 @@ Upper Yarra Secondary College,45477.0,2019,YARRA JUNCTION,26.0,1.9,77.1,100.0,95
 Upper Yarra Secondary College,45477.0,2020,YARRA JUNCTION,27.0,1.5,76.2,95.0,961.0,Government,Secondary,554.0,-37.79209352,145.62393303
 Upper Yarra Secondary College,45477.0,2021,YARRA JUNCTION,25.0,0.0,48.8,90.0,963.0,Government,Secondary,618.0,-37.79209352,145.62393303
 Upper Yarra Secondary College,45477.0,2022,YARRA JUNCTION,26.0,0.5,90.5,95.0,965.0,Government,Secondary,638.0,-37.79209352,145.62393303
-Upper Yarra Secondary College,,2023,YARRA JUNCTION,25.0,3.1,59.7,85.0,,,,,,
+Upper Yarra Secondary College,45477.0,2023,YARRA JUNCTION,25.0,3.1,59.7,85.0,,,,,,
 Upwey High School,45478.0,2014,UPWEY,28.0,2.7,89.0,95.0,1023.0,Government,Secondary,756.0,-37.90323624,145.33428967
 Upwey High School,45478.0,2015,UPWEY,29.0,2.4,78.0,98.0,1023.0,Government,Secondary,701.0,-37.90323624,145.33428967
 Upwey High School,45478.0,2016,UPWEY,27.0,2.7,64.0,99.0,1018.0,Government,Secondary,685.0,-37.90323624,145.33428967
@@ -5233,7 +5326,7 @@ Upwey High School,45478.0,2019,UPWEY,26.0,2.9,76.5,93.0,1028.0,Government,Second
 Upwey High School,45478.0,2020,UPWEY,26.0,3.1,77.9,90.0,1032.0,Government,Secondary,822.0,-37.90323624,145.33428967
 Upwey High School,45478.0,2021,UPWEY,27.0,1.3,70.4,94.0,1033.0,Government,Secondary,839.0,-37.90323624,145.33428967
 Upwey High School,45478.0,2022,UPWEY,26.0,0.9,59.0,95.0,1039.0,Government,Secondary,840.0,-37.90323624,145.33428967
-Upwey High School,,2023,UPWEY,27.0,1.5,56.4,96.0,,,,,,
+Upwey High School,45478.0,2023,UPWEY,27.0,1.5,56.4,96.0,,,,,,
 Vermont Secondary College,45479.0,2014,VERMONT,31.0,8.7,94.0,99.0,1052.0,Government,Secondary,1316.0,-37.842864,145.199846
 Vermont Secondary College,45479.0,2015,VERMONT,31.0,7.9,94.0,99.0,1050.0,Government,Secondary,1346.0,-37.842864,145.199846
 Vermont Secondary College,45479.0,2016,VERMONT,30.0,6.1,97.0,100.0,1054.0,Government,Secondary,1409.0,-37.842864,145.199846
@@ -5243,24 +5336,26 @@ Vermont Secondary College,45479.0,2019,VERMONT,32.0,10.3,91.8,100.0,1091.0,Gover
 Vermont Secondary College,45479.0,2020,VERMONT,31.0,8.5,86.6,99.0,1097.0,Government,Secondary,1521.0,-37.842864,145.199846
 Vermont Secondary College,45479.0,2021,VERMONT,31.0,9.8,77.9,100.0,1103.0,Government,Secondary,1534.0,-37.842864,145.199846
 Vermont Secondary College,45479.0,2022,VERMONT,31.0,7.1,84.7,100.0,1105.0,Government,Secondary,1519.0,-37.842864,145.199846
-Vermont Secondary College,,2023,VERMONT,32.0,9.9,86.2,100.0,,,,,,
-Victoria University - TAFE,45621.0,2016,FOOTSCRAY,20.0,1.7,44.0,79.0,943.0,Government,Secondary,907.0,-37.7405,144.786
-Victoria University - TAFE,45621.0,2017,FOOTSCRAY,19.0,0.8,46.0,74.0,949.0,Government,Secondary,907.0,-37.7405,144.786
-Victoria University - TAFE,45621.0,2018,FOOTSCRAY,21.0,0.0,54.3,86.0,954.0,Government,Secondary,927.0,-37.7405,144.786
-Victoria University Polytechnic,45621.0,2019,FOOTSCRAY,21.0,0.0,27.5,75.0,962.0,Government,Secondary,958.0,-37.758674,144.76619
-Victoria University Polytechnic,45621.0,2020,FOOTSCRAY,20.0,2.4,59.4,94.0,962.0,Government,Secondary,995.0,-37.758674,144.76619
-Victoria University Polytechnic,45621.0,2021,FOOTSCRAY,20.0,0.0,53.8,96.0,963.0,Government,Secondary,975.0,-37.758674,144.76619
-Victoria University Polytechnic,45621.0,2022,FOOTSCRAY,22.0,0.0,64.3,100.0,961.0,Government,Secondary,1030.0,-37.758674,144.76619
+Vermont Secondary College,45479.0,2023,VERMONT,32.0,9.9,86.2,100.0,,,,,,
+Victoria Uni of Tech - TAFE,,2014,FOOTSCRAY,18.0,0.0,32.0,82.0,,,,,,
+Victoria Uni of Tech - TAFE,,2015,FOOTSCRAY,20.0,1.1,43.0,80.0,,,,,,
+Victoria University - TAFE,,2016,FOOTSCRAY,20.0,1.7,44.0,79.0,,,,,,
+Victoria University - TAFE,,2017,FOOTSCRAY,19.0,0.8,46.0,74.0,,,,,,
+Victoria University - TAFE,,2018,FOOTSCRAY,21.0,0.0,54.3,86.0,,,,,,
+Victoria University Polytechnic,,2019,FOOTSCRAY,21.0,0.0,27.5,75.0,,,,,,
+Victoria University Polytechnic,,2020,FOOTSCRAY,20.0,2.4,59.4,94.0,,,,,,
+Victoria University Polytechnic,,2021,FOOTSCRAY,20.0,0.0,53.8,96.0,,,,,,
+Victoria University Polytechnic,,2022,FOOTSCRAY,22.0,0.0,64.3,100.0,,,,,,
 Victoria University Polytechnic,,2023,FOOTSCRAY,,,6.7,67.0,,,,,,
-Victoria University SC,45621.0,2014,ST ALBANS,25.0,0.4,96.0,95.0,934.0,Government,Secondary,1014.0,-37.7405,144.786
-Victoria University SC,45621.0,2015,ST ALBANS,27.0,1.9,91.0,95.0,937.0,Government,Secondary,953.0,-37.7405,144.786
-Victoria University SC,45621.0,2016,ST ALBANS,27.0,0.8,84.0,93.0,943.0,Government,Secondary,907.0,-37.7405,144.786
-Victoria University SC,45621.0,2017,ST ALBANS,27.0,2.6,85.0,91.0,949.0,Government,Secondary,907.0,-37.7405,144.786
-Victoria University SC,45621.0,2018,ST ALBANS,26.0,2.5,89.3,97.0,954.0,Government,Secondary,927.0,-37.7405,144.786
-Victoria University SC,45621.0,2019,ST ALBANS,28.0,2.7,93.5,97.0,962.0,Government,Secondary,958.0,-37.758674,144.76619
-Victoria University SC,45621.0,2020,ST ALBANS,28.0,5.0,91.7,96.0,962.0,Government,Secondary,995.0,-37.758674,144.76619
-Victoria University SC,45621.0,2021,ST ALBANS,28.0,4.9,94.0,98.0,963.0,Government,Secondary,975.0,-37.758674,144.76619
-Victoria University SC,45621.0,2022,CAIRNLEA,28.0,5.7,86.0,99.0,961.0,Government,Secondary,1030.0,-37.758674,144.76619
+Victoria University SC,,2014,ST ALBANS,25.0,0.4,96.0,95.0,,,,,,
+Victoria University SC,,2015,ST ALBANS,27.0,1.9,91.0,95.0,,,,,,
+Victoria University SC,,2016,ST ALBANS,27.0,0.8,84.0,93.0,,,,,,
+Victoria University SC,,2017,ST ALBANS,27.0,2.6,85.0,91.0,,,,,,
+Victoria University SC,,2018,ST ALBANS,26.0,2.5,89.3,97.0,,,,,,
+Victoria University SC,,2019,ST ALBANS,28.0,2.7,93.5,97.0,,,,,,
+Victoria University SC,,2020,ST ALBANS,28.0,5.0,91.7,96.0,,,,,,
+Victoria University SC,,2021,ST ALBANS,28.0,4.9,94.0,98.0,,,,,,
+Victoria University SC,,2022,CAIRNLEA,28.0,5.7,86.0,99.0,,,,,,
 Victoria University SC,,2023,CAIRNLEA,29.0,5.9,75.9,98.0,,,,,,
 Victorian College for the Deaf,44652.0,2014,MELBOURNE,36.0,20.0,,,,Government,Special,70.0,-37.849774,144.982306
 Victorian College for the Deaf,44652.0,2015,MELBOURNE,19.0,0.0,100.0,100.0,,Government,Special,72.0,-37.849774,144.982306
@@ -5271,17 +5366,17 @@ Victorian College for the Deaf,44652.0,2019,MELBOURNE,42.0,60.0,,,962.0,Governme
 Victorian College for the Deaf,44652.0,2020,MELBOURNE,,,,,964.0,Government,Special,56.0,-37.849774,144.982306
 Victorian College for the Deaf,44652.0,2021,MELBOURNE,35.0,25.0,,,968.0,Government,Special,58.0,-37.849774,144.982306
 Victorian College for the Deaf,44652.0,2022,MELBOURNE,,,,,930.0,Government,Special,58.0,-37.849774,144.982306
-Victorian College for the Deaf,,2023,MELBOURNE,24.0,,,,,,,,,
-Victorian College of the Arts,44652.0,2014,SOUTHBANK,34.0,20.8,69.0,99.0,,Government,Special,70.0,-37.849774,144.982306
-Victorian College of the Arts,44652.0,2015,SOUTHBANK,34.0,15.4,71.0,99.0,,Government,Special,72.0,-37.849774,144.982306
-Victorian College of the Arts,44652.0,2016,SOUTHBANK,34.0,22.7,71.0,98.0,,Government,Special,78.0,-37.849774,144.982306
-Victorian College of the Arts,44652.0,2017,SOUTHBANK,35.0,23.3,69.0,94.0,,Government,Special,74.0,-37.849774,144.982306
-Victorian College of the Arts,44652.0,2018,SOUTHBANK,33.0,16.1,68.6,96.0,1008.0,Government,Special,61.0,-37.849774,144.982306
-Victorian College of the Arts,44652.0,2019,SOUTHBANK,33.0,16.6,57.4,99.0,962.0,Government,Special,56.0,-37.849774,144.982306
-Victorian College of the Arts,44652.0,2020,SOUTHBANK,33.0,19.8,69.4,98.0,964.0,Government,Special,56.0,-37.849774,144.982306
-Victorian College of the Arts,44652.0,2021,SOUTHBANK,33.0,15.4,68.4,100.0,968.0,Government,Special,58.0,-37.849774,144.982306
-Victorian College of the Arts,44652.0,2022,SOUTHBANK,32.0,13.2,64.5,97.0,930.0,Government,Special,58.0,-37.849774,144.982306
-Victorian College of the Arts,,2023,SOUTHBANK,31.0,13.2,60.5,100.0,,,,,,
+Victorian College for the Deaf,44652.0,2023,MELBOURNE,24.0,,,,,,,,,
+Victorian College of the Arts,45344.0,2014,SOUTHBANK,34.0,20.8,69.0,99.0,1145.0,Government,Secondary,345.0,-37.828229,144.964767
+Victorian College of the Arts,45344.0,2015,SOUTHBANK,34.0,15.4,71.0,99.0,1145.0,Government,Secondary,355.0,-37.828229,144.964767
+Victorian College of the Arts,45344.0,2016,SOUTHBANK,34.0,22.7,71.0,98.0,1132.0,Government,Secondary,379.0,-37.828229,144.964767
+Victorian College of the Arts,45344.0,2017,SOUTHBANK,35.0,23.3,69.0,94.0,1133.0,Government,Secondary,397.0,-37.828229,144.964767
+Victorian College of the Arts,45344.0,2018,SOUTHBANK,33.0,16.1,68.6,96.0,1143.0,Government,Secondary,406.0,-37.828229,144.964767
+Victorian College of the Arts,45344.0,2019,SOUTHBANK,33.0,16.6,57.4,99.0,1139.0,Government,Secondary,403.0,-37.828229,144.964767
+Victorian College of the Arts,45344.0,2020,SOUTHBANK,33.0,19.8,69.4,98.0,1134.0,Government,Secondary,402.0,-37.828229,144.964767
+Victorian College of the Arts,45344.0,2021,SOUTHBANK,33.0,15.4,68.4,100.0,1138.0,Government,Secondary,382.0,-37.828229,144.964767
+Victorian College of the Arts,45344.0,2022,SOUTHBANK,32.0,13.2,64.5,97.0,1137.0,Government,Secondary,353.0,-37.828229,144.964767
+Victorian College of the Arts,45344.0,2023,SOUTHBANK,31.0,13.2,60.5,100.0,,,,,,
 Victory Christian College,46327.0,2014,STRATHDALE,27.0,0.0,33.0,100.0,1038.0,Independent,Combined,360.0,-36.782625,144.313456
 Victory Christian College,46327.0,2015,STRATHDALE,29.0,5.5,56.0,100.0,1043.0,Independent,Combined,390.0,-36.782625,144.313456
 Victory Christian College,46327.0,2016,STRATHDALE,28.0,5.0,63.0,100.0,1042.0,Independent,Combined,395.0,-36.782625,144.313456
@@ -5291,7 +5386,7 @@ Victory Christian College,46327.0,2019,STRATHDALE,28.0,6.6,45.0,100.0,1056.0,Ind
 Victory Christian College,46327.0,2020,STRATHDALE,27.0,1.8,67.5,98.0,1056.0,Independent,Combined,588.0,-36.782625,144.313456
 Victory Christian College,46327.0,2021,STRATHDALE,28.0,4.9,69.0,100.0,1067.0,Independent,Combined,645.0,-36.782625,144.313456
 Victory Christian College,46327.0,2022,STRATHDALE,29.0,2.0,56.0,96.0,1073.0,Independent,Combined,705.0,-36.782625,144.313456
-Victory Christian College,,2023,STRATHDALE,28.0,2.7,67.7,100.0,,,,,,
+Victory Christian College,46327.0,2023,STRATHDALE,28.0,2.7,67.7,100.0,,,,,,
 Victory Lutheran College,46323.0,2014,WEST WODONGA,29.0,4.7,71.0,96.0,1064.0,Independent,Combined,628.0,-36.116752,146.846422
 Victory Lutheran College,46323.0,2015,WEST WODONGA,29.0,1.4,69.0,100.0,1066.0,Independent,Combined,674.0,-36.116752,146.846422
 Victory Lutheran College,46323.0,2016,WEST WODONGA,29.0,0.7,82.0,100.0,1066.0,Independent,Combined,676.0,-36.116752,146.846422
@@ -5301,7 +5396,7 @@ Victory Lutheran College,46323.0,2019,WEST WODONGA,29.0,3.2,67.6,100.0,1067.0,In
 Victory Lutheran College,46323.0,2020,WEST WODONGA,29.0,6.1,54.7,98.0,1067.0,Independent,Combined,788.0,-36.116752,146.846422
 Victory Lutheran College,46323.0,2021,WEST WODONGA,30.0,11.3,68.4,97.0,1073.0,Independent,Combined,791.0,-36.116752,146.846422
 Victory Lutheran College,46323.0,2022,WEST WODONGA,29.0,5.9,71.1,97.0,1074.0,Independent,Combined,786.0,-36.116752,146.846422
-Victory Lutheran College,,2023,WEST WODONGA,28.0,4.0,59.1,100.0,,,,,,
+Victory Lutheran College,46323.0,2023,WEST WODONGA,28.0,4.0,59.1,100.0,,,,,,
 Viewbank College,45550.0,2014,ROSANNA,31.0,8.2,89.0,99.0,1087.0,Government,Secondary,1141.0,-37.741226,145.086953
 Viewbank College,45550.0,2015,ROSANNA,31.0,8.6,86.0,98.0,1090.0,Government,Secondary,1177.0,-37.741226,145.086953
 Viewbank College,45550.0,2016,ROSANNA,32.0,9.1,90.0,99.0,1090.0,Government,Secondary,1241.0,-37.741226,145.086953
@@ -5311,13 +5406,13 @@ Viewbank College,45550.0,2019,ROSANNA,32.0,8.6,77.7,97.0,1103.0,Government,Secon
 Viewbank College,45550.0,2020,VIEWBANK,30.0,5.3,91.6,97.0,1108.0,Government,Secondary,1432.0,-37.741226,145.086953
 Viewbank College,45550.0,2021,VIEWBANK,30.0,3.9,79.7,99.0,1108.0,Government,Secondary,1444.0,-37.741226,145.086953
 Viewbank College,45550.0,2022,VIEWBANK,29.0,6.9,78.2,99.0,1115.0,Government,Secondary,1470.0,-37.741226,145.086953
-Viewbank College,,2023,VIEWBANK,31.0,8.1,75.4,97.0,,,,,,
-Village High School,,2023,RYANSTON,,,,,,,,,,
+Viewbank College,45550.0,2023,VIEWBANK,31.0,8.1,75.4,97.0,,,,,,
+Village High School,52861.0,2023,RYANSTON,,,,,,,,,,
 Virtual School Victoria,45322.0,2019,THORNBURY,28.0,2.8,35.4,85.0,1061.0,Government,Combined,3649.0,-37.76204,145.025701
 Virtual School Victoria,45322.0,2020,THORNBURY,29.0,3.0,48.1,88.0,1059.0,Government,Combined,4033.0,-37.76204,145.025701
 Virtual School Victoria,45322.0,2021,THORNBURY,28.0,4.7,31.9,84.0,1062.0,Government,Combined,4667.0,-37.76204,145.025701
 Virtual School Victoria,45322.0,2022,THORNBURY,28.0,6.5,38.8,87.0,1058.0,Government,Combined,5003.0,-37.76204,145.025701
-Virtual School Victoria,,2023,THORNBURY,26.0,3.0,35.2,90.0,,,,,,
+Virtual School Victoria,45322.0,2023,THORNBURY,26.0,3.0,35.2,90.0,,,,,,
 Wallan Secondary College,45532.0,2014,WALLAN,23.0,0.7,68.0,89.0,960.0,Government,Secondary,541.0,-37.41944661,144.98036163
 Wallan Secondary College,45532.0,2015,WALLAN,24.0,1.1,65.0,94.0,964.0,Government,Secondary,581.0,-37.41944661,144.98036163
 Wallan Secondary College,45532.0,2016,WALLAN,26.0,3.0,62.0,93.0,968.0,Government,Secondary,604.0,-37.41944661,144.98036163
@@ -5327,13 +5422,13 @@ Wallan Secondary College,45532.0,2019,WALLAN,22.0,0.0,30.6,98.0,966.0,Government
 Wallan Secondary College,45532.0,2020,WALLAN,23.0,1.0,51.0,96.0,968.0,Government,Secondary,667.0,-37.41944661,144.98036163
 Wallan Secondary College,45532.0,2021,WALLAN,24.0,0.0,60.3,92.0,968.0,Government,Secondary,672.0,-37.41944661,144.98036163
 Wallan Secondary College,45532.0,2022,WALLAN,22.0,0.0,50.9,89.0,965.0,Government,Secondary,704.0,-37.41944661,144.98036163
-Wallan Secondary College,,2023,WALLAN,21.0,1.8,31.8,92.0,,,,,,
-Wanganui Park Sec College,45524.0,2014,SHEPPARTON,28.0,4.9,79.0,98.0,984.0,Government,Secondary,1603.0,-37.66390279,145.06286022
-Wanganui Park Sec College,45524.0,2015,SHEPPARTON,28.0,3.9,72.0,98.0,987.0,Government,Secondary,1558.0,-37.66390279,145.06286022
-Wanganui Park Sec College,45524.0,2016,SHEPPARTON,27.0,2.7,78.0,95.0,986.0,Government,Secondary,1574.0,-37.66390279,145.06286022
-Wanganui Park Sec College,45524.0,2017,SHEPPARTON,27.0,2.9,70.0,99.0,990.0,Government,Secondary,1512.0,-37.66390279,145.06286022
-Wanganui Park Sec College,45524.0,2018,SHEPPARTON,27.0,2.3,73.6,96.0,994.0,Government,Secondary,1461.0,-37.66390279,145.06286022
-Wanganui Park Sec College,45524.0,2019,SHEPPARTON,27.0,1.5,72.5,98.0,999.0,Government,Secondary,1441.0,-37.66390279,145.06286022
+Wallan Secondary College,45532.0,2023,WALLAN,21.0,1.8,31.8,92.0,,,,,,
+Wanganui Park Sec College,53105.0,2014,SHEPPARTON,28.0,4.9,79.0,98.0,,,,,,
+Wanganui Park Sec College,53105.0,2015,SHEPPARTON,28.0,3.9,72.0,98.0,,,,,,
+Wanganui Park Sec College,53105.0,2016,SHEPPARTON,27.0,2.7,78.0,95.0,,,,,,
+Wanganui Park Sec College,53105.0,2017,SHEPPARTON,27.0,2.9,70.0,99.0,,,,,,
+Wanganui Park Sec College,53105.0,2018,SHEPPARTON,27.0,2.3,73.6,96.0,,,,,,
+Wanganui Park Sec College,53105.0,2019,SHEPPARTON,27.0,1.5,72.5,98.0,,,,,,
 Wangaratta High School,45483.0,2014,WANGARATTA,27.0,4.3,75.0,98.0,990.0,Government,Secondary,955.0,-36.344898,146.307723
 Wangaratta High School,45483.0,2015,WANGARATTA,25.0,3.7,64.0,98.0,981.0,Government,Secondary,890.0,-36.344898,146.307723
 Wangaratta High School,45483.0,2016,WANGARATTA,27.0,4.5,58.0,98.0,980.0,Government,Secondary,817.0,-36.344898,146.307723
@@ -5343,7 +5438,7 @@ Wangaratta High School,45483.0,2019,WANGARATTA,27.0,3.2,58.3,96.0,965.0,Governme
 Wangaratta High School,45483.0,2020,WANGARATTA,26.0,3.9,39.7,92.0,959.0,Government,Secondary,638.0,-36.344898,146.307723
 Wangaratta High School,45483.0,2021,WANGARATTA,28.0,7.0,56.5,92.0,960.0,Government,Secondary,643.0,-36.344064,146.309332
 Wangaratta High School,45483.0,2022,WANGARATTA,25.0,3.2,50.0,94.0,958.0,Government,Secondary,616.0,-36.344064,146.309332
-Wangaratta High School,,2023,WANGARATTA,28.0,3.0,56.8,92.0,,,,,,
+Wangaratta High School,45483.0,2023,WANGARATTA,28.0,3.0,56.8,92.0,,,,,,
 Wantirna College,45484.0,2014,WANTIRNA,29.0,3.4,96.0,98.0,1009.0,Government,Secondary,1227.0,-37.857785,145.230563
 Wantirna College,45484.0,2015,WANTIRNA,30.0,4.2,90.0,97.0,1012.0,Government,Secondary,1243.0,-37.857785,145.230563
 Wantirna College,45484.0,2016,WANTIRNA,29.0,5.4,85.0,99.0,1005.0,Government,Secondary,1248.0,-37.857785,145.230563
@@ -5353,7 +5448,7 @@ Wantirna College,45484.0,2019,WANTIRNA,27.0,3.1,72.4,98.0,1022.0,Government,Seco
 Wantirna College,45484.0,2020,WANTIRNA,27.0,4.1,77.2,97.0,1022.0,Government,Secondary,1419.0,-37.857785,145.230563
 Wantirna College,45484.0,2021,WANTIRNA,28.0,3.2,58.6,93.0,1023.0,Government,Secondary,1473.0,-37.857785,145.230563
 Wantirna College,45484.0,2022,WANTIRNA,27.0,2.9,71.5,97.0,1021.0,Government,Secondary,1438.0,-37.857785,145.230563
-Wantirna College,,2023,WANTIRNA,29.0,3.8,57.9,98.0,,,,,,
+Wantirna College,45484.0,2023,WANTIRNA,29.0,3.8,57.9,98.0,,,,,,
 Warracknabeal Sec College,45485.0,2014,WARRACKNABEAL,28.0,1.5,64.0,100.0,964.0,Government,Secondary,231.0,-36.2621,142.391
 Warracknabeal Sec College,45485.0,2015,WARRACKNABEAL,29.0,9.0,69.0,94.0,958.0,Government,Secondary,209.0,-36.2621,142.391
 Warracknabeal Sec College,45485.0,2016,WARRACKNABEAL,28.0,4.1,90.0,100.0,954.0,Government,Secondary,207.0,-36.2621,142.391
@@ -5363,7 +5458,7 @@ Warracknabeal Sec College,45485.0,2019,WARRACKNABEAL,28.0,5.3,56.2,100.0,953.0,G
 Warracknabeal Sec College,45485.0,2020,WARRACKNABEAL,29.0,0.0,78.6,100.0,964.0,Government,Secondary,170.0,-36.2621,142.391
 Warracknabeal Sec College,45485.0,2021,WARRACKNABEAL,28.0,3.3,84.6,100.0,965.0,Government,Secondary,185.0,-36.2621,142.391
 Warracknabeal Sec College,45485.0,2022,WARRACKNABEAL,30.0,8.8,57.1,100.0,964.0,Government,Secondary,180.0,-36.2621,142.391
-Warracknabeal Sec College,,2023,WARRACKNABEAL,26.0,7.5,25.0,94.0,,,,,,
+Warracknabeal Sec College,45485.0,2023,WARRACKNABEAL,26.0,7.5,25.0,94.0,,,,,,
 Warragul Regional College,45563.0,2014,WARRAGUL,28.0,2.9,68.0,94.0,964.0,Government,Secondary,734.0,-38.16519591,145.92548523
 Warragul Regional College,45563.0,2015,WARRAGUL,29.0,7.5,58.0,91.0,967.0,Government,Secondary,747.0,-38.16519591,145.92548523
 Warragul Regional College,45563.0,2016,WARRAGUL,28.0,6.3,75.0,99.0,970.0,Government,Secondary,763.0,-38.16519591,145.92548523
@@ -5373,7 +5468,7 @@ Warragul Regional College,45563.0,2019,WARRAGUL,27.0,2.4,53.6,92.0,970.0,Governm
 Warragul Regional College,45563.0,2020,WARRAGUL,26.0,0.3,58.9,95.0,975.0,Government,Secondary,750.0,-38.16519591,145.92548523
 Warragul Regional College,45563.0,2021,WARRAGUL,25.0,0.0,58.1,95.0,978.0,Government,Secondary,728.0,-38.16519591,145.92548523
 Warragul Regional College,45563.0,2022,WARRAGUL,27.0,1.0,50.0,95.0,979.0,Government,Secondary,745.0,-38.16519591,145.92548523
-Warragul Regional College,,2023,WARRAGUL,25.0,2.3,41.5,96.0,,,,,,
+Warragul Regional College,45563.0,2023,WARRAGUL,25.0,2.3,41.5,96.0,,,,,,
 Warrandyte High School,45486.0,2014,WARRANDYTE,28.0,3.7,96.0,100.0,1041.0,Government,Secondary,512.0,-37.74707962,145.18458158
 Warrandyte High School,45486.0,2015,WARRANDYTE,27.0,2.7,89.0,96.0,1050.0,Government,Secondary,497.0,-37.74707962,145.18458158
 Warrandyte High School,45486.0,2016,WARRANDYTE,27.0,4.8,70.0,96.0,1045.0,Government,Secondary,466.0,-37.74707962,145.18458158
@@ -5383,7 +5478,7 @@ Warrandyte High School,45486.0,2019,WARRANDYTE,26.0,1.4,76.1,100.0,1040.0,Govern
 Warrandyte High School,45486.0,2020,WARRANDYTE,27.0,2.3,80.0,98.0,1040.0,Government,Secondary,383.0,-37.74707962,145.18458158
 Warrandyte High School,45486.0,2021,WARRANDYTE,25.0,2.2,74.1,95.0,1038.0,Government,Secondary,388.0,-37.74707962,145.18458158
 Warrandyte High School,45486.0,2022,WARRANDYTE,23.0,0.0,71.4,98.0,1038.0,Government,Secondary,334.0,-37.74707962,145.18458158
-Warrandyte High School,,2023,WARRANDYTE,24.0,0.5,50.0,100.0,,,,,,
+Warrandyte High School,45486.0,2023,WARRANDYTE,24.0,0.5,50.0,100.0,,,,,,
 Warrnambool College,45549.0,2014,WARRNAMBOOL,27.0,5.4,74.0,97.0,991.0,Government,Secondary,1118.0,-38.37671595,142.4996761
 Warrnambool College,45549.0,2015,WARRNAMBOOL,27.0,5.2,83.0,94.0,994.0,Government,Secondary,1164.0,-38.37671595,142.4996761
 Warrnambool College,45549.0,2016,WARRNAMBOOL,28.0,5.5,75.0,91.0,992.0,Government,Secondary,1247.0,-38.37671595,142.4996761
@@ -5393,7 +5488,7 @@ Warrnambool College,45549.0,2019,WARRNAMBOOL,27.0,2.0,69.4,93.0,983.0,Government
 Warrnambool College,45549.0,2020,WARRNAMBOOL,26.0,2.7,58.0,96.0,981.0,Government,Secondary,1234.0,-38.37671595,142.4996761
 Warrnambool College,45549.0,2021,WARRNAMBOOL,27.0,1.4,58.7,96.0,977.0,Government,Secondary,1239.0,-38.37671595,142.4996761
 Warrnambool College,45549.0,2022,WARRNAMBOOL,27.0,3.5,49.6,95.0,977.0,Government,Secondary,1203.0,-38.37671595,142.4996761
-Warrnambool College,,2023,WARRNAMBOOL,28.0,2.2,50.3,96.0,,,,,,
+Warrnambool College,45549.0,2023,WARRNAMBOOL,28.0,2.2,50.3,96.0,,,,,,
 Waverley Christian College,46246.0,2014,WANTIRNA SOUTH,33.0,15.4,96.0,100.0,1107.0,Independent,Combined,1576.0,-37.879582,145.215085
 Waverley Christian College,46246.0,2015,WANTIRNA SOUTH,33.0,14.2,91.0,100.0,1141.0,Independent,Combined,1681.0,-37.879582,145.215085
 Waverley Christian College,46246.0,2016,WANTIRNA SOUTH,32.0,11.8,89.0,99.0,1120.0,Independent,Combined,1799.0,-37.879582,145.215085
@@ -5404,8 +5499,8 @@ Waverley Christian College,46246.0,2020,WANTIRNA SOUTH,33.0,13.1,98.5,100.0,1143
 Waverley Christian College,46246.0,2021,WANTIRNA SOUTH,33.0,14.8,92.2,99.0,1144.0,Independent,Combined,2128.0,-37.879582,145.215085
 Waverley Christian College,46246.0,2022,WANTIRNA SOUTH,35.0,19.4,96.4,100.0,1148.0,Independent,Combined,2196.0,-37.879582,145.215085
 Waverley Christian College,46246.0,2022,NARRE WARREN SOUTH,33.0,12.5,100.0,100.0,1148.0,Independent,Combined,2196.0,-37.879582,145.215085
-Waverley Christian College,,2023,WANTIRNA SOUTH,33.0,11.4,93.2,100.0,,,,,,
-Waverley Christian College,,2023,NARRE WARREN SOUTH,32.0,7.5,90.3,100.0,,,,,,
+Waverley Christian College,46246.0,2023,WANTIRNA SOUTH,33.0,11.4,93.2,100.0,,,,,,
+Waverley Christian College,46246.0,2023,NARRE WARREN SOUTH,32.0,7.5,90.3,100.0,,,,,,
 Wedderburn College,45323.0,2014,WEDDERBURN,31.0,10.5,100.0,100.0,941.0,Government,Combined,234.0,-36.416952,143.61714
 Wedderburn College,45323.0,2015,WEDDERBURN,27.0,0.0,80.0,93.0,930.0,Government,Combined,233.0,-36.416952,143.61714
 Wedderburn College,45323.0,2016,WEDDERBURN,26.0,1.6,86.0,100.0,942.0,Government,Combined,224.0,-36.416952,143.61714
@@ -5415,7 +5510,7 @@ Wedderburn College,45323.0,2019,WEDDERBURN,31.0,4.0,90.9,100.0,929.0,Government,
 Wedderburn College,45323.0,2020,WEDDERBURN,30.0,5.6,57.1,86.0,925.0,Government,Combined,172.0,-36.416952,143.61714
 Wedderburn College,45323.0,2021,WEDDERBURN,29.0,0.0,80.0,80.0,924.0,Government,Combined,182.0,-36.416952,143.61714
 Wedderburn College,45323.0,2022,WEDDERBURN,26.0,0.0,77.8,100.0,924.0,Government,Combined,184.0,-36.416952,143.61714
-Wedderburn College,,2023,WEDDERBURN,28.0,,71.4,100.0,,,,,,
+Wedderburn College,45323.0,2023,WEDDERBURN,28.0,,71.4,100.0,,,,,,
 Weeroona College Bendigo,45347.0,2022,WHITE HILLS,,,,,941.0,Government,Secondary,749.0,-36.73893,144.29798
 Wellington Secondary College,45487.0,2014,MULGRAVE,29.0,4.7,94.0,99.0,970.0,Government,Secondary,1505.0,-37.934656,145.17022
 Wellington Secondary College,45487.0,2015,MULGRAVE,28.0,5.6,94.0,100.0,977.0,Government,Secondary,1614.0,-37.934656,145.17022
@@ -5426,7 +5521,7 @@ Wellington Secondary College,45487.0,2019,MULGRAVE,29.0,4.9,90.0,99.0,1000.0,Gov
 Wellington Secondary College,45487.0,2020,MULGRAVE,29.0,5.6,90.5,98.0,1000.0,Government,Secondary,1888.0,-37.934656,145.17022
 Wellington Secondary College,45487.0,2021,MULGRAVE,28.0,4.8,83.1,99.0,1000.0,Government,Secondary,1850.0,-37.934656,145.17022
 Wellington Secondary College,45487.0,2022,MULGRAVE,28.0,4.4,87.3,99.0,992.0,Government,Secondary,1761.0,-37.934656,145.17022
-Wellington Secondary College,,2023,MULGRAVE,28.0,4.7,77.1,97.0,,,,,,
+Wellington Secondary College,45487.0,2023,MULGRAVE,28.0,4.7,77.1,97.0,,,,,,
 Werribee Secondary College,45488.0,2014,WERRIBEE,31.0,7.4,88.0,94.0,1016.0,Government,Secondary,1406.0,-37.90552851,144.66892175
 Werribee Secondary College,45488.0,2015,WERRIBEE,30.0,5.7,85.0,95.0,1019.0,Government,Secondary,1441.0,-37.90552851,144.66892175
 Werribee Secondary College,45488.0,2016,WERRIBEE,30.0,5.8,86.0,93.0,1020.0,Government,Secondary,1500.0,-37.90552851,144.66892175
@@ -5436,11 +5531,11 @@ Werribee Secondary College,45488.0,2019,WERRIBEE,31.0,8.6,87.4,94.0,1033.0,Gover
 Werribee Secondary College,45488.0,2020,WERRIBEE,30.0,5.6,93.2,96.0,1032.0,Government,Secondary,1582.0,-37.90552851,144.66892175
 Werribee Secondary College,45488.0,2021,WERRIBEE,29.0,4.9,95.7,95.0,1031.0,Government,Secondary,1545.0,-37.90552851,144.66892175
 Werribee Secondary College,45488.0,2022,WERRIBEE,28.0,4.6,87.7,97.0,1031.0,Government,Secondary,1564.0,-37.90552851,144.66892175
-Werribee Secondary College,,2023,WERRIBEE,28.0,5.1,87.5,96.0,,,,,,
-Werrimull P-12 College,45183.0,2014,WERRIMULL,32.0,16.7,100.0,100.0,993.0,Government,Combined,72.0,-37.939591,143.216741
-Werrimull P-12 College,45183.0,2015,WERRIMULL,30.0,0.0,100.0,100.0,973.0,Government,Combined,74.0,-37.939591,143.216741
-Werrimull P-12 College,45183.0,2017,WERRIMULL,29.0,0.0,100.0,100.0,956.0,Government,Combined,70.0,-37.939591,143.216741
-Werrimull P-12 College,45183.0,2018,WERRIMULL,26.0,0.0,25.0,100.0,980.0,Government,Combined,59.0,-37.939591,143.216741
+Werribee Secondary College,45488.0,2023,WERRIBEE,28.0,5.1,87.5,96.0,,,,,,
+Werrimull P-12 College,45318.0,2014,WERRIMULL,32.0,16.7,100.0,100.0,981.0,Government,Combined,55.0,-34.390411,141.593839
+Werrimull P-12 College,45318.0,2015,WERRIMULL,30.0,0.0,100.0,100.0,975.0,Government,Combined,39.0,-34.390411,141.593839
+Werrimull P-12 College,45318.0,2017,WERRIMULL,29.0,0.0,100.0,100.0,953.0,Government,Combined,37.0,-34.390411,141.593839
+Werrimull P-12 College,45318.0,2018,WERRIMULL,26.0,0.0,25.0,100.0,944.0,Government,Combined,36.0,-34.390411,141.593839
 Wesley College,46132.0,2014,MELBOURNE,33.0,13.0,94.0,99.0,1173.0,Independent,Combined,2889.0,-37.84883,144.982144
 Wesley College,46132.0,2014,GLEN WAVERLEY,32.0,6.9,89.0,100.0,1173.0,Independent,Combined,2889.0,-37.84883,144.982144
 Wesley College,46132.0,2015,MELBOURNE,33.0,12.6,88.0,100.0,1172.0,Independent,Combined,2982.0,-37.84883,144.982144
@@ -5459,8 +5554,8 @@ Wesley College,46132.0,2021,MELBOURNE,32.0,9.6,97.1,100.0,1166.0,Independent,Com
 Wesley College,46132.0,2021,GLEN WAVERLEY,31.0,6.9,95.8,100.0,1166.0,Independent,Combined,3118.0,-37.84883,144.982144
 Wesley College,46132.0,2022,MELBOURNE,32.0,10.9,92.5,99.0,1173.0,Independent,Combined,3162.0,-37.84883,144.982144
 Wesley College,46132.0,2022,GLEN WAVERLEY,33.0,8.2,92.9,100.0,1173.0,Independent,Combined,3162.0,-37.84883,144.982144
-Wesley College,,2023,MELBOURNE,31.0,5.4,97.7,99.0,,,,,,
-Wesley College,,2023,GLEN WAVERLEY,31.0,7.2,93.6,100.0,,,,,,
+Wesley College,46132.0,2023,MELBOURNE,31.0,5.4,97.7,99.0,,,,,,
+Wesley College,46132.0,2023,GLEN WAVERLEY,31.0,7.2,93.6,100.0,,,,,,
 Westall Secondary College,45490.0,2014,CLAYTON SOUTH,27.0,3.7,96.0,100.0,922.0,Government,Secondary,475.0,-37.94021554,145.1361047
 Westall Secondary College,45490.0,2015,CLAYTON SOUTH,26.0,5.0,87.0,100.0,938.0,Government,Secondary,469.0,-37.94021554,145.1361047
 Westall Secondary College,45490.0,2016,CLAYTON SOUTH,26.0,7.7,93.0,100.0,931.0,Government,Secondary,488.0,-37.94021554,145.1361047
@@ -5470,7 +5565,7 @@ Westall Secondary College,45490.0,2019,CLAYTON SOUTH,27.0,1.5,92.9,96.0,952.0,Go
 Westall Secondary College,45490.0,2020,CLAYTON SOUTH,27.0,3.5,88.2,100.0,962.0,Government,Secondary,600.0,-37.94021554,145.1361047
 Westall Secondary College,45490.0,2021,CLAYTON SOUTH,27.0,3.8,90.0,100.0,960.0,Government,Secondary,541.0,-37.94021554,145.1361047
 Westall Secondary College,45490.0,2022,CLAYTON SOUTH,26.0,4.4,75.0,95.0,966.0,Government,Secondary,595.0,-37.94021554,145.1361047
-Westall Secondary College,,2023,CLAYTON SOUTH,27.0,2.9,62.8,95.0,,,,,,
+Westall Secondary College,45490.0,2023,CLAYTON SOUTH,27.0,2.9,62.8,95.0,,,,,,
 Westbourne Grammar School,46249.0,2014,TRUGANINA,34.0,14.2,96.0,99.0,1141.0,Independent,Combined,1338.0,-37.850843,144.724898
 Westbourne Grammar School,46249.0,2015,TRUGANINA,33.0,9.8,95.0,100.0,1148.0,Independent,Combined,1377.0,-37.850843,144.724898
 Westbourne Grammar School,46249.0,2016,TRUGANINA,33.0,14.7,92.0,100.0,1144.0,Independent,Combined,1416.0,-37.850843,144.724898
@@ -5480,7 +5575,7 @@ Westbourne Grammar School,46249.0,2019,TRUGANINA,34.0,15.8,94.9,100.0,1144.0,Ind
 Westbourne Grammar School,46249.0,2020,TRUGANINA,34.0,15.4,97.3,100.0,1144.0,Independent,Combined,1481.0,-37.850843,144.724898
 Westbourne Grammar School,46249.0,2021,TRUGANINA,33.0,13.4,96.3,100.0,1149.0,Independent,Combined,1482.0,-37.850843,144.724898
 Westbourne Grammar School,46249.0,2022,TRUGANINA,33.0,12.4,93.9,99.0,1155.0,Independent,Combined,1500.0,-37.850843,144.724898
-Westbourne Grammar School,,2023,TRUGANINA,33.0,13.6,95.7,100.0,,,,,,
+Westbourne Grammar School,46249.0,2023,TRUGANINA,33.0,13.6,95.7,100.0,,,,,,
 Western Heights Sec College,45558.0,2014,HAMLYN HEIGHTS,24.0,2.3,69.0,96.0,949.0,Government,Secondary,823.0,-38.122893,144.328966
 Western Heights Sec College,45558.0,2015,HAMLYN HEIGHTS,22.0,1.2,65.0,93.0,935.0,Government,Secondary,744.0,-38.122893,144.328966
 Western Heights Sec College,45558.0,2016,HAMLYN HEIGHTS,24.0,0.5,38.0,88.0,950.0,Government,Secondary,605.0,-38.122893,144.328966
@@ -5490,7 +5585,7 @@ Western Heights Sec College,45558.0,2019,HAMLYN HEIGHTS,24.0,1.2,52.6,100.0,950.
 Western Heights Sec College,45558.0,2020,HAMLYN HEIGHTS,23.0,2.7,48.1,96.0,957.0,Government,Secondary,400.0,-38.122893,144.328966
 Western Heights Sec College,45558.0,2021,HAMLYN HEIGHTS,24.0,1.4,55.6,97.0,963.0,Government,Secondary,498.0,-38.122893,144.328966
 Western Heights Sec College,45558.0,2022,HAMLYN HEIGHTS,21.0,0.0,46.7,97.0,964.0,Government,Secondary,555.0,-38.122893,144.328966
-Western Heights Sec College,,2023,HAMLYN HEIGHTS,22.0,,37.9,98.0,,,,,,
+Western Heights Sec College,45558.0,2023,HAMLYN HEIGHTS,22.0,,37.9,98.0,,,,,,
 Western Port Sec College,45396.0,2014,HASTINGS,22.0,0.6,51.0,100.0,939.0,Government,Secondary,604.0,-38.307988,145.17524
 Western Port Sec College,45396.0,2015,HASTINGS,23.0,1.9,49.0,98.0,931.0,Government,Secondary,632.0,-38.307988,145.17524
 Western Port Sec College,45396.0,2016,HASTINGS,26.0,1.3,60.0,100.0,932.0,Government,Secondary,576.0,-38.307988,145.17524
@@ -5500,12 +5595,12 @@ Western Port Sec College,45396.0,2019,HASTINGS,23.0,0.0,39.5,95.0,954.0,Governme
 Western Port Sec College,45396.0,2020,HASTINGS,26.0,1.0,57.1,96.0,955.0,Government,Secondary,636.0,-38.307988,145.17524
 Western Port Sec College,45396.0,2021,HASTINGS,24.0,0.7,53.1,88.0,958.0,Government,Secondary,672.0,-38.307988,145.17524
 Western Port Sec College,45396.0,2022,HASTINGS,22.0,0.9,32.4,88.0,947.0,Government,Secondary,671.0,-38.307988,145.17524
-Western Port Sec College,,2023,HASTINGS,25.0,1.4,52.7,91.0,,,,,,
-Western Senior Sec Coll,45396.0,2015,WEST MELBOURNE,,,,,931.0,Government,Secondary,632.0,-38.307988,145.17524
-Western Senior Sec Coll,45396.0,2016,WEST MELBOURNE,,,,,932.0,Government,Secondary,576.0,-38.307988,145.17524
-Western Senior Sec Coll,45396.0,2017,WEST MELBOURNE,,,,,940.0,Government,Secondary,551.0,-38.307988,145.17524
-Western Senior Sec Coll,45396.0,2018,WEST MELBOURNE,,,,,953.0,Government,Secondary,553.0,-38.307988,145.17524
-Western Senior Sec Coll,45396.0,2019,WEST MELBOURNE,,,,,954.0,Government,Secondary,590.0,-38.307988,145.17524
+Western Port Sec College,45396.0,2023,HASTINGS,25.0,1.4,52.7,91.0,,,,,,
+Western Senior Sec Coll,,2015,WEST MELBOURNE,,,,,,,,,,
+Western Senior Sec Coll,,2016,WEST MELBOURNE,,,,,,,,,,
+Western Senior Sec Coll,,2017,WEST MELBOURNE,,,,,,,,,,
+Western Senior Sec Coll,,2018,WEST MELBOURNE,,,,,,,,,,
+Western Senior Sec Coll,,2019,WEST MELBOURNE,,,,,,,,,,
 Wheelers Hill Sec College,45491.0,2014,WHEELERS HILL,28.0,2.6,87.0,99.0,1004.0,Government,Secondary,552.0,-37.91029916,145.18120525
 Wheelers Hill Sec College,45491.0,2015,WHEELERS HILL,26.0,0.7,86.0,96.0,1003.0,Government,Secondary,561.0,-37.91029916,145.18120525
 Wheelers Hill Sec College,45491.0,2016,WHEELERS HILL,29.0,5.6,82.0,100.0,999.0,Government,Secondary,588.0,-37.91029916,145.18120525
@@ -5515,7 +5610,7 @@ Wheelers Hill Sec College,45491.0,2019,WHEELERS HILL,27.0,2.9,80.6,100.0,1009.0,
 Wheelers Hill Sec College,45491.0,2020,WHEELERS HILL,29.0,3.9,70.6,98.0,1014.0,Government,Secondary,660.0,-37.91029916,145.18120525
 Wheelers Hill Sec College,45491.0,2021,WHEELERS HILL,28.0,1.2,57.0,89.0,1019.0,Government,Secondary,698.0,-37.91029916,145.18120525
 Wheelers Hill Sec College,45491.0,2022,WHEELERS HILL,28.0,1.2,60.4,94.0,1025.0,Government,Secondary,700.0,-37.91029916,145.18120525
-Wheelers Hill Sec College,,2023,WHEELERS HILL,26.0,2.1,67.3,98.0,,,,,,
+Wheelers Hill Sec College,45491.0,2023,WHEELERS HILL,26.0,2.1,67.3,98.0,,,,,,
 Whitefriars College,45865.0,2014,DONVALE,31.0,8.1,94.0,100.0,1061.0,Catholic,Secondary,1188.0,-37.7918,145.199541
 Whitefriars College,45865.0,2015,DONVALE,31.0,8.3,93.0,100.0,1087.0,Catholic,Secondary,1206.0,-37.7918,145.199541
 Whitefriars College,45865.0,2016,DONVALE,31.0,7.3,92.0,100.0,1086.0,Catholic,Secondary,1220.0,-37.7918,145.199541
@@ -5525,7 +5620,7 @@ Whitefriars College,45865.0,2019,DONVALE,31.0,9.3,83.2,98.0,1095.0,Catholic,Seco
 Whitefriars College,45865.0,2020,DONVALE,31.0,5.9,92.0,100.0,1101.0,Catholic,Secondary,1148.0,-37.7918,145.199541
 Whitefriars College,45865.0,2021,DONVALE,31.0,9.2,89.9,100.0,1105.0,Catholic,Secondary,1118.0,-37.7918,145.199541
 Whitefriars College,45865.0,2022,DONVALE,31.0,5.5,87.2,99.0,1113.0,Catholic,Secondary,1079.0,-37.7918,145.199541
-Whitefriars College,,2023,DONVALE,32.0,10.0,73.9,100.0,,,,,,
+Whitefriars College,45865.0,2023,DONVALE,32.0,10.0,73.9,100.0,,,,,,
 Whittlesea Secondary College,45348.0,2014,WHITTLESEA,25.0,0.3,65.0,86.0,969.0,Government,Secondary,872.0,-37.5150463,145.12017505
 Whittlesea Secondary College,45348.0,2015,WHITTLESEA,26.0,1.6,86.0,91.0,957.0,Government,Secondary,920.0,-37.5150463,145.12017505
 Whittlesea Secondary College,45348.0,2016,WHITTLESEA,25.0,0.8,75.0,95.0,962.0,Government,Secondary,857.0,-37.5150463,145.12017505
@@ -5535,7 +5630,15 @@ Whittlesea Secondary College,45348.0,2019,WHITTLESEA,25.0,1.8,61.0,93.0,956.0,Go
 Whittlesea Secondary College,45348.0,2020,WHITTLESEA,23.0,1.8,56.2,100.0,953.0,Government,Secondary,693.0,-37.5150463,145.12017505
 Whittlesea Secondary College,45348.0,2021,WHITTLESEA,25.0,0.5,60.0,100.0,957.0,Government,Secondary,679.0,-37.5150463,145.12017505
 Whittlesea Secondary College,45348.0,2022,WHITTLESEA,23.0,1.2,74.5,100.0,961.0,Government,Secondary,720.0,-37.5150463,145.12017505
-Whittlesea Secondary College,,2023,WHITTLESEA,22.0,1.4,78.2,96.0,,,,,,
+Whittlesea Secondary College,45348.0,2023,WHITTLESEA,22.0,1.4,78.2,96.0,,,,,,
+William Angliss Inst of TAFE,,2014,MELBOURNE,,,,,,,,,,
+William Angliss Inst of TAFE,,2015,MELBOURNE,,,,,,,,,,
+William Angliss Inst of TAFE,,2016,MELBOURNE,,,0.0,0.0,,,,,,
+William Angliss Inst of TAFE,,2017,MELBOURNE,,,,,,,,,,
+William Angliss Inst of TAFE,,2018,MELBOURNE,,,0.0,0.0,,,,,,
+William Angliss Inst of TAFE,,2019,MELBOURNE,,,,,,,,,,
+William Angliss Inst of TAFE,,2020,MELBOURNE,,,,,,,,,,
+William Angliss Inst of TAFE,,2021,MELBOURNE,,,,,,,,,,
 William Ruthven Sec College,45627.0,2014,RESERVOIR,25.0,1.3,88.0,97.0,933.0,Government,Secondary,469.0,-37.6954,145.003
 William Ruthven Sec College,45627.0,2015,RESERVOIR,26.0,1.2,96.0,94.0,928.0,Government,Secondary,431.0,-37.6954,145.003
 William Ruthven Sec College,45627.0,2016,RESERVOIR,25.0,1.3,92.0,96.0,942.0,Government,Secondary,420.0,-37.6954,145.003
@@ -5545,7 +5648,7 @@ William Ruthven Sec College,45627.0,2019,RESERVOIR,27.0,3.1,84.4,87.0,952.0,Gove
 William Ruthven Sec College,45627.0,2020,RESERVOIR,28.0,7.5,84.2,95.0,960.0,Government,Secondary,394.0,-37.6954,145.003
 William Ruthven Sec College,45627.0,2021,RESERVOIR,27.0,2.7,100.0,100.0,966.0,Government,Secondary,412.0,-37.6954,145.003
 William Ruthven Sec College,45627.0,2022,RESERVOIR,27.0,3.1,71.1,96.0,959.0,Government,Secondary,440.0,-37.6954,145.003
-William Ruthven Sec College,,2023,RESERVOIR,27.0,1.1,88.5,100.0,,,,,,
+William Ruthven Sec College,45627.0,2023,RESERVOIR,27.0,1.1,88.5,100.0,,,,,,
 Williamstown High School,40427.0,2014,WILLIAMSTOWN,30.0,4.5,75.0,99.0,1075.0,Government,Secondary,1463.0,-37.862753,144.895131
 Williamstown High School,40427.0,2015,WILLIAMSTOWN,30.0,7.8,77.0,100.0,1078.0,Government,Secondary,1477.0,-37.862753,144.895131
 Williamstown High School,40427.0,2016,WILLIAMSTOWN,31.0,10.5,77.0,99.0,1080.0,Government,Secondary,1475.0,-37.862753,144.895131
@@ -5555,7 +5658,15 @@ Williamstown High School,40427.0,2019,WILLIAMSTOWN,31.0,8.6,80.6,98.0,1097.0,Gov
 Williamstown High School,40427.0,2020,WILLIAMSTOWN,31.0,10.9,82.3,99.0,1102.0,Government,Secondary,1543.0,-37.862753,144.895131
 Williamstown High School,40427.0,2021,WILLIAMSTOWN,32.0,10.0,77.5,100.0,1105.0,Government,Secondary,1484.0,-37.862753,144.895131
 Williamstown High School,40427.0,2022,WILLIAMSTOWN,32.0,9.1,83.6,98.0,1109.0,Government,Secondary,1475.0,-37.862753,144.895131
-Williamstown High School,,2023,WILLIAMSTOWN,32.0,12.0,72.2,97.0,,,,,,
+Williamstown High School,40427.0,2023,WILLIAMSTOWN,32.0,12.0,72.2,97.0,,,,,,
+Wodonga Institute of TAFE,,2014,WODONGA,,,,,,,,,,
+Wodonga Institute of TAFE,,2015,WODONGA,,,,,,,,,,
+Wodonga Institute of TAFE,,2016,WODONGA,,,,,,,,,,
+Wodonga Institute of TAFE,,2017,WODONGA,,,,,,,,,,
+Wodonga Institute of TAFE,,2018,WODONGA,,,0.0,0.0,,,,,,
+Wodonga Institute of TAFE,,2019,WODONGA,,,,,,,,,,
+Wodonga Institute of TAFE,,2020,WODONGA,,,,,,,,,,
+Wodonga Institute of TAFE,,2021,WODONGA,,,,,,,,,,
 Wodonga Senior Sec College,40429.0,2014,WODONGA,24.0,1.2,53.0,95.0,,Government,Secondary,984.0,-36.12745035,146.88022763
 Wodonga Senior Sec College,40429.0,2015,WODONGA,25.0,1.3,44.0,94.0,,Government,Secondary,1084.0,-36.12745035,146.88022763
 Wodonga Senior Sec College,40429.0,2016,WODONGA,24.0,1.5,31.0,87.0,,Government,Secondary,1232.0,-36.12745035,146.88022763
@@ -5565,15 +5676,15 @@ Wodonga Senior Sec College,40429.0,2019,WODONGA,23.0,0.7,57.7,96.0,866.0,Governm
 Wodonga Senior Sec College,40429.0,2020,WODONGA,23.0,1.1,40.4,93.0,865.0,Government,Secondary,1111.0,-36.12745035,146.88022763
 Wodonga Senior Sec College,40429.0,2021,WODONGA,24.0,1.9,40.2,91.0,871.0,Government,Secondary,1123.0,-36.12745035,146.88022763
 Wodonga Senior Sec College,40429.0,2022,WODONGA,22.0,1.4,54.0,96.0,917.0,Government,Secondary,1200.0,-36.12745035,146.88022763
-Wodonga Senior Sec College,,2023,WODONGA,23.0,1.3,35.8,92.0,,,,,,
-Wonthaggi Secondary College,45520.0,2014,WONTHAGGI,28.0,3.8,72.0,100.0,981.0,Government,Secondary,494.0,-38.47868659,145.96124111
-Wonthaggi Secondary College,45520.0,2015,WONTHAGGI,29.0,2.6,71.0,97.0,979.0,Government,Secondary,483.0,-38.47868659,145.96124111
-Wonthaggi Secondary College,45520.0,2016,WONTHAGGI,27.0,3.1,68.0,96.0,990.0,Government,Secondary,506.0,-38.47868659,145.96124111
-Wonthaggi Secondary College,45520.0,2017,WONTHAGGI,28.0,4.0,75.0,99.0,987.0,Government,Secondary,554.0,-38.47868659,145.96124111
-Wonthaggi Secondary College,45520.0,2018,WONTHAGGI,27.0,4.0,72.1,98.0,991.0,Government,Secondary,562.0,-38.47868659,145.96124111
-Wonthaggi Secondary College,45520.0,2019,WONTHAGGI,27.0,3.0,62.4,98.0,992.0,Government,Secondary,602.0,-38.47868659,145.96124111
-Wonthaggi Secondary College,45520.0,2020,WONTHAGGI,27.0,4.0,60.8,100.0,993.0,Government,Secondary,622.0,-38.47868659,145.96124111
-Wonthaggi Secondary College,45520.0,2021,WONTHAGGI,27.0,2.3,55.6,95.0,992.0,Government,Secondary,616.0,-38.47868659,145.96124111
+Wodonga Senior Sec College,40429.0,2023,WODONGA,23.0,1.3,35.8,92.0,,,,,,
+Wonthaggi Secondary College,40597.0,2014,WONTHAGGI,28.0,3.8,72.0,100.0,969.0,Government,Secondary,1208.0,-38.607571,145.591814
+Wonthaggi Secondary College,40597.0,2015,WONTHAGGI,29.0,2.6,71.0,97.0,973.0,Government,Secondary,1235.0,-38.607571,145.591814
+Wonthaggi Secondary College,40597.0,2016,WONTHAGGI,27.0,3.1,68.0,96.0,972.0,Government,Secondary,1265.0,-38.607571,145.591814
+Wonthaggi Secondary College,40597.0,2017,WONTHAGGI,28.0,4.0,75.0,99.0,972.0,Government,Secondary,1294.0,-38.607571,145.591814
+Wonthaggi Secondary College,40597.0,2018,WONTHAGGI,27.0,4.0,72.1,98.0,981.0,Government,Secondary,1310.0,-38.607571,145.591814
+Wonthaggi Secondary College,40597.0,2019,WONTHAGGI,27.0,3.0,62.4,98.0,987.0,Government,Secondary,1384.0,-38.609807,145.597177
+Wonthaggi Secondary College,40597.0,2020,WONTHAGGI,27.0,4.0,60.8,100.0,992.0,Government,Secondary,1442.0,-38.609807,145.597177
+Wonthaggi Secondary College,40597.0,2021,WONTHAGGI,27.0,2.3,55.6,95.0,995.0,Government,Secondary,1467.0,-38.609807,145.597177
 Woodleigh School,46391.0,2014,LANGWARRIN SOUTH,33.0,12.9,99.0,100.0,1132.0,Independent,Combined,774.0,-38.192609,145.173558
 Woodleigh School,46391.0,2015,LANGWARRIN SOUTH,33.0,13.7,94.0,100.0,1130.0,Independent,Combined,923.0,-38.192609,145.173558
 Woodleigh School,46391.0,2016,LANGWARRIN SOUTH,35.0,18.8,96.0,100.0,1121.0,Independent,Combined,941.0,-38.192609,145.173558
@@ -5583,12 +5694,12 @@ Woodleigh School,46391.0,2019,LANGWARRIN SOUTH,33.0,12.3,86.7,100.0,1110.0,Indep
 Woodleigh School,46391.0,2020,LANGWARRIN SOUTH,33.0,8.6,94.4,100.0,1115.0,Independent,Combined,919.0,-38.192609,145.173558
 Woodleigh School,46391.0,2021,LANGWARRIN SOUTH,32.0,8.2,94.9,100.0,1113.0,Independent,Combined,944.0,-38.192609,145.173558
 Woodleigh School,46391.0,2022,LANGWARRIN SOUTH,30.0,5.8,88.8,100.0,1111.0,Independent,Combined,926.0,-38.192609,145.173558
-Woodleigh School,,2023,LANGWARRIN SOUTH,30.0,4.6,87.8,100.0,,,,,,
+Woodleigh School,46391.0,2023,LANGWARRIN SOUTH,30.0,4.6,87.8,100.0,,,,,,
 Woodmans Hill Secondary College,52702.0,2019,BALLARAT EAST,25.0,0.0,55.6,94.0,954.0,Government,Secondary,377.0,-37.559117,143.893784
 Woodmans Hill Secondary College,52702.0,2020,BALLARAT EAST,24.0,1.0,48.1,81.0,967.0,Government,Secondary,417.0,-37.559117,143.893784
 Woodmans Hill Secondary College,52702.0,2021,BALLARAT EAST,29.0,2.8,52.9,100.0,969.0,Government,Secondary,460.0,-37.559117,143.893784
 Woodmans Hill Secondary College,52702.0,2022,BALLARAT EAST,29.0,11.4,76.2,90.0,975.0,Government,Secondary,508.0,-37.559117,143.893784
-Woodmans Hill Secondary College,,2023,BALLARAT EAST,29.0,9.3,38.1,90.0,,,,,,
+Woodmans Hill Secondary College,52702.0,2023,BALLARAT EAST,29.0,9.3,38.1,90.0,,,,,,
 Wycheproof P-12 College,45567.0,2014,WYCHEPROOF,31.0,7.4,80.0,100.0,1006.0,Government,Combined,121.0,-36.075704,143.229098
 Wycheproof P-12 College,45567.0,2015,WYCHEPROOF,34.0,13.9,100.0,100.0,1000.0,Government,Combined,115.0,-36.075704,143.229098
 Wycheproof P-12 College,45567.0,2016,WYCHEPROOF,30.0,0.0,93.0,100.0,1002.0,Government,Combined,120.0,-36.075704,143.229098
@@ -5598,7 +5709,7 @@ Wycheproof P-12 College,45567.0,2019,WYCHEPROOF,27.0,5.6,100.0,100.0,991.0,Gover
 Wycheproof P-12 College,45567.0,2020,WYCHEPROOF,28.0,15.0,66.7,100.0,996.0,Government,Combined,96.0,-36.075704,143.229098
 Wycheproof P-12 College,45567.0,2021,WYCHEPROOF,33.0,9.1,66.7,100.0,1004.0,Government,Combined,100.0,-36.075704,143.229098
 Wycheproof P-12 College,45567.0,2022,WYCHEPROOF,34.0,25.0,50.0,88.0,995.0,Government,Combined,105.0,-36.075704,143.229098
-Wycheproof P-12 College,,2023,WYCHEPROOF,29.0,6.5,50.0,100.0,,,,,,
+Wycheproof P-12 College,45567.0,2023,WYCHEPROOF,29.0,6.5,50.0,100.0,,,,,,
 Wyndham Central Sec Coll,45346.0,2014,WERRIBEE,24.0,0.0,82.0,97.0,900.0,Government,Secondary,711.0,-37.88866554,144.65307732
 Wyndham Central Sec Coll,45346.0,2015,WERRIBEE,26.0,3.8,78.0,93.0,912.0,Government,Secondary,743.0,-37.88866554,144.65307732
 Wyndham Central Sec Coll,45346.0,2016,WERRIBEE,28.0,4.2,81.0,92.0,906.0,Government,Secondary,834.0,-37.88866554,144.65307732
@@ -5608,15 +5719,17 @@ Wyndham Central Sec Coll,45346.0,2019,WERRIBEE,27.0,2.3,81.7,98.0,918.0,Governme
 Wyndham Central Sec Coll,45346.0,2020,WERRIBEE,24.0,2.2,81.3,96.0,919.0,Government,Secondary,1255.0,-37.88866554,144.65307732
 Wyndham Central Sec Coll,45346.0,2021,WERRIBEE,25.0,0.3,73.2,95.0,925.0,Government,Secondary,1319.0,-37.88866554,144.65307732
 Wyndham Central Sec Coll,45346.0,2022,WERRIBEE,26.0,2.0,54.1,95.0,915.0,Government,Secondary,1343.0,-37.88866554,144.65307732
-Wyndham Central Sec Coll,,2023,WERRIBEE,24.0,2.2,64.2,96.0,,,,,,
-Wyndham Community Centre,46299.0,2014,WERRIBEE,,,,,1076.0,Independent,Combined,2150.0,-38.26334,145.167227
-Wyndham Community Centre,46299.0,2015,WERRIBEE,,,,,1079.0,Independent,Combined,2102.0,-38.26334,145.167227
-Wyndham Community Centre,46299.0,2016,WERRIBEE,,,,,1078.0,Independent,Combined,2035.0,-38.26334,145.167227
-Wyndham Community Centre,46299.0,2017,WERRIBEE,,,,,1083.0,Independent,Combined,1877.0,-38.26334,145.167227
-Wyndham Community Centre,46299.0,2018,WERRIBEE,,,,,1087.0,Independent,Combined,1737.0,-38.26334,145.167227
-Wyndham Community Centre,46299.0,2019,WERRIBEE,,,,,1084.0,Independent,Combined,1614.0,-38.26334,145.167227
-Wyndham Community Centre,46299.0,2020,WERRIBEE,,,,,1084.0,Independent,Combined,1491.0,-38.26334,145.167227
-Wyndham Community Centre,46299.0,2021,WERRIBEE,,,,,1086.0,Independent,Combined,1491.0,-38.26334,145.167227
+Wyndham Central Sec Coll,45346.0,2023,WERRIBEE,24.0,2.2,64.2,96.0,,,,,,
+Wyndham Comm & Educ Centre,,2022,WERRIBEE,,,,,,,,,,
+Wyndham Comm & Educ Centre,,2023,WERRIBEE,,,20.0,100.0,,,,,,
+Wyndham Community Centre,,2014,WERRIBEE,,,,,,,,,,
+Wyndham Community Centre,,2015,WERRIBEE,,,,,,,,,,
+Wyndham Community Centre,,2016,WERRIBEE,,,,,,,,,,
+Wyndham Community Centre,,2017,WERRIBEE,,,,,,,,,,
+Wyndham Community Centre,,2018,WERRIBEE,,,,,,,,,,
+Wyndham Community Centre,,2019,WERRIBEE,,,,,,,,,,
+Wyndham Community Centre,,2020,WERRIBEE,,,,,,,,,,
+Wyndham Community Centre,,2021,WERRIBEE,,,,,,,,,,
 Xavier College,45696.0,2014,KEW,33.0,17.8,94.0,100.0,1162.0,Catholic,Combined,2011.0,-37.813858,145.031105
 Xavier College,45696.0,2015,KEW,34.0,16.6,91.0,100.0,1165.0,Catholic,Combined,1991.0,-37.813858,145.031105
 Xavier College,45696.0,2016,KEW,33.0,14.1,92.0,100.0,1157.0,Catholic,Combined,1982.0,-37.813858,145.031105
@@ -5626,9 +5739,9 @@ Xavier College,45696.0,2019,KEW,34.0,16.2,91.8,100.0,1160.0,Catholic,Combined,19
 Xavier College,45696.0,2020,KEW,34.0,19.2,97.6,100.0,1160.0,Catholic,Combined,1862.0,-37.813858,145.031105
 Xavier College,45696.0,2021,KEW,33.0,13.1,92.1,99.0,1159.0,Catholic,Combined,1744.0,-37.813858,145.031105
 Xavier College,45696.0,2022,KEW,33.0,14.1,98.0,100.0,1165.0,Catholic,Combined,1651.0,-37.813858,145.031105
-Xavier College,,2023,KEW,33.0,15.7,96.8,100.0,,,,,,
-Yarra Hills Sec Coll Mooroolbark,,2023,MOOROOLBARK,23.0,,46.0,97.0,,,,,,
-Yarra Hills Sec Coll Mt Evelyn,,2023,MOUNT EVELYN,,,,83.0,,,,,,
+Xavier College,45696.0,2023,KEW,33.0,15.7,96.8,100.0,,,,,,
+Yarra Hills Sec Coll Mooroolbark,50185.0,2023,MOOROOLBARK,23.0,,46.0,97.0,,,,,,
+Yarra Hills Sec Coll Mt Evelyn,50185.0,2023,MOUNT EVELYN,,,,83.0,,,,,,
 Yarra Hills Secondary College,50185.0,2014,MOOROOLBARK,24.0,0.8,72.0,96.0,958.0,Government,Secondary,600.0,-37.78925938,145.3160489
 Yarra Hills Secondary College,50185.0,2015,MOOROOLBARK,24.0,2.4,80.0,92.0,959.0,Government,Secondary,623.0,-37.78925938,145.3160489
 Yarra Hills Secondary College,50185.0,2016,MOOROOLBARK,25.0,2.6,78.0,94.0,963.0,Government,Secondary,696.0,-37.78925938,145.3160489
@@ -5648,7 +5761,7 @@ Yarra Valley Grammar School,46224.0,2019,RINGWOOD,34.0,18.8,91.6,100.0,1133.0,In
 Yarra Valley Grammar School,46224.0,2020,RINGWOOD,34.0,21.3,89.8,100.0,1133.0,Independent,Combined,1330.0,-37.783701,145.258164
 Yarra Valley Grammar School,46224.0,2021,RINGWOOD,34.0,18.9,91.7,100.0,1128.0,Independent,Combined,1359.0,-37.783701,145.258164
 Yarra Valley Grammar School,46224.0,2022,RINGWOOD,35.0,25.1,90.7,100.0,1147.0,Independent,Combined,1479.0,-37.783701,145.258164
-Yarra Valley Grammar School,,2023,RINGWOOD,35.0,22.3,90.5,100.0,,,,,,
+Yarra Valley Grammar School,46224.0,2023,RINGWOOD,35.0,22.3,90.5,100.0,,,,,,
 Yarram Secondary College,45493.0,2014,YARRAM,25.0,1.5,75.0,100.0,963.0,Government,Secondary,308.0,-38.566575,146.68546
 Yarram Secondary College,45493.0,2015,YARRAM,27.0,3.8,63.0,89.0,956.0,Government,Secondary,294.0,-38.566575,146.68546
 Yarram Secondary College,45493.0,2016,YARRAM,24.0,3.4,51.0,92.0,953.0,Government,Secondary,300.0,-38.566575,146.68546
@@ -5658,7 +5771,7 @@ Yarram Secondary College,45493.0,2019,YARRAM,23.0,0.0,50.0,95.0,952.0,Government
 Yarram Secondary College,45493.0,2020,YARRAM,25.0,0.0,56.7,97.0,950.0,Government,Secondary,325.0,-38.566575,146.68546
 Yarram Secondary College,45493.0,2021,YARRAM,26.0,0.7,56.5,91.0,954.0,Government,Secondary,327.0,-38.566575,146.68546
 Yarram Secondary College,45493.0,2022,YARRAM,25.0,0.0,81.8,95.0,951.0,Government,Secondary,342.0,-38.566575,146.68546
-Yarram Secondary College,,2023,YARRAM,26.0,2.8,37.5,91.0,,,,,,
+Yarram Secondary College,45493.0,2023,YARRAM,26.0,2.8,37.5,91.0,,,,,,
 Yarrawonga College P-12,45608.0,2014,YARRAWONGA,26.0,3.5,70.0,100.0,969.0,Government,Combined,808.0,-36.02144074,146.0066682
 Yarrawonga College P-12,45608.0,2015,YARRAWONGA,26.0,0.6,79.0,96.0,965.0,Government,Combined,812.0,-36.02144074,146.0066682
 Yarrawonga College P-12,45608.0,2016,YARRAWONGA,27.0,3.0,81.0,100.0,971.0,Government,Combined,790.0,-36.02144074,146.0066682
@@ -5668,7 +5781,7 @@ Yarrawonga College P-12,45608.0,2019,YARRAWONGA,26.0,2.3,78.3,96.0,969.0,Governm
 Yarrawonga College P-12,45608.0,2020,YARRAWONGA,28.0,3.3,70.4,100.0,970.0,Government,Combined,944.0,-36.02144074,146.0066682
 Yarrawonga College P-12,45608.0,2021,YARRAWONGA,27.0,0.9,61.9,100.0,968.0,Government,Combined,962.0,-36.02144074,146.0066682
 Yarrawonga College P-12,45608.0,2022,YARRAWONGA,25.0,1.2,54.3,97.0,965.0,Government,Combined,981.0,-36.02144074,146.0066682
-Yarrawonga College P-12,,2023,YARRAWONGA,26.0,3.7,43.2,98.0,,,,,,
+Yarrawonga College P-12,45608.0,2023,YARRAWONGA,26.0,3.7,43.2,98.0,,,,,,
 Yea High School,45494.0,2014,YEA,24.0,5.4,88.0,100.0,991.0,Government,Secondary,349.0,-37.215011,145.408536
 Yea High School,45494.0,2015,YEA,27.0,1.1,82.0,100.0,984.0,Government,Secondary,323.0,-37.215011,145.408536
 Yea High School,45494.0,2016,YEA,25.0,1.9,70.0,97.0,991.0,Government,Secondary,336.0,-37.215011,145.408536
@@ -5678,7 +5791,7 @@ Yea High School,45494.0,2019,YEA,26.0,2.7,68.9,91.0,981.0,Government,Secondary,3
 Yea High School,45494.0,2020,YEA,26.0,5.0,84.8,100.0,986.0,Government,Secondary,313.0,-37.215011,145.408536
 Yea High School,45494.0,2021,YEA,26.0,0.7,65.5,93.0,980.0,Government,Secondary,301.0,-37.215011,145.408536
 Yea High School,45494.0,2022,YEA,25.0,1.4,38.7,94.0,979.0,Government,Secondary,326.0,-37.215011,145.408536
-Yea High School,,2023,YEA,25.0,,32.4,85.0,,,,,,
+Yea High School,45494.0,2023,YEA,25.0,,32.4,85.0,,,,,,
 Yeshivah College,46215.0,2014,ST KILDA EAST,37.0,32.8,91.0,100.0,1078.0,Independent,Combined,371.0,-37.867922,144.999941
 Yeshivah College,46215.0,2015,ST KILDA EAST,37.0,23.2,100.0,100.0,1091.0,Independent,Combined,379.0,-37.867922,144.999941
 Yeshivah College,46215.0,2016,ST KILDA EAST,38.0,31.9,82.0,100.0,1079.0,Independent,Combined,390.0,-37.867922,144.999941
@@ -5688,9 +5801,9 @@ Yeshivah College,46215.0,2019,ST KILDA EAST,35.0,28.1,50.0,100.0,1081.0,Independ
 Yeshivah College,46215.0,2020,ST KILDA EAST,34.0,15.9,85.7,100.0,1090.0,Independent,Combined,423.0,-37.867922,144.999941
 Yeshivah College,46215.0,2021,ST KILDA EAST,35.0,14.3,88.2,100.0,1081.0,Independent,Combined,413.0,-37.867922,144.999941
 Yeshivah College,46215.0,2022,ST KILDA EAST,36.0,22.7,100.0,100.0,1080.0,Independent,Combined,391.0,-37.867922,144.999941
-Yeshivah College,,2023,ST KILDA EAST,34.0,17.9,76.9,100.0,,,,,,
-Yesodei HaTorah College,,2014,BRIGHTON,34.0,17.9,75.0,100.0,,,,,,
-Yesodei HaTorah College,,2015,BRIGHTON,41.0,57.1,0.0,100.0,,,,,,
+Yeshivah College,46215.0,2023,ST KILDA EAST,34.0,17.9,76.9,100.0,,,,,,
+Yesodei HaTorah College,46376.0,2014,BRIGHTON,34.0,17.9,75.0,100.0,,,,,,
+Yesodei HaTorah College,46376.0,2015,BRIGHTON,41.0,57.1,0.0,100.0,,,,,,
 Yesodei HaTorah College,46376.0,2016,BRIGHTON,35.0,20.0,43.0,100.0,1101.0,Independent,Combined,150.0,-37.873227,144.983491
 Yesodei HaTorah College,46376.0,2017,BRIGHTON,34.0,37.9,63.0,100.0,1109.0,Independent,Combined,163.0,-37.873227,144.983491
 Yesodei HaTorah College,46376.0,2018,BRIGHTON,34.0,24.0,50.0,100.0,1097.0,Independent,Combined,154.0,-37.873227,144.983491
@@ -5698,10 +5811,10 @@ Yesodei HaTorah College,46376.0,2019,BRIGHTON,34.0,25.0,42.9,86.0,1107.0,Indepen
 Yesodei HaTorah College,46376.0,2020,BRIGHTON,33.0,0.0,57.1,86.0,1107.0,Independent,Combined,167.0,-37.873227,144.983491
 Yesodei HaTorah College,46376.0,2021,BRIGHTON,31.0,3.1,63.6,91.0,1123.0,Independent,Combined,161.0,-37.873227,144.983491
 Yesodei HaTorah College,46376.0,2022,ORMOND,,,0.0,100.0,1112.0,Independent,Combined,155.0,-37.873227,144.983491
-Yesodei HaTorah College,,2023,ORMOND,37.0,20.0,100.0,100.0,,,,,,
+Yesodei HaTorah College,46376.0,2023,ORMOND,37.0,20.0,100.0,100.0,,,,,,
 Youth2Industry College,52992.0,2021,SOUTH MELBOURNE,,,,,918.0,Independent,Secondary,33.0,-37.83708725,144.9665614
 Youth2Industry College,52992.0,2022,SOUTH MELBOURNE,,,,,952.0,Independent,Secondary,52.0,-37.83708725,144.9665614
-Youth2Industry College,,2023,SOUTH MELBOURNE,,,11.8,59.0,,,,,,
+Youth2Industry College,52992.0,2023,SOUTH MELBOURNE,,,11.8,59.0,,,,,,
 Yuille Park Community College,45268.0,2016,DELACOMBE,,,,,862.0,Government,Combined,276.0,-37.52778453,143.82008822
 Yuille Park Community College,45268.0,2017,DELACOMBE,,,,,852.0,Government,Combined,249.0,-37.52778453,143.82008822
 Yuille Park Community College,45268.0,2018,DELACOMBE,,,,,854.0,Government,Combined,234.0,-37.52778453,143.82008822


### PR DESCRIPTION
Fixes #6 

Because Victoria & the federal gov don't use the same names for schools, a lookup table has been manually created to map them together. This replaces the old fuzzy match implementation and starts using the lookup table.